### PR TITLE
Add installation script and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# redmine-cli
+
+A command-line interface for [Redmine](https://www.redmine.org/) project management.
+
+## Quick Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aarondpn/redmine-cli/main/install.sh | bash
+```
+
+This auto-detects your OS and architecture, downloads the latest release, and installs the `redmine` binary to `/usr/local/bin`.
+
+## Manual Download
+
+Grab the latest release for your platform from [GitHub Releases](https://github.com/aarondpn/redmine-cli/releases/latest):
+
+| Platform      | Architecture | Download |
+|---------------|-------------|----------|
+| Linux         | x86_64      | `redmine-linux-amd64.tar.gz` |
+| Linux         | ARM64       | `redmine-linux-arm64.tar.gz` |
+| macOS         | Intel       | `redmine-darwin-amd64.tar.gz` |
+| macOS         | Apple Silicon | `redmine-darwin-arm64.tar.gz` |
+| Windows       | x86_64      | `redmine-windows-amd64.zip` |
+
+## Install with Go
+
+```bash
+go install github.com/aarondpn/redmine-cli@latest
+```
+
+## Getting Started
+
+```bash
+# Configure your Redmine server and API key
+redmine init
+
+# List issues
+redmine issue list
+
+# View a specific issue
+redmine issue view 123
+
+# Log time
+redmine time log
+```
+
+Run `redmine --help` to see all available commands.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="aarondpn/redmine-cli"
+BINARY="redmine"
+INSTALL_DIR="/usr/local/bin"
+
+info() { printf "\033[1;34m==>\033[0m %s\n" "$*"; }
+error() { printf "\033[1;31merror:\033[0m %s\n" "$*" >&2; exit 1; }
+
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+  Linux*)  OS=linux ;;
+  Darwin*) OS=darwin ;;
+  *)       error "Unsupported OS: $OS. Download manually from https://github.com/$REPO/releases" ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64)  ARCH=amd64 ;;
+  aarch64|arm64)  ARCH=arm64 ;;
+  *)              error "Unsupported architecture: $ARCH" ;;
+esac
+
+info "Detected platform: ${OS}/${ARCH}"
+
+# Get latest release tag
+info "Fetching latest release..."
+TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+[ -z "$TAG" ] && error "Could not determine latest release"
+info "Latest version: ${TAG}"
+
+# Download
+ARCHIVE="redmine-${OS}-${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info "Downloading ${URL}..."
+curl -fsSL -o "${TMPDIR}/${ARCHIVE}" "$URL"
+
+# Extract
+tar xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+chmod +x "${TMPDIR}/${BINARY}"
+
+# Install
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+  info "Need sudo to install to ${INSTALL_DIR}"
+  sudo mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+
+info "Installed ${BINARY} ${TAG} to ${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
## Summary
This PR adds installation documentation and an automated installation script for the redmine-cli project, making it easier for users to get started with the tool.

## Key Changes
- **install.sh**: Added a bash installation script that:
  - Auto-detects the user's OS (Linux/macOS) and architecture (x86_64/ARM64)
  - Fetches the latest release from GitHub API
  - Downloads the appropriate binary archive
  - Extracts and installs the binary to `/usr/local/bin`
  - Handles permission elevation with `sudo` when necessary
  - Includes proper error handling and user feedback

- **README.md**: Added comprehensive documentation including:
  - Quick install instructions via curl pipe
  - Manual download table with all supported platforms (Linux, macOS, Windows)
  - Go install alternative
  - Getting started guide with common commands
  - Reference to full help documentation

## Notable Implementation Details
- The install script uses strict bash settings (`set -euo pipefail`) for reliability
- Platform detection handles common OS/architecture naming variations (e.g., `aarch64` → `arm64`)
- Temporary directory is properly cleaned up via trap handler
- Script provides informative colored output for better user experience
- Gracefully handles cases where sudo elevation is needed for system-wide installation

https://claude.ai/code/session_01YQRzSjpyNSE6BgMAdZ9pa4