### PR TITLE
Add `redmine api` command for raw API access

### DIFF
--- a/docs/src/content/docs/commands/other.md
+++ b/docs/src/content/docs/commands/other.md
@@ -3,6 +3,44 @@ title: Other Commands
 description: Categories, trackers, statuses, and utility commands.
 ---
 
+## API
+
+Make authenticated requests to any Redmine REST API endpoint:
+
+```bash
+# GET the current user
+redmine api /users/current.json
+
+# GET with query parameters
+redmine api /issues.json -f project_id=myproject -f limit=5
+
+# POST with JSON fields (method auto-detected)
+redmine api /issues.json -F 'issue[subject]=Bug report' -F 'issue[project_id]=1'
+
+# POST from a file (use - for stdin)
+redmine api /issues.json --input body.json
+
+# Explicit HTTP method
+redmine api -X DELETE /issues/123.json
+
+# Show response headers
+redmine api /issues.json -i
+
+# Suppress output
+redmine api -X PUT /issues/123.json -F 'issue[status_id]=5' --silent
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--method` | `-X` | HTTP method (default: GET, or POST when body provided) |
+| `--field` | `-f` | Query parameter as `key=value` (repeatable) |
+| `--raw-field` | `-F` | JSON body field as `key=value` (repeatable) |
+| `--input` | | Read request body from file (`-` for stdin) |
+| `--include` | `-i` | Show response status line and headers |
+| `--silent` | | Suppress response output |
+
+JSON responses are pretty-printed when stdout is a terminal. Non-2xx responses still print the body but exit with code 1.
+
 ## Categories
 
 List issue categories for a project:

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -15,6 +15,14 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/debug"
 )
 
+// RawResponse holds the unprocessed HTTP response from DoRaw.
+type RawResponse struct {
+	StatusCode int
+	Status     string
+	Headers    http.Header
+	Body       []byte
+}
+
 // Client is the Redmine API client.
 type Client struct {
 	httpClient *http.Client
@@ -155,6 +163,43 @@ func (c *Client) doWithBody(ctx context.Context, method, path string, body inter
 	}
 
 	return c.do(req, out)
+}
+
+// DoRaw performs an HTTP request and returns the raw response without parsing.
+func (c *Client) DoRaw(ctx context.Context, method, path string, params url.Values, body io.Reader) (*RawResponse, error) {
+	u := c.baseURL + path
+	if len(params) > 0 {
+		u += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u, body)
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start)
+
+	if err != nil {
+		c.debugLog.Printf("HTTP %s %s -> error (%s): %v", req.Method, debug.ScrubURL(req.URL.String()), duration.Round(time.Millisecond), err)
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	c.debugLog.Printf("HTTP %s %s -> %d (%s)", req.Method, debug.ScrubURL(req.URL.String()), resp.StatusCode, duration.Round(time.Millisecond))
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	return &RawResponse{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Headers:    resp.Header,
+		Body:       respBody,
+	}, nil
 }
 
 func (c *Client) do(req *http.Request, out interface{}) error {

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+// NewCmdAPI creates the `api` command for raw Redmine API access.
+func NewCmdAPI(f *cmdutil.Factory) *cobra.Command {
+	var (
+		method    string
+		fields    []string
+		rawFields []string
+		input     string
+		include   bool
+		silent    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "api <endpoint> [flags]",
+		Short: "Make an authenticated API request",
+		Long: `Make an authenticated HTTP request to the Redmine API and print the response.
+
+The endpoint argument should be a path like "/issues.json" or "issues.json"
+(the leading slash is optional).
+
+The default HTTP method is GET. When --raw-field or --input is provided,
+the method defaults to POST instead.`,
+		Example: `  # GET the current user
+  redmine api /users/current.json
+
+  # GET issues with query parameters
+  redmine api /issues.json -f project_id=myproject -f limit=5
+
+  # POST with JSON fields
+  redmine api /issues.json -F 'issue[subject]=Bug report' -F 'issue[project_id]=1'
+
+  # POST from a file
+  redmine api /issues.json --input body.json
+
+  # DELETE an issue
+  redmine api -X DELETE /issues/123.json
+
+  # Show response headers
+  redmine api /issues.json -i`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAPI(f, args[0], method, fields, rawFields, input, include, silent)
+		},
+	}
+
+	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (default: auto)")
+	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Query parameter as key=value")
+	cmd.Flags().StringArrayVarP(&rawFields, "raw-field", "F", nil, "JSON body field as key=value")
+	cmd.Flags().StringVar(&input, "input", "", "Read request body from file (use - for stdin)")
+	cmd.Flags().BoolVarP(&include, "include", "i", false, "Show response status and headers")
+	cmd.Flags().BoolVar(&silent, "silent", false, "Suppress response output")
+
+	return cmd
+}
+
+func runAPI(f *cmdutil.Factory, endpoint, method string, fields, rawFields []string, input string, include, silent bool) error {
+	// Validate mutual exclusion.
+	if len(rawFields) > 0 && input != "" {
+		return fmt.Errorf("--raw-field and --input are mutually exclusive")
+	}
+
+	// Normalise endpoint.
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+
+	// Auto-detect HTTP method.
+	if method == "" {
+		if len(rawFields) > 0 || input != "" {
+			method = "POST"
+		} else {
+			method = "GET"
+		}
+	}
+	method = strings.ToUpper(method)
+
+	// Build query params from -f flags.
+	params := url.Values{}
+	for _, fv := range fields {
+		k, v, ok := strings.Cut(fv, "=")
+		if !ok {
+			return fmt.Errorf("invalid --field value %q: expected key=value", fv)
+		}
+		params.Add(k, v)
+	}
+
+	// Build request body.
+	var body io.Reader
+	if len(rawFields) > 0 {
+		b, err := buildJSONBody(rawFields)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	} else if input != "" {
+		b, err := readInput(input, f.IOStreams.In)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+
+	client, err := f.ApiClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.DoRaw(context.Background(), method, endpoint, params, body)
+	if err != nil {
+		return err
+	}
+
+	if !silent {
+		out := f.IOStreams.Out
+
+		if include {
+			fmt.Fprintf(out, "%s\n", resp.Status)
+			// Sort header keys for stable output.
+			keys := make([]string, 0, len(resp.Headers))
+			for k := range resp.Headers {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				for _, v := range resp.Headers[k] {
+					fmt.Fprintf(out, "%s: %s\n", k, v)
+				}
+			}
+			fmt.Fprintln(out)
+		}
+
+		if len(resp.Body) > 0 {
+			if f.IOStreams.IsTTY && isJSON(resp.Body) {
+				var buf bytes.Buffer
+				if json.Indent(&buf, resp.Body, "", "  ") == nil {
+					buf.WriteByte('\n')
+					_, _ = buf.WriteTo(out)
+				} else {
+					_, _ = out.Write(resp.Body)
+				}
+			} else {
+				_, _ = out.Write(resp.Body)
+			}
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		return &cmdutil.SilentError{Code: 1}
+	}
+	return nil
+}
+
+// buildJSONBody constructs a JSON object from key=value pairs.
+// Values are parsed as JSON (numbers, bools, arrays, objects); strings are kept as-is.
+func buildJSONBody(fields []string) ([]byte, error) {
+	obj := make(map[string]interface{})
+	for _, fv := range fields {
+		k, v, ok := strings.Cut(fv, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --raw-field value %q: expected key=value", fv)
+		}
+		obj[k] = parseJSONValue(v)
+	}
+	return json.Marshal(obj)
+}
+
+// parseJSONValue attempts to parse s as a JSON value. If parsing fails it
+// returns s as a plain string.
+func parseJSONValue(s string) interface{} {
+	if s == "true" {
+		return true
+	}
+	if s == "false" {
+		return false
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	// Try JSON array/object.
+	if (strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]")) ||
+		(strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}")) {
+		var v interface{}
+		if json.Unmarshal([]byte(s), &v) == nil {
+			return v
+		}
+	}
+	return s
+}
+
+// readInput reads the request body from a file path or stdin (when path is "-").
+func readInput(path string, stdin io.Reader) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(stdin)
+	}
+	return os.ReadFile(path)
+}
+
+// isJSON reports whether data looks like a JSON value.
+func isJSON(data []byte) bool {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return false
+	}
+	return data[0] == '{' || data[0] == '['
+}

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -1,0 +1,296 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+// testFactory creates a Factory pointing at the given test server.
+func testFactory(t *testing.T, serverURL string) *cmdutil.Factory {
+	t.Helper()
+	tmp := t.TempDir()
+	cfgPath := tmp + "/config.yaml"
+	cfg := "server: " + serverURL + "\napi_key: test\nauth_method: apikey\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+			IsTTY:  false,
+		},
+	}
+}
+
+func output(f *cmdutil.Factory) string {
+	return f.IOStreams.Out.(*bytes.Buffer).String()
+}
+
+func TestGetDefaultMethod(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/test.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("expected GET, got %s", gotMethod)
+	}
+}
+
+func TestAutoPrependSlash(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"issues.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/issues.json" {
+		t.Errorf("expected /issues.json, got %s", gotPath)
+	}
+}
+
+func TestExplicitMethod(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"-X", "DELETE", "/issues/123.json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("expected DELETE, got %s", gotMethod)
+	}
+}
+
+func TestQueryParamsField(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/issues.json", "-f", "project_id=demo", "-f", "limit=5"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotQuery, "project_id=demo") {
+		t.Errorf("expected project_id=demo in query, got %s", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "limit=5") {
+		t.Errorf("expected limit=5 in query, got %s", gotQuery)
+	}
+}
+
+func TestRawFieldsPOST(t *testing.T) {
+	var gotMethod string
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/issues.json", "-F", "issue[subject]=Bug", "-F", "issue[project_id]=1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("expected POST (auto-detected), got %s", gotMethod)
+	}
+	if gotBody["issue[subject]"] != "Bug" {
+		t.Errorf("expected issue[subject]=Bug, got %v", gotBody["issue[subject]"])
+	}
+	// "1" should be parsed as number
+	if gotBody["issue[project_id]"] != float64(1) {
+		t.Errorf("expected issue[project_id]=1 (number), got %v (%T)", gotBody["issue[project_id]"], gotBody["issue[project_id]"])
+	}
+}
+
+func TestJSONValueParsing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{"true", true},
+		{"false", false},
+		{"42", int64(42)},
+		{"3.14", 3.14},
+		{`[1,2,3]`, []interface{}{float64(1), float64(2), float64(3)}},
+		{"hello", "hello"},
+	}
+	for _, tt := range tests {
+		got := parseJSONValue(tt.input)
+		gotJSON, _ := json.Marshal(got)
+		expJSON, _ := json.Marshal(tt.expected)
+		if string(gotJSON) != string(expJSON) {
+			t.Errorf("parseJSONValue(%q) = %v, want %v", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestInputFile(t *testing.T) {
+	var gotMethod string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		gotBody = buf.Bytes()
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	bodyFile := tmp + "/body.json"
+	os.WriteFile(bodyFile, []byte(`{"issue":{"subject":"test"}}`), 0644)
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/issues.json", "--input", bodyFile})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if string(gotBody) != `{"issue":{"subject":"test"}}` {
+		t.Errorf("unexpected body: %s", gotBody)
+	}
+}
+
+func TestInputStdin(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		gotBody = buf.String()
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	f.IOStreams.In = strings.NewReader(`{"test":1}`)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/issues.json", "--input", "-"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotBody != `{"test":1}` {
+		t.Errorf("unexpected stdin body: %s", gotBody)
+	}
+}
+
+func TestIncludeHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Custom", "value")
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/test.json", "-i"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	out := output(f)
+	if !strings.Contains(out, "200") {
+		t.Errorf("expected status line with 200, got:\n%s", out)
+	}
+	if !strings.Contains(out, "X-Custom: value") {
+		t.Errorf("expected X-Custom header, got:\n%s", out)
+	}
+}
+
+func TestSilentSuppressesOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":"secret"}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/test.json", "--silent"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if out := output(f); out != "" {
+		t.Errorf("expected no output with --silent, got: %s", out)
+	}
+}
+
+func TestNon2xxReturnsErrorWithBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"errors":["not found"]}`))
+	}))
+	defer srv.Close()
+
+	f := testFactory(t, srv.URL)
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/missing.json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	var silentErr *cmdutil.SilentError
+	if !errors.As(err, &silentErr) {
+		t.Fatalf("expected SilentError, got %T: %v", err, err)
+	}
+	// Body should still be written.
+	if out := output(f); !strings.Contains(out, "not found") {
+		t.Errorf("expected error body in output, got: %s", out)
+	}
+}
+
+func TestMutualExclusion(t *testing.T) {
+	f := testFactory(t, "http://unused")
+	cmd := NewCmdAPI(f)
+	cmd.SetArgs([]string{"/test.json", "-F", "a=b", "--input", "file.json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutual exclusion")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutually exclusive error, got: %v", err)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	apicmd "github.com/aarondpn/redmine-cli/internal/cmd/api"
 	"github.com/aarondpn/redmine-cli/internal/cmd/category"
 	"github.com/aarondpn/redmine-cli/internal/cmd/completion"
 	"github.com/aarondpn/redmine-cli/internal/cmd/group"
@@ -71,6 +72,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.Version = version
 
 	// Subcommands
+	cmd.AddCommand(apicmd.NewCmdAPI(f))
 	cmd.AddCommand(initcmd.NewCmdInit(f))
 	cmd.AddCommand(issue.NewCmdIssue(f))
 	cmd.AddCommand(group.NewCmdGroup(f))

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -7,6 +7,12 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/api"
 )
 
+// SilentError is returned when the error message has already been printed
+// or should be suppressed. main.go will still exit with the given code.
+type SilentError struct{ Code int }
+
+func (e *SilentError) Error() string { return "" }
+
 // FormatError converts an API error into a user-friendly message.
 func FormatError(err error) string {
 	var apiErr *api.APIError

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -13,6 +14,10 @@ var version = "dev"
 func main() {
 	rootCmd := cmd.NewRootCmd(version)
 	if err := rootCmd.Execute(); err != nil {
+		var silent *cmdutil.SilentError
+		if errors.As(err, &silent) {
+			os.Exit(silent.Code)
+		}
 		fmt.Fprintf(os.Stderr, "Error: %s\n", cmdutil.FormatError(err))
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- Add `redmine api <endpoint>` command for making authenticated requests to arbitrary Redmine REST API endpoints, modeled after `gh api`
- Supports query params (`-f`), JSON body fields (`-F`), file/stdin input (`--input`), response headers (`-i`), silent mode, HTTP method auto-detection, and TTY-aware JSON pretty-printing
- Add `SilentError` type so non-2xx responses print the body but exit with code 1 without a double "Error:" line

## Changes

- **`internal/cmd/api/api.go`** — New command implementation
- **`internal/cmd/api/api_test.go`** — 12 test cases covering all flags and behaviors
- **`internal/api/client.go`** — `RawResponse` type and `DoRaw()` method that returns raw HTTP responses without parsing
- **`internal/cmdutil/errors.go`** — `SilentError` type for suppressing error messages while preserving exit codes
- **`main.go`** — Handle `SilentError` before formatting
- **`internal/cmd/root.go`** — Register `api` command
- **`docs/src/content/docs/commands/other.md`** — Documentation with usage examples and flag reference

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/cmd/api/ -v` — all 12 tests pass
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [ ] Manual test: `redmine api /users/current.json`
- [ ] Manual test: `redmine api /issues.json -f limit=2`
- [ ] Manual test: `redmine api /issues.json -i`
- [ ] Manual test: `redmine api /nonexistent.json` (error body + exit 1)