### PR TITLE
Fix project name resolution and JSON output handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	go test ./...
 
 lint:
-	go vet ./...
+	golangci-lint run
 
 clean:
 	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ This uses the [skills](https://github.com/anthropics/skills) CLI under the hood 
 Once installed, the agent will:
 
 - Use `-o json` for all commands to get machine-readable output
+- Keep `stderr` separate when capturing `-o json`; JSON is written only to `stdout`
 - Query available options (trackers, statuses, versions, etc.) before creating or updating issues, rather than guessing values
 - Present options to the user for selection when values are ambiguous
 - Handle pagination with `--limit` and `--offset`

--- a/docs/src/content/docs/commands/issues.md
+++ b/docs/src/content/docs/commands/issues.md
@@ -13,7 +13,7 @@ redmine issues list [flags]
 
 | Flag | Description |
 |------|------------|
-| `--project` | Filter by project (name or ID) |
+| `--project` | Filter by project (name, identifier, or ID) |
 | `--tracker` | Filter by tracker (name or ID) |
 | `--status` | Filter by status: `open`, `closed`, `*`, name, or ID |
 | `--assignee` | Filter by assignee: `me`, name, or ID |
@@ -53,7 +53,7 @@ redmine issues create [flags]
 
 | Flag | Description |
 |------|------------|
-| `--project` | Project (name or ID) — **required** |
+| `--project` | Project (name, identifier, or ID) — **required** |
 | `--subject` | Issue subject — **required** |
 | `--tracker` | Tracker (name or ID) |
 | `--status` | Status (name or ID) |

--- a/docs/src/content/docs/guides/output-formats.md
+++ b/docs/src/content/docs/guides/output-formats.md
@@ -59,6 +59,8 @@ redmine issues list --tracker Bug -o json | jq '.[].id'
 redmine issues list --project myproject -o json | jq 'group_by(.status.name) | map({status: .[0].status.name, count: length})'
 ```
 
+When `-o json` is selected, the CLI emits JSON only on `stdout`. Human-readable pagination hints are suppressed in this mode, so piping to tools like `jq` is safe. Keep `stderr` separate if you want to capture actual errors.
+
 ## CSV
 
 Comma-separated values for spreadsheets and data analysis:

--- a/internal/cmd/category/list.go
+++ b/internal/cmd/category/list.go
@@ -53,6 +53,11 @@ func newCmdCategoryList(f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("--project is required (or set a default project in config)")
 			}
 
+			project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
 			printer := f.Printer(format)
 
 			stop := printer.Spinner("Fetching categories...")

--- a/internal/cmd/issue/browse.go
+++ b/internal/cmd/issue/browse.go
@@ -28,6 +28,14 @@ func NewCmdBrowse(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				resolvedProject, err := cmdutil.ResolveProjectID(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+				project = resolvedProject
+			}
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
@@ -50,7 +58,7 @@ func NewCmdBrowse(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Filter by project")
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Filter by project name, identifier, or ID")
 	cmd.Flags().StringVar(&status, "status", "open", "Filter by status")
 	cmd.Flags().StringVar(&assignee, "assignee", "", "Filter by assignee")
 	return cmd

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -63,6 +63,13 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectID(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			var trackerID int
 			if tracker != "" {
 				trackerID, err = resolver.ResolveTracker(context.Background(), client, tracker)
@@ -100,7 +107,13 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(issues) == 0 {
-				printer.Warning("No issues found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(issues)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No issues found")
+				}
 				return nil
 			}
 
@@ -139,7 +152,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				printer.Table(headers, rows)
 			}
 
-			if total > limit+offset {
+			if total > limit+offset && output.SupportsWarnings(printer.Format()) {
 				printer.Warning(fmt.Sprintf("Showing %d of %d issues. Use --offset to paginate.", len(issues), total))
 			}
 
@@ -147,7 +160,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID")
 	cmd.Flags().StringVar(&tracker, "tracker", "", "Tracker name or ID")
 	cmd.Flags().StringVar(&status, "status", "open", "Status filter: open, closed, *, or status ID")
 	cmd.Flags().StringVar(&assignee, "assignee", "", "Assignee ID or 'me'")

--- a/internal/cmd/search/browse.go
+++ b/internal/cmd/search/browse.go
@@ -45,6 +45,14 @@ func newCmdSearchBrowse(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				resolvedProject, err := cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+				project = resolvedProject
+			}
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
@@ -83,7 +91,7 @@ func newCmdSearchBrowse(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project name, identifier, or ID")
 	cmd.Flags().StringVar(&scope, "scope", "", "Search scope: all, my_projects, subprojects")
 	cmd.Flags().BoolVar(&allWords, "all-words", false, "Match all query words")
 	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Search titles only")

--- a/internal/cmd/search/issues.go
+++ b/internal/cmd/search/issues.go
@@ -44,6 +44,13 @@ func newCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			params := api.SearchParams{
 				Query:       query,
 				ProjectID:   project,
@@ -66,7 +73,13 @@ func newCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				printer.Warning("No issues found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(results)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No issues found")
+				}
 				return nil
 			}
 
@@ -97,7 +110,7 @@ func newCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 				printer.Table(headers, rows)
 			}
 
-			if total > limit+offset {
+			if total > limit+offset && output.SupportsWarnings(printer.Format()) {
 				printer.Warning(fmt.Sprintf("Showing %d of %d results. Use --offset to paginate.", len(results), total))
 			}
 
@@ -105,7 +118,7 @@ func newCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project name, identifier, or ID")
 	cmd.Flags().StringVar(&scope, "scope", "", "Search scope: all, my_projects, subprojects")
 	cmd.Flags().BoolVar(&allWords, "all-words", false, "Match all query words")
 	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Search titles only")

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aarondpn/redmine-cli/internal/api"
 	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/output"
 )
 
 func newCmdSearchMessages(f *cmdutil.Factory) *cobra.Command {
@@ -41,6 +42,13 @@ func newCmdSearchMessages(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			params := api.SearchParams{
 				Query:      query,
 				ProjectID:  project,
@@ -61,7 +69,13 @@ func newCmdSearchMessages(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				printer.Warning("No messages found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(results)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No messages found")
+				}
 				return nil
 			}
 
@@ -70,7 +84,7 @@ func newCmdSearchMessages(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project name, identifier, or ID")
 	cmd.Flags().StringVar(&scope, "scope", "", "Search scope: all, my_projects, subprojects")
 	cmd.Flags().BoolVar(&allWords, "all-words", false, "Match all query words")
 	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Search titles only")

--- a/internal/cmd/search/news.go
+++ b/internal/cmd/search/news.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aarondpn/redmine-cli/internal/api"
 	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/output"
 )
 
 func newCmdSearchNews(f *cmdutil.Factory) *cobra.Command {
@@ -41,6 +42,13 @@ func newCmdSearchNews(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			params := api.SearchParams{
 				Query:      query,
 				ProjectID:  project,
@@ -61,7 +69,13 @@ func newCmdSearchNews(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				printer.Warning("No news found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(results)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No news found")
+				}
 				return nil
 			}
 
@@ -70,7 +84,7 @@ func newCmdSearchNews(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project name, identifier, or ID")
 	cmd.Flags().StringVar(&scope, "scope", "", "Search scope: all, my_projects, subprojects")
 	cmd.Flags().BoolVar(&allWords, "all-words", false, "Match all query words")
 	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Search titles only")

--- a/internal/cmd/search/search.go
+++ b/internal/cmd/search/search.go
@@ -54,6 +54,13 @@ func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			params := api.SearchParams{
 				Query:       query,
 				ProjectID:   project,
@@ -82,7 +89,13 @@ func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				printer.Warning("No results found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(results)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No results found")
+				}
 				return nil
 			}
 
@@ -91,7 +104,7 @@ func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project name, identifier, or ID")
 	cmd.Flags().StringVar(&scope, "scope", "", "Search scope: all, my_projects, subprojects")
 	cmd.Flags().BoolVar(&allWords, "all-words", false, "Match all query words")
 	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Search titles only")
@@ -149,7 +162,7 @@ func printResults(printer output.Printer, results []models.SearchResult, total, 
 		printer.Table(headers, rows)
 	}
 
-	if total > limit+offset {
+	if total > limit+offset && output.SupportsWarnings(printer.Format()) {
 		printer.Warning(fmt.Sprintf("Showing %d of %d results. Use --offset to paginate.", len(results), total))
 	}
 }

--- a/internal/cmd/search/wiki.go
+++ b/internal/cmd/search/wiki.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aarondpn/redmine-cli/internal/api"
 	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/output"
 )
 
 func newCmdSearchWiki(f *cmdutil.Factory) *cobra.Command {
@@ -41,6 +42,13 @@ func newCmdSearchWiki(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			params := api.SearchParams{
 				Query:      query,
 				ProjectID:  project,
@@ -61,7 +69,13 @@ func newCmdSearchWiki(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				printer.Warning("No wiki pages found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(results)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No wiki pages found")
+				}
 				return nil
 			}
 
@@ -70,7 +84,7 @@ func newCmdSearchWiki(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Limit search to a project name, identifier, or ID")
 	cmd.Flags().StringVar(&scope, "scope", "", "Search scope: all, my_projects, subprojects")
 	cmd.Flags().BoolVar(&allWords, "all-words", false, "Match all query words")
 	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Search titles only")

--- a/internal/cmd/time/list.go
+++ b/internal/cmd/time/list.go
@@ -45,6 +45,13 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 
 			ctx := context.Background()
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectID(ctx, f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			// Resolve user: if non-numeric and not "me", resolve by name
 			userID := user
 			if user != "" && user != "me" {
@@ -82,6 +89,11 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			printer := f.Printer(format)
+
+			if len(entries) == 0 && printer.Format() == output.FormatJSON {
+				printer.JSON(entries)
+				return nil
+			}
 
 			switch printer.Format() {
 			case output.FormatJSON:
@@ -130,7 +142,7 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			printer.Table(headers, rows)
-			if total > len(entries) {
+			if total > len(entries) && output.SupportsWarnings(printer.Format()) {
 				printer.Warning(fmt.Sprintf("Showing %d of %d entries", len(entries), total))
 			}
 
@@ -138,7 +150,7 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Filter by project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Filter by project name, identifier, or ID")
 	cmd.Flags().StringVar(&user, "user", "", "Filter by user ID, login, name, or 'me'")
 	cmd.Flags().IntVar(&issue, "issue", 0, "Filter by issue ID")
 	cmd.Flags().StringVar(&from, "from", "", "Start date (YYYY-MM-DD)")

--- a/internal/cmd/time/log.go
+++ b/internal/cmd/time/log.go
@@ -40,6 +40,13 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectID(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			if date == "" {
 				date = time.Now().Format("2006-01-02")
 			}
@@ -75,7 +82,7 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&issue, "issue", 0, "Issue ID")
-	cmd.Flags().StringVar(&project, "project", "", "Project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID")
 	cmd.Flags().Float64Var(&hours, "hours", 0, "Hours spent (required)")
 	cmd.Flags().StringVar(&activity, "activity", "", "Activity name or ID")
 	cmd.Flags().StringVar(&date, "date", "", "Date (YYYY-MM-DD, default today)")

--- a/internal/cmd/time/summary.go
+++ b/internal/cmd/time/summary.go
@@ -42,6 +42,13 @@ func newCmdTimeSummary(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if project != "" {
+				project, err = cmdutil.ResolveProjectID(context.Background(), f, project)
+				if err != nil {
+					return err
+				}
+			}
+
 			if from == "" {
 				// Default to start of current week (Monday)
 				now := time.Now()
@@ -143,7 +150,7 @@ func newCmdTimeSummary(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Filter by project identifier")
+	cmd.Flags().StringVar(&project, "project", "", "Filter by project name, identifier, or ID")
 	cmd.Flags().StringVar(&user, "user", "", "Filter by user ID, login, name, or 'me'")
 	cmd.Flags().StringVar(&from, "from", "", "Start date (YYYY-MM-DD, default: start of current week)")
 	cmd.Flags().StringVar(&to, "to", "", "End date (YYYY-MM-DD, default: today)")

--- a/internal/cmd/version/get.go
+++ b/internal/cmd/version/get.go
@@ -46,6 +46,10 @@ func newCmdVersionGet(f *cmdutil.Factory) *cobra.Command {
 				if project == "" {
 					return fmt.Errorf("--project is required when looking up a version by name")
 				}
+				project, err = cmdutil.ResolveProjectIdentifier(ctx, f, project)
+				if err != nil {
+					return err
+				}
 				resolved, err := resolver.ResolveVersion(ctx, client, args[0], project)
 				if err != nil {
 					return err
@@ -91,7 +95,7 @@ func newCmdVersionGet(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project identifier (for name resolution; falls back to default project)")
+	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID (for name resolution; falls back to default project)")
 	cmdutil.AddOutputFlag(cmd, &format)
 	return cmd
 }

--- a/internal/cmd/version/list.go
+++ b/internal/cmd/version/list.go
@@ -82,6 +82,11 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("project is required. Use --project or set a default project")
 			}
 
+			project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
 			printer := f.Printer(format)
 			stop := printer.Spinner("Fetching versions...")
 
@@ -122,7 +127,13 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(versions) == 0 {
-				printer.Warning("No versions found")
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(versions)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No versions found")
+				}
 				return nil
 			}
 
@@ -159,7 +170,7 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 				printer.Table(headers, rows)
 			}
 
-			if hasMore {
+			if hasMore && output.SupportsWarnings(printer.Format()) {
 				printer.Warning("More versions available. Use --limit and --offset to paginate.")
 			}
 
@@ -167,7 +178,7 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&project, "project", "", "Project identifier (required)")
+	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID (required)")
 	cmd.Flags().StringVar(&statusFilter, "status", "", "Filter by status: open, locked, closed")
 	cmd.Flags().BoolVar(&open, "open", false, "Show only open versions")
 	cmd.Flags().BoolVar(&closed, "closed", false, "Show only closed versions")

--- a/internal/cmdutil/projects.go
+++ b/internal/cmdutil/projects.go
@@ -1,0 +1,46 @@
+package cmdutil
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/aarondpn/redmine-cli/internal/resolver"
+)
+
+// ResolveProjectID resolves a project input to its numeric ID string.
+func ResolveProjectID(ctx context.Context, f *Factory, input string) (string, error) {
+	if input == "" {
+		return "", nil
+	}
+
+	client, err := f.ApiClient()
+	if err != nil {
+		return "", err
+	}
+
+	id, _, err := resolver.ResolveProject(ctx, client, input)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.Itoa(id), nil
+}
+
+// ResolveProjectIdentifier resolves a project input to its canonical identifier.
+func ResolveProjectIdentifier(ctx context.Context, f *Factory, input string) (string, error) {
+	if input == "" {
+		return "", nil
+	}
+
+	client, err := f.ApiClient()
+	if err != nil {
+		return "", err
+	}
+
+	_, identifier, err := resolver.ResolveProject(ctx, client, input)
+	if err != nil {
+		return "", err
+	}
+
+	return identifier, nil
+}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -4,10 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 )
 
 // RenderJSON renders a value as pretty-printed JSON to the writer.
 func RenderJSON(w io.Writer, v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.IsValid() && rv.Kind() == reflect.Slice && rv.IsNil() {
+		v = reflect.MakeSlice(rv.Type(), 0, 0).Interface()
+	}
+
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return err

--- a/internal/output/warnings.go
+++ b/internal/output/warnings.go
@@ -1,0 +1,7 @@
+package output
+
+// SupportsWarnings reports whether human-readable warnings should be emitted
+// for the selected output format.
+func SupportsWarnings(format string) bool {
+	return format != FormatJSON
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -130,12 +131,64 @@ func Resolve(input string, resourceType string, client *api.Client, fetcher func
 // Returns both the numeric ID and the string identifier (needed for version resolution).
 func ResolveProject(ctx context.Context, client *api.Client, input string) (int, string, error) {
 	client.DebugLog().Printf("Resolver: resolving project %q", input)
+
 	project, err := client.Projects.Get(ctx, input, nil)
-	if err != nil {
+	if err == nil {
+		client.DebugLog().Printf("Resolver: resolved project %q -> ID %d, identifier %q", input, project.ID, project.Identifier)
+		return project.ID, project.Identifier, nil
+	}
+
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) || !apiErr.IsNotFound() {
 		return 0, "", fmt.Errorf("failed to resolve project %q: %w", input, err)
 	}
-	client.DebugLog().Printf("Resolver: resolved project %q -> ID %d, identifier %q", input, project.ID, project.Identifier)
-	return project.ID, project.Identifier, nil
+
+	projects, _, err := client.Projects.List(ctx, nil, 0, 0)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to fetch projects: %w", err)
+	}
+
+	return resolveProjectFromList(client, input, projects)
+}
+
+func resolveProjectFromList(client *api.Client, input string, projects []models.Project) (int, string, error) {
+	if id, err := strconv.Atoi(input); err == nil {
+		for _, project := range projects {
+			if project.ID == id {
+				client.DebugLog().Printf("Resolver: resolved project %q -> ID %d, identifier %q", input, project.ID, project.Identifier)
+				return project.ID, project.Identifier, nil
+			}
+		}
+		return 0, "", fmt.Errorf("no match found for project ID %d", id)
+	}
+
+	needle := strings.ToLower(input)
+	var matches []models.Project
+	for _, project := range projects {
+		if strings.ToLower(project.Name) == needle || strings.ToLower(project.Identifier) == needle {
+			matches = append(matches, project)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		names := make([]string, len(projects))
+		ids := make([]int, len(projects))
+		for i, project := range projects {
+			names[i] = fmt.Sprintf("%s [%s]", project.Name, project.Identifier)
+			ids[i] = project.ID
+		}
+		return 0, "", fmt.Errorf("%s", buildSuggestions(input, names, ids, "project"))
+	case 1:
+		client.DebugLog().Printf("Resolver: resolved project %q -> ID %d, identifier %q", input, matches[0].ID, matches[0].Identifier)
+		return matches[0].ID, matches[0].Identifier, nil
+	default:
+		lines := make([]string, len(matches))
+		for i, project := range matches {
+			lines[i] = fmt.Sprintf("  - %s [%s] (ID: %d)", project.Name, project.Identifier, project.ID)
+		}
+		return 0, "", fmt.Errorf("multiple projects match %q, please use the numeric ID:\n%s", input, strings.Join(lines, "\n"))
+	}
 }
 
 // ResolveTracker resolves a tracker by name or numeric ID.

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/api"
 	"github.com/aarondpn/redmine-cli/internal/config"
 	"github.com/aarondpn/redmine-cli/internal/debug"
+	"github.com/aarondpn/redmine-cli/internal/models"
 )
 
 func testClient(t *testing.T) *api.Client {
@@ -149,6 +150,53 @@ func TestResolve_FetcherError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "connection refused") {
 		t.Errorf("expected fetcher error propagated, got: %v", err)
+	}
+}
+
+func TestResolveProjectFromList_MatchesDisplayName(t *testing.T) {
+	client := testClient(t)
+	projects := []models.Project{
+		{ID: 129, Name: "Internal Platform", Identifier: "platform"},
+		{ID: 130, Name: "Internal Tools", Identifier: "tools"},
+	}
+
+	id, identifier, err := resolveProjectFromList(client, "Internal Platform", projects)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 129 || identifier != "platform" {
+		t.Fatalf("expected project 129/platform, got %d/%s", id, identifier)
+	}
+}
+
+func TestResolveProjectFromList_MatchesIdentifier(t *testing.T) {
+	client := testClient(t)
+	projects := []models.Project{
+		{ID: 129, Name: "Internal Platform", Identifier: "platform"},
+	}
+
+	id, identifier, err := resolveProjectFromList(client, "platform", projects)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 129 || identifier != "platform" {
+		t.Fatalf("expected project 129/platform, got %d/%s", id, identifier)
+	}
+}
+
+func TestResolveProjectFromList_SuggestionsIncludeIdentifier(t *testing.T) {
+	client := testClient(t)
+	projects := []models.Project{
+		{ID: 129, Name: "Internal Platform", Identifier: "platform"},
+		{ID: 130, Name: "Internal Tools", Identifier: "tools"},
+	}
+
+	_, _, err := resolveProjectFromList(client, "Internal Pltform", projects)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Internal Platform [platform]") {
+		t.Fatalf("expected identifier in suggestion output, got: %v", err)
 	}
 }
 

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -30,6 +30,8 @@ redmine issues list -o json
 redmine versions list --project myproject -o json
 ```
 
+With `-o json`, the CLI writes JSON only to `stdout`. Do not merge `stderr` into the JSON stream unless you explicitly want errors mixed into your capture.
+
 Other formats: `-o csv` (tabular), `-o table` (default, human-readable).
 
 ## Pagination
@@ -85,7 +87,7 @@ redmine issues get 123 --include journals,children,relations -o json
 
 ### Create an issue
 
-All flags that reference other resources (project, tracker, priority, status, assignee, version) accept **names or numeric IDs**. The CLI resolves names automatically.
+All flags that reference other resources (project, tracker, priority, status, assignee, version) accept **names, identifiers where applicable, or numeric IDs**. The CLI resolves them automatically.
 
 ```bash
 # Create using human-readable names


### PR DESCRIPTION
## Summary
- resolve --project consistently by name, identifier, or ID across affected commands
- keep machine-readable JSON output clean and emit [] for empty result sets
- align make lint with CI by using golangci-lint

## Testing
- make lint
- env GOCACHE=/tmp/redmine-cli-go-cache go test ./... -run '^$'