### PR TITLE
Improve error messages for permission-restricted name resolution

### DIFF
--- a/internal/cmd/issue/assign.go
+++ b/internal/cmd/issue/assign.go
@@ -32,7 +32,7 @@ func NewCmdAssign(f *cmdutil.Factory) *cobra.Command {
 
 			userID, err := resolver.ResolveUser(context.Background(), client, args[1])
 			if err != nil {
-				return err
+				return fmt.Errorf("resolving user: %w", err)
 			}
 
 			update := models.IssueUpdate{

--- a/internal/cmd/issue/create.go
+++ b/internal/cmd/issue/create.go
@@ -68,7 +68,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 			projectID, projectIdentifier, err := resolver.ResolveProject(ctx, client, project)
 			if err != nil {
-				return err
+				return fmt.Errorf("resolving project: %w", err)
 			}
 
 			create := models.IssueCreate{
@@ -82,7 +82,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if tracker != "" {
 				id, err := resolver.ResolveTracker(ctx, client, tracker)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving tracker: %w", err)
 				}
 				create.TrackerID = id
 			}
@@ -90,7 +90,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if priority != "" {
 				id, err := resolver.ResolvePriority(ctx, client, priority)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving priority: %w", err)
 				}
 				create.PriorityID = id
 			}
@@ -98,7 +98,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if assignee != "" {
 				id, err := resolver.ResolveAssignee(ctx, client, assignee)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving assignee: %w", err)
 				}
 				create.AssignedToID = id
 			}
@@ -106,7 +106,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if status != "" {
 				id, err := resolver.ResolveStatus(ctx, client, status)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving status: %w", err)
 				}
 				create.StatusID = id
 			}
@@ -114,7 +114,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if category != "" {
 				id, err := resolver.ResolveCategory(ctx, client, category, projectIdentifier)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving category: %w", err)
 				}
 				create.CategoryID = id
 			}
@@ -122,7 +122,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if version != "" {
 				id, err := resolver.ResolveVersion(ctx, client, version, projectIdentifier)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving version: %w", err)
 				}
 				create.FixedVersionID = id
 			}

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -74,7 +74,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			if tracker != "" {
 				trackerID, err = resolver.ResolveTracker(context.Background(), client, tracker)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving tracker: %w", err)
 				}
 			}
 
@@ -82,7 +82,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			if version != "" {
 				id, err := resolver.ResolveVersion(context.Background(), client, version, project)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving version: %w", err)
 				}
 				versionID = id
 			}

--- a/internal/cmd/issue/update.go
+++ b/internal/cmd/issue/update.go
@@ -89,28 +89,28 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			if cmd.Flags().Changed("tracker") {
 				tid, err := resolver.ResolveTracker(ctx, client, tracker)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving tracker: %w", err)
 				}
 				update.TrackerID = &tid
 			}
 			if cmd.Flags().Changed("status") {
 				sid, err := resolver.ResolveStatus(ctx, client, status)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving status: %w", err)
 				}
 				update.StatusID = &sid
 			}
 			if cmd.Flags().Changed("priority") {
 				pid, err := resolver.ResolvePriority(ctx, client, priority)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving priority: %w", err)
 				}
 				update.PriorityID = &pid
 			}
 			if cmd.Flags().Changed("assignee") {
 				aid, err := resolver.ResolveAssignee(ctx, client, assignee)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving assignee: %w", err)
 				}
 				update.AssignedToID = &aid
 			}
@@ -132,14 +132,14 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			if cmd.Flags().Changed("category") {
 				cid, err := resolver.ResolveCategory(ctx, client, category, projectIdentifier)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving category: %w", err)
 				}
 				update.CategoryID = &cid
 			}
 			if cmd.Flags().Changed("version") {
 				vid, err := resolver.ResolveVersion(ctx, client, version, projectIdentifier)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving version: %w", err)
 				}
 				update.FixedVersionID = &vid
 			}

--- a/internal/cmd/time/list.go
+++ b/internal/cmd/time/list.go
@@ -58,7 +58,7 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 				if _, err := strconv.Atoi(user); err != nil {
 					resolved, err := resolver.ResolveUser(ctx, client, user)
 					if err != nil {
-						return err
+						return fmt.Errorf("resolving user: %w", err)
 					}
 					userID = strconv.Itoa(resolved)
 				}
@@ -68,7 +68,7 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 			if activity != "" {
 				activityID, err = resolver.ResolveActivity(ctx, client, activity)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving activity: %w", err)
 				}
 			}
 

--- a/internal/cmd/time/log.go
+++ b/internal/cmd/time/log.go
@@ -55,7 +55,7 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 			if activity != "" {
 				activityID, err = resolver.ResolveActivity(context.Background(), client, activity)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving activity: %w", err)
 				}
 			}
 

--- a/internal/cmd/time/summary.go
+++ b/internal/cmd/time/summary.go
@@ -69,7 +69,7 @@ func newCmdTimeSummary(f *cmdutil.Factory) *cobra.Command {
 				if _, err := strconv.Atoi(user); err != nil {
 					resolved, err := resolver.ResolveUser(context.Background(), client, user)
 					if err != nil {
-						return err
+						return fmt.Errorf("resolving user: %w", err)
 					}
 					userID = strconv.Itoa(resolved)
 				}

--- a/internal/cmd/time/update.go
+++ b/internal/cmd/time/update.go
@@ -44,7 +44,7 @@ func newCmdTimeUpdate(f *cmdutil.Factory) *cobra.Command {
 			if cmd.Flags().Changed("activity") {
 				activityID, err := resolver.ResolveActivity(context.Background(), client, activity)
 				if err != nil {
-					return err
+					return fmt.Errorf("resolving activity: %w", err)
 				}
 				update.ActivityID = &activityID
 			}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -79,6 +79,12 @@ func buildSuggestions(input string, names []string, ids []int, resourceType stri
 	return fmt.Sprintf("no match found for %q. Did you mean:\n%s", input, strings.Join(lines, "\n"))
 }
 
+// isForbiddenErr checks whether the error is a 403 Forbidden API error.
+func isForbiddenErr(err error) bool {
+	var apiErr *api.APIError
+	return errors.As(err, &apiErr) && apiErr.IsForbidden()
+}
+
 // Resolve attempts to resolve input to a numeric ID.
 // If input is numeric, it returns the parsed int directly.
 // Otherwise, it calls fetcher to get available options and performs
@@ -93,6 +99,9 @@ func Resolve(input string, resourceType string, client *api.Client, fetcher func
 
 	options, err := fetcher()
 	if err != nil {
+		if isForbiddenErr(err) {
+			return 0, fmt.Errorf("cannot resolve %s by name (insufficient permissions). Use a numeric ID instead", resourceType)
+		}
 		return 0, err
 	}
 
@@ -140,11 +149,17 @@ func ResolveProject(ctx context.Context, client *api.Client, input string) (int,
 
 	var apiErr *api.APIError
 	if !errors.As(err, &apiErr) || !apiErr.IsNotFound() {
+		if isForbiddenErr(err) {
+			return 0, "", fmt.Errorf("cannot resolve project %q (insufficient permissions). Use the project identifier or numeric ID instead", input)
+		}
 		return 0, "", fmt.Errorf("failed to resolve project %q: %w", input, err)
 	}
 
 	projects, _, err := client.Projects.List(ctx, nil, 0, 0)
 	if err != nil {
+		if isForbiddenErr(err) {
+			return 0, "", fmt.Errorf("cannot resolve project %q (insufficient permissions). Use the project identifier or numeric ID instead", input)
+		}
 		return 0, "", fmt.Errorf("failed to fetch projects: %w", err)
 	}
 
@@ -252,6 +267,9 @@ func ResolveCategory(ctx context.Context, client *api.Client, input string, proj
 
 	categories, _, err := client.Categories.List(ctx, projectIdentifier)
 	if err != nil {
+		if isForbiddenErr(err) {
+			return 0, fmt.Errorf("cannot resolve category by name (insufficient permissions). Use a numeric ID instead")
+		}
 		return 0, fmt.Errorf("failed to fetch issue categories: %w", err)
 	}
 
@@ -302,6 +320,9 @@ func ResolveVersion(ctx context.Context, client *api.Client, input string, proje
 
 	versions, _, err := client.Versions.List(ctx, projectIdentifier, 0, 0)
 	if err != nil {
+		if isForbiddenErr(err) {
+			return 0, fmt.Errorf("cannot resolve version by name (insufficient permissions). Use a numeric ID instead")
+		}
 		return 0, fmt.Errorf("failed to fetch versions for name resolution: %w", err)
 	}
 
@@ -366,6 +387,9 @@ func resolveUser(ctx context.Context, client *api.Client, input string, label st
 
 	users, _, err := client.Users.List(ctx, models.UserFilter{Name: input})
 	if err != nil {
+		if isForbiddenErr(err) {
+			return 0, fmt.Errorf("cannot resolve %s by name (listing users requires admin privileges). Use a numeric user ID instead, or \"me\" for yourself", label)
+		}
 		return 0, fmt.Errorf("failed to search users: %w", err)
 	}
 

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -153,6 +153,104 @@ func TestResolve_FetcherError(t *testing.T) {
 	}
 }
 
+func TestResolve_ForbiddenError(t *testing.T) {
+	client := testClient(t)
+	fetcher := func() ([]Option, error) {
+		return nil, &api.APIError{StatusCode: 403, URL: "/groups.json"}
+	}
+
+	_, err := Resolve("Developers", "group", client, fetcher)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve group by name") {
+		t.Errorf("expected permission hint, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "numeric ID") {
+		t.Errorf("expected numeric ID suggestion, got: %v", err)
+	}
+}
+
+func TestResolve_ForbiddenErrorWrapped(t *testing.T) {
+	// Simulates the real code path: fetcher wraps the 403 with fmt.Errorf,
+	// e.g. ResolveGroup's "failed to fetch groups: %w"
+	client := testClient(t)
+	fetcher := func() ([]Option, error) {
+		return nil, fmt.Errorf("failed to fetch groups: %w", &api.APIError{StatusCode: 403, URL: "/groups.json"})
+	}
+
+	_, err := Resolve("Developers", "group", client, fetcher)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve group by name") {
+		t.Errorf("expected permission hint even for wrapped 403, got: %v", err)
+	}
+	// Should NOT contain the raw API error — we want a clean message
+	if strings.Contains(err.Error(), "API error 403") {
+		t.Errorf("expected clean message without raw API error, got: %v", err)
+	}
+}
+
+func TestResolve_NonForbiddenAPIError(t *testing.T) {
+	// Non-403 API errors (401, 500, etc.) should pass through unchanged
+	client := testClient(t)
+	fetcher := func() ([]Option, error) {
+		return nil, &api.APIError{StatusCode: 401, URL: "/trackers.json"}
+	}
+
+	_, err := Resolve("Bug", "tracker", client, fetcher)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "cannot resolve") {
+		t.Errorf("non-403 error should not get permission hint, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected original error propagated, got: %v", err)
+	}
+}
+
+func TestResolve_ForbiddenNumericBypass(t *testing.T) {
+	// Numeric input should bypass the fetcher entirely, even if it would 403
+	client := testClient(t)
+	fetcher := func() ([]Option, error) {
+		t.Fatal("fetcher should not be called for numeric input")
+		return nil, nil
+	}
+
+	id, err := Resolve("42", "group", client, fetcher)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("expected ID 42, got %d", id)
+	}
+}
+
+func TestIsForbiddenErr_WrappedError(t *testing.T) {
+	inner := &api.APIError{StatusCode: 403, URL: "/users.json"}
+	wrapped := fmt.Errorf("failed to fetch users: %w", inner)
+	if !isForbiddenErr(wrapped) {
+		t.Error("expected isForbiddenErr to detect wrapped 403")
+	}
+}
+
+func TestIsForbiddenErr_NonForbidden(t *testing.T) {
+	err := &api.APIError{StatusCode: 404, URL: "/users.json"}
+	if isForbiddenErr(err) {
+		t.Error("expected isForbiddenErr to return false for 404")
+	}
+
+	if isForbiddenErr(fmt.Errorf("some other error")) {
+		t.Error("expected isForbiddenErr to return false for non-API error")
+	}
+
+	if isForbiddenErr(nil) {
+		t.Error("expected isForbiddenErr to return false for nil")
+	}
+}
+
 func TestResolveProjectFromList_MatchesDisplayName(t *testing.T) {
 	client := testClient(t)
 	projects := []models.Project{

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -150,6 +150,7 @@ If a name doesn't match, the CLI provides helpful suggestions:
 - **Small lists** (≤10 options): all available options are shown
 - **Large lists** (>10 options): fuzzy "Did you mean?" suggestions based on typo similarity
 - **Ambiguous matches**: all exact matches are listed with their IDs
+- **Permission errors**: some endpoints (notably `/users.json` and `/groups.json`) require admin privileges. When this happens, the CLI tells you explicitly and suggests using a numeric ID or `me` instead. The error message will say which field caused the failure (e.g. `resolving assignee: cannot resolve assignee by name ...`).
 
 ```bash
 # Will show all available trackers if "NonExistent" doesn't match
@@ -160,6 +161,16 @@ redmine issues create --project myproject --tracker Featrue --subject "Test"
 
 # Will show matching users if the name is ambiguous
 redmine issues update 123 --assignee "John"
+```
+
+**If you get a permission error resolving a user/group by name**, fall back to a numeric ID or `me`:
+
+```bash
+# Instead of --assignee "John Smith", use the numeric ID
+redmine issues create --project myproject --subject "Task" --assignee 42
+
+# Or use "me" to assign to yourself
+redmine issues create --project myproject --subject "Task" --assignee me
 ```
 
 ## Versions
@@ -264,10 +275,12 @@ When you need to specify a project, tracker, version, assignee, priority, or sta
    redmine projects list -o json        # available projects
    redmine trackers list -o json        # available trackers
    redmine statuses list -o json        # available statuses
-   redmine categories list -o json              # available categories
-   redmine versions list -o json               # available versions
-   redmine users list -o json           # available users
+   redmine categories list -o json      # available categories
+   redmine versions list -o json        # available versions
+   redmine users list -o json           # available users (requires admin)
+   redmine groups list -o json          # available groups (requires admin)
    ```
+   **Note:** `redmine users list` and `redmine groups list` require admin privileges. If you get a permission error, ask the user for a numeric user/group ID or use `me` for the current user.
 2. **Present the options to the user** in a clear, numbered list or selection prompt using your interactive tools (e.g. AskUserQuestion with a formatted list of choices). Let the user pick from the actual available options rather than asking them to type a free-form name.
 3. **Then use the confirmed value** in the create/update command.
 
@@ -284,3 +297,4 @@ This pattern applies broadly — whenever a command requires a value from a fixe
 - Set a default project with `redmine init` to avoid `--project` on every command.
 - Use `--project` or `-p` to override the default project per-command.
 - If a name doesn't resolve, the CLI shows all available options — use this to discover valid values.
+- Resolving users and groups by name requires admin privileges. For non-admin users, use numeric IDs or `me`. If resolution fails with a permission error, do **not** retry with the same name — switch to a numeric ID instead.


### PR DESCRIPTION
## Summary

- Detect 403 errors during name resolution and return actionable messages (e.g. "cannot resolve assignee by name (listing users requires admin privileges). Use a numeric user ID instead, or "me" for yourself") instead of generic "Permission denied"
- Wrap all command-level resolution errors with context (e.g. "resolving tracker: ...") so it's clear which field caused the failure
- Update SKILL.md to document permission constraints and instruct agents to fall back to numeric IDs instead of retrying with the same name

## Test plan

- [x] New tests for 403 detection in `Resolve()` (direct and wrapped errors)
- [x] Test that non-403 API errors still pass through unchanged
- [x] Test that numeric input bypasses the fetcher entirely
- [x] Test `isForbiddenErr` with wrapped, non-forbidden, and nil errors
- [x] All existing tests pass
- [x] Formatting and linting clean