### PR TITLE
Add dedicated memberships command with full CRUD support

### DIFF
--- a/docs/src/content/docs/commands/memberships.md
+++ b/docs/src/content/docs/commands/memberships.md
@@ -1,0 +1,69 @@
+---
+title: Memberships
+description: Manage Redmine project memberships.
+---
+
+The `memberships` command (alias: `m`) manages project memberships.
+
+## List Memberships
+
+```bash
+redmine memberships list --project <identifier> [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `--project` | Project name, identifier, or ID -- **required** |
+| `--limit` | Maximum number of results |
+| `--offset` | Result offset for pagination |
+| `-o, --output` | Output format: `table`, `json`, `csv` |
+
+## View a Membership
+
+```bash
+redmine memberships get <id> [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `-o, --output` | Output format |
+
+## Create a Membership
+
+```bash
+redmine memberships create [flags]
+```
+
+Adds a user or group to a project with specified roles.
+
+| Flag | Description |
+|------|------------|
+| `--project` | Project name, identifier, or ID -- **required** |
+| `--user-id` | User ID to add |
+| `--group-id` | Group ID to add |
+| `--role-ids` | Comma-separated role IDs -- **required** |
+| `-o, --output` | Output format |
+
+Either `--user-id` or `--group-id` must be provided. They are mutually exclusive.
+
+## Update a Membership
+
+```bash
+redmine memberships update <id> [flags]
+```
+
+Only the assigned roles can be changed on an existing membership.
+
+| Flag | Description |
+|------|------------|
+| `--role-ids` | Comma-separated role IDs -- **required** |
+
+## Delete a Membership
+
+```bash
+redmine memberships delete <id> [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `-f, --force` | Skip confirmation prompt |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -40,6 +40,7 @@ type Client struct {
 	Categories   *CategoryService
 	Groups       *GroupService
 	Search       *SearchService
+	Memberships  *MembershipService
 }
 
 // DebugLog returns the client's debug logger.
@@ -107,6 +108,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Categories = &CategoryService{client: c}
 	c.Groups = &GroupService{client: c}
 	c.Search = &SearchService{client: c}
+	c.Memberships = &MembershipService{client: c}
 
 	return c, nil
 }

--- a/internal/api/memberships.go
+++ b/internal/api/memberships.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/aarondpn/redmine-cli/internal/models"
+)
+
+// MembershipService handles membership-related API calls.
+type MembershipService struct {
+	client *Client
+}
+
+// List retrieves memberships for a project.
+func (s *MembershipService) List(ctx context.Context, projectID string, limit, offset int) ([]models.Membership, int, error) {
+	var params url.Values
+	if offset > 0 {
+		params = url.Values{}
+		params.Set("offset", strconv.Itoa(offset))
+	}
+	return FetchAll[models.Membership](ctx, s.client, fmt.Sprintf("/projects/%s/memberships.json", projectID), params, "memberships", limit)
+}
+
+// Get retrieves a single membership by ID.
+func (s *MembershipService) Get(ctx context.Context, id int) (*models.Membership, error) {
+	var resp struct {
+		Membership models.Membership `json:"membership"`
+	}
+	if err := s.client.Get(ctx, fmt.Sprintf("/memberships/%d.json", id), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Membership, nil
+}
+
+// Create creates a new membership in a project.
+func (s *MembershipService) Create(ctx context.Context, projectID string, membership models.MembershipCreate) (*models.Membership, error) {
+	body := map[string]interface{}{"membership": membership}
+	var resp struct {
+		Membership models.Membership `json:"membership"`
+	}
+	if err := s.client.Post(ctx, fmt.Sprintf("/projects/%s/memberships.json", projectID), body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Membership, nil
+}
+
+// Update updates an existing membership.
+func (s *MembershipService) Update(ctx context.Context, id int, update models.MembershipUpdate) error {
+	body := map[string]interface{}{"membership": update}
+	return s.client.Put(ctx, fmt.Sprintf("/memberships/%d.json", id), body)
+}
+
+// Delete deletes a membership.
+func (s *MembershipService) Delete(ctx context.Context, id int) error {
+	return s.client.Delete(ctx, fmt.Sprintf("/memberships/%d.json", id))
+}

--- a/internal/cmd/membership/create.go
+++ b/internal/cmd/membership/create.go
@@ -1,0 +1,94 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/models"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project string
+		userID  int
+		groupID int
+		roleIDs []int
+		format  string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"add", "new"},
+		Short:   "Add a member to a project",
+		Long:    "Create a new membership, adding a user or group to a project with specified roles.",
+		Example: `  # Add a user with roles
+  redmine memberships create --project myproject --user-id 5 --role-ids 1,2
+
+  # Add a group with a role
+  redmine memberships create --project myproject --group-id 10 --role-ids 3`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hasUser := cmd.Flags().Changed("user-id")
+			hasGroup := cmd.Flags().Changed("group-id")
+			if !hasUser && !hasGroup {
+				return fmt.Errorf("either --user-id or --group-id is required")
+			}
+
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			if project == "" {
+				cfg, err := f.Config()
+				if err == nil && cfg.DefaultProject != "" {
+					project = cfg.DefaultProject
+				}
+			}
+			if project == "" {
+				return fmt.Errorf("project is required. Use --project or set a default project")
+			}
+
+			project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			memberID := userID
+			if hasGroup {
+				memberID = groupID
+			}
+
+			printer := f.Printer(format)
+			stop := printer.Spinner("Creating membership...")
+			m, err := client.Memberships.Create(context.Background(), project, models.MembershipCreate{
+				UserID:  memberID,
+				RoleIDs: roleIDs,
+			})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(m)
+				return nil
+			}
+
+			printer.Success(fmt.Sprintf("Created membership (ID: %d) for %s in project %s", m.ID, memberName(*m), m.Project.Name))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID (required)")
+	cmd.Flags().IntVar(&userID, "user-id", 0, "User ID to add")
+	cmd.Flags().IntVar(&groupID, "group-id", 0, "Group ID to add")
+	cmd.Flags().IntSliceVar(&roleIDs, "role-ids", nil, "Role IDs to assign (required)")
+	cmd.MarkFlagRequired("role-ids")
+	cmd.MarkFlagsMutuallyExclusive("user-id", "group-id")
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}

--- a/internal/cmd/membership/delete.go
+++ b/internal/cmd/membership/delete.go
@@ -1,0 +1,57 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+func newCmdMembershipDelete(f *cmdutil.Factory) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <id>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a membership",
+		Long:    "Delete a membership, removing a user or group from a project.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("membership ID must be a number: %s", args[0])
+			}
+
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer("")
+
+			if !force {
+				msg := fmt.Sprintf("Are you sure you want to delete membership %d?", id)
+				if !cmdutil.ConfirmAction(f.IOStreams.In, f.IOStreams.ErrOut, msg) {
+					printer.Warning("Delete cancelled")
+					return nil
+				}
+			}
+
+			stop := printer.Spinner("Deleting membership...")
+			err = client.Memberships.Delete(context.Background(), id)
+			stop()
+			if err != nil {
+				return err
+			}
+
+			printer.Success(fmt.Sprintf("Deleted membership %d", id))
+			return nil
+		},
+	}
+
+	cmdutil.AddForceFlag(cmd, &force)
+	return cmd
+}

--- a/internal/cmd/membership/get.go
+++ b/internal/cmd/membership/get.go
@@ -1,0 +1,60 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+func newCmdMembershipGet(f *cmdutil.Factory) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:     "get <id>",
+		Aliases: []string{"show", "view"},
+		Short:   "Get membership details",
+		Long:    "Display detailed information about a specific membership.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("membership ID must be a number: %s", args[0])
+			}
+
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer(format)
+			stop := printer.Spinner("Fetching membership...")
+			m, err := client.Memberships.Get(context.Background(), id)
+			stop()
+			if err != nil {
+				return fmt.Errorf("failed to get membership %d: %w", id, err)
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(m)
+				return nil
+			}
+
+			pairs := []output.KeyValue{
+				{Key: "ID", Value: output.StyleID.Render(fmt.Sprintf("%d", m.ID))},
+				{Key: "Project", Value: m.Project.Name},
+				{Key: "User/Group", Value: memberName(*m)},
+				{Key: "Roles", Value: formatRoles(m.Roles)},
+			}
+			printer.Detail(pairs)
+			return nil
+		},
+	}
+
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}

--- a/internal/cmd/membership/list.go
+++ b/internal/cmd/membership/list.go
@@ -1,0 +1,135 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/models"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+func newCmdMembershipList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project string
+		limit   int
+		offset  int
+		format  string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List project memberships",
+		Long:    "List all memberships for a project.",
+		Example: `  # List memberships for a project
+  redmine memberships list --project myproject
+
+  # Output as JSON
+  redmine memberships list --project myproject -o json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			if project == "" {
+				cfg, err := f.Config()
+				if err == nil && cfg.DefaultProject != "" {
+					project = cfg.DefaultProject
+				}
+			}
+			if project == "" {
+				return fmt.Errorf("project is required. Use --project or set a default project")
+			}
+
+			project, err = cmdutil.ResolveProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer(format)
+			stop := printer.Spinner("Fetching memberships...")
+
+			memberships, total, err := client.Memberships.List(context.Background(), project, limit, offset)
+			stop()
+			if err != nil {
+				return fmt.Errorf("failed to list memberships: %s", cmdutil.FormatError(err))
+			}
+
+			if len(memberships) == 0 {
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(memberships)
+					return nil
+				}
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning("No memberships found")
+				}
+				return nil
+			}
+
+			switch printer.Format() {
+			case output.FormatJSON:
+				printer.JSON(memberships)
+			case output.FormatCSV:
+				headers := []string{"ID", "User/Group", "Roles"}
+				rows := make([][]string, len(memberships))
+				for i, m := range memberships {
+					rows[i] = []string{
+						fmt.Sprintf("%d", m.ID),
+						memberName(m),
+						formatRoles(m.Roles),
+					}
+				}
+				printer.CSV(headers, rows)
+			default:
+				headers := []string{"ID", "User/Group", "Roles"}
+				rows := make([][]string, len(memberships))
+				for i, m := range memberships {
+					rows[i] = []string{
+						output.StyleID.Render(strconv.Itoa(m.ID)),
+						memberName(m),
+						formatRoles(m.Roles),
+					}
+				}
+				printer.Table(headers, rows)
+			}
+
+			if limit > 0 && total > limit+offset {
+				if output.SupportsWarnings(printer.Format()) {
+					printer.Warning(fmt.Sprintf("Showing %d of %d memberships. Use --limit and --offset to paginate.", len(memberships), total))
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID (required)")
+	cmdutil.AddPaginationFlags(cmd, &limit, &offset)
+	cmdutil.AddOutputFlag(cmd, &format)
+
+	return cmd
+}
+
+func memberName(m models.Membership) string {
+	if m.User != nil {
+		return m.User.Name
+	}
+	if m.Group != nil {
+		return m.Group.Name + " (group)"
+	}
+	return "unknown"
+}
+
+func formatRoles(roles []models.IDName) string {
+	names := make([]string, len(roles))
+	for i, r := range roles {
+		names[i] = r.Name
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/cmd/membership/membership.go
+++ b/internal/cmd/membership/membership.go
@@ -1,0 +1,25 @@
+package membership
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+// NewCmdMemberships creates the parent memberships command.
+func NewCmdMemberships(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "memberships",
+		Aliases: []string{"m"},
+		Short:   "Manage project memberships",
+		Long:    "List, view, create, update, and delete Redmine project memberships.",
+	}
+
+	cmd.AddCommand(newCmdMembershipList(f))
+	cmd.AddCommand(newCmdMembershipGet(f))
+	cmd.AddCommand(newCmdMembershipCreate(f))
+	cmd.AddCommand(newCmdMembershipUpdate(f))
+	cmd.AddCommand(newCmdMembershipDelete(f))
+
+	return cmd
+}

--- a/internal/cmd/membership/update.go
+++ b/internal/cmd/membership/update.go
@@ -1,0 +1,56 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/models"
+)
+
+func newCmdMembershipUpdate(f *cmdutil.Factory) *cobra.Command {
+	var roleIDs []int
+
+	cmd := &cobra.Command{
+		Use:     "update <id>",
+		Aliases: []string{"edit"},
+		Short:   "Update membership roles",
+		Long:    "Update the roles assigned to a membership.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("membership ID must be a number: %s", args[0])
+			}
+
+			if !cmd.Flags().Changed("role-ids") {
+				return fmt.Errorf("--role-ids is required")
+			}
+
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer("")
+
+			stop := printer.Spinner("Updating membership...")
+			err = client.Memberships.Update(context.Background(), id, models.MembershipUpdate{
+				RoleIDs: roleIDs,
+			})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			printer.Success(fmt.Sprintf("Updated membership %d", id))
+			return nil
+		},
+	}
+
+	cmd.Flags().IntSliceVar(&roleIDs, "role-ids", nil, "Role IDs to assign (required)")
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	initcmd "github.com/aarondpn/redmine-cli/internal/cmd/initialize"
 	"github.com/aarondpn/redmine-cli/internal/cmd/installskill"
 	"github.com/aarondpn/redmine-cli/internal/cmd/issue"
+	"github.com/aarondpn/redmine-cli/internal/cmd/membership"
 	"github.com/aarondpn/redmine-cli/internal/cmd/project"
 	"github.com/aarondpn/redmine-cli/internal/cmd/search"
 	"github.com/aarondpn/redmine-cli/internal/cmd/status"
@@ -76,6 +77,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(initcmd.NewCmdInit(f))
 	cmd.AddCommand(issue.NewCmdIssue(f))
 	cmd.AddCommand(group.NewCmdGroup(f))
+	cmd.AddCommand(membership.NewCmdMemberships(f))
 	cmd.AddCommand(project.NewCmdProject(f))
 	cmd.AddCommand(timecmd.NewCmdTime(f))
 	cmd.AddCommand(user.NewCmdUser(f))

--- a/internal/models/membership.go
+++ b/internal/models/membership.go
@@ -1,0 +1,28 @@
+package models
+
+// Membership represents a project membership.
+type Membership struct {
+	ID      int      `json:"id"`
+	Project IDName   `json:"project"`
+	User    *IDName  `json:"user,omitempty"`
+	Group   *IDName  `json:"group,omitempty"`
+	Roles   []IDName `json:"roles"`
+}
+
+// MembershipCreate defines fields for creating a membership.
+type MembershipCreate struct {
+	UserID  int   `json:"user_id"`
+	RoleIDs []int `json:"role_ids"`
+}
+
+// MembershipUpdate defines fields for updating a membership.
+type MembershipUpdate struct {
+	RoleIDs []int `json:"role_ids"`
+}
+
+// MembershipFilter defines parameters for listing memberships.
+type MembershipFilter struct {
+	Project string
+	Limit   int
+	Offset  int
+}

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -30,12 +30,3 @@ type ProjectUpdate struct {
 	Description *string `json:"description,omitempty"`
 	IsPublic    *bool   `json:"is_public,omitempty"`
 }
-
-// Membership represents a project membership.
-type Membership struct {
-	ID      int      `json:"id"`
-	Project IDName   `json:"project"`
-	User    *IDName  `json:"user,omitempty"`
-	Group   *IDName  `json:"group,omitempty"`
-	Roles   []IDName `json:"roles"`
-}

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when the user asks you to:
 - List, view, or search Redmine issues
 - List or view project versions (milestones)
 - Log or view time entries
+- Manage project memberships (add, update, remove users/groups from projects)
 - Query projects, users, groups, trackers, or statuses
 - Perform any task involving Redmine project management data
 
@@ -242,6 +243,46 @@ redmine groups get Developers -o json
 # Add/remove users by name
 redmine groups add-user Developers jsmith
 redmine groups remove-user Developers "John Smith"
+```
+
+## Memberships
+
+### List project memberships
+
+```bash
+redmine memberships list --project myproject -o json
+
+# With pagination
+redmine memberships list --project myproject --limit 25 --offset 0 -o json
+```
+
+### Get a single membership
+
+```bash
+redmine memberships get 42 -o json
+```
+
+### Create a membership (add user/group to project)
+
+```bash
+# Add a user with roles
+redmine memberships create --project myproject --user-id 5 --role-ids 1,2 -o json
+
+# Add a group with a role
+redmine memberships create --project myproject --group-id 10 --role-ids 3 -o json
+```
+
+### Update membership roles
+
+```bash
+redmine memberships update 42 --role-ids 1,3
+```
+
+### Delete a membership
+
+```bash
+redmine memberships delete 42
+redmine memberships delete 42 --force
 ```
 
 ## Other Commands


### PR DESCRIPTION
## Summary

- Adds a new top-level `memberships` (alias: `m`) command with full CRUD: `list`, `get`, `create`, `update`, `delete`
- Extracts the `Membership` model from `project.go` into its own `membership.go` file, adds `MembershipCreate`, `MembershipUpdate`, and `MembershipFilter` types
- Adds `MembershipService` to the API layer with all five endpoints matching the Redmine REST API
- Includes command documentation (`docs/src/content/docs/commands/memberships.md`) and skill file updates

## Details

The Redmine Memberships API was previously only partially exposed via `redmine projects members <id>` (list only). This PR adds the full API surface:

| Command | Description |
|---------|-------------|
| `redmine memberships list --project <id>` | List project memberships (with pagination) |
| `redmine memberships get <id>` | View a single membership |
| `redmine memberships create --project <id> --user-id <uid> --role-ids <rids>` | Add user/group to project |
| `redmine memberships update <id> --role-ids <rids>` | Change assigned roles |
| `redmine memberships delete <id>` | Remove a membership |

The existing `projects members` convenience shortcut remains unchanged.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `redmine memberships --help` shows all subcommands
- [x] Manual smoke test: list, get, create, update, delete against a Redmine instance