### PR TITLE
Add shorthand include flags for issues list and get

### DIFF
--- a/docs/src/content/docs/commands/issues.md
+++ b/docs/src/content/docs/commands/issues.md
@@ -19,6 +19,9 @@ redmine issues list [flags]
 | `--assignee` | Filter by assignee: `me`, name, or ID |
 | `--version` | Filter by target version (name or ID) |
 | `--sort` | Sort order, e.g. `updated_on:desc` |
+| `--include` | Include related data: `attachments`, `relations` |
+| `--attachments` | Shorthand for `--include attachments` |
+| `--relations` | Shorthand for `--include relations` |
 | `--limit` | Maximum number of results (0 for all) |
 | `--offset` | Result offset for pagination |
 | `-o, --output` | Output format: `table`, `wide`, `json`, `csv` |
@@ -42,7 +45,10 @@ redmine issues get <id> [flags]
 
 | Flag | Description |
 |------|------------|
-| `--journals` | Include issue history/comments |
+| `--include` | Include related data: `journals`, `children`, `relations` |
+| `--journals` | Shorthand for `--include journals` |
+| `--children` | Shorthand for `--include children` |
+| `--relations` | Shorthand for `--include relations` |
 | `-o, --output` | Output format |
 
 ## Create an Issue

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -32,6 +32,9 @@ func (s *IssueService) List(ctx context.Context, filter models.IssueFilter) ([]m
 	if filter.FixedVersionID > 0 {
 		params.Set("fixed_version_id", strconv.Itoa(filter.FixedVersionID))
 	}
+	if len(filter.Includes) > 0 {
+		params.Set("include", joinStrings(filter.Includes, ","))
+	}
 	if filter.Sort != "" {
 		params.Set("sort", filter.Sort)
 	}

--- a/internal/cmd/issue/get.go
+++ b/internal/cmd/issue/get.go
@@ -15,8 +15,11 @@ import (
 // NewCmdGet creates the issues get command.
 func NewCmdGet(f *cmdutil.Factory) *cobra.Command {
 	var (
-		include string
-		format  string
+		include   string
+		journals  bool
+		children  bool
+		relations bool
+		format    string
 	)
 
 	cmd := &cobra.Command{
@@ -39,6 +42,15 @@ func NewCmdGet(f *cmdutil.Factory) *cobra.Command {
 			var includes []string
 			if include != "" {
 				includes = strings.Split(include, ",")
+			}
+			if journals {
+				includes = append(includes, "journals")
+			}
+			if children {
+				includes = append(includes, "children")
+			}
+			if relations {
+				includes = append(includes, "relations")
 			}
 
 			printer := f.Printer(format)
@@ -103,6 +115,9 @@ func NewCmdGet(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&include, "include", "", "Include related data: journals,children,relations")
+	cmd.Flags().BoolVar(&journals, "journals", false, "Include issue history/comments (shorthand for --include journals)")
+	cmd.Flags().BoolVar(&children, "children", false, "Include child issues (shorthand for --include children)")
+	cmd.Flags().BoolVar(&relations, "relations", false, "Include issue relations (shorthand for --include relations)")
 	cmdutil.AddOutputFlag(cmd, &format)
 
 	return cmd

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -3,6 +3,7 @@ package issue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,15 +16,18 @@ import (
 // NewCmdList creates the issues list command.
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	var (
-		project  string
-		tracker  string
-		status   string
-		assignee string
-		version  string
-		sort     string
-		limit    int
-		offset   int
-		format   string
+		project     string
+		tracker     string
+		status      string
+		assignee    string
+		version     string
+		sort        string
+		include     string
+		attachments bool
+		relations   bool
+		limit       int
+		offset      int
+		format      string
 	)
 
 	cmd := &cobra.Command{
@@ -87,6 +91,17 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				versionID = id
 			}
 
+			var includes []string
+			if include != "" {
+				includes = strings.Split(include, ",")
+			}
+			if attachments {
+				includes = append(includes, "attachments")
+			}
+			if relations {
+				includes = append(includes, "relations")
+			}
+
 			filter := models.IssueFilter{
 				ProjectID:      project,
 				TrackerID:      trackerID,
@@ -94,6 +109,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				AssignedToID:   assignee,
 				FixedVersionID: versionID,
 				Sort:           sort,
+				Includes:       includes,
 				Limit:          limit,
 				Offset:         offset,
 			}
@@ -166,6 +182,9 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&assignee, "assignee", "", "Assignee ID or 'me'")
 	cmd.Flags().StringVar(&version, "version", "", "Filter by version name or ID")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort field (e.g., updated_on:desc)")
+	cmd.Flags().StringVar(&include, "include", "", "Include related data: attachments,relations")
+	cmd.Flags().BoolVar(&attachments, "attachments", false, "Include attachments (shorthand for --include attachments)")
+	cmd.Flags().BoolVar(&relations, "relations", false, "Include issue relations (shorthand for --include relations)")
 	cmdutil.AddPaginationFlags(cmd, &limit, &offset)
 	cmdutil.AddOutputFlag(cmd, &format)
 

--- a/internal/models/issue.go
+++ b/internal/models/issue.go
@@ -41,6 +41,7 @@ type IssueFilter struct {
 	AssignedToID   string // numeric ID or "me"
 	FixedVersionID int
 	Sort           string // e.g., "updated_on:desc"
+	Includes       []string
 	Limit          int
 	Offset         int
 }

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -79,10 +79,13 @@ redmine issues list --project myproject --sort updated_on:desc -o json
 ```bash
 redmine issues get 123 -o json
 
-# With comments/journals
-redmine issues get 123 --include journals -o json
+# With comments/journals (shorthand flag)
+redmine issues get 123 --journals -o json
 
-# With all related data
+# With children or relations
+redmine issues get 123 --children --relations -o json
+
+# Using --include for multiple values
 redmine issues get 123 --include journals,children,relations -o json
 ```
 


### PR DESCRIPTION
## Summary

- Adds shorthand boolean flags for commonly used `--include` values on issues commands
- **`issues get`**: `--journals`, `--children`, `--relations` (all supported by the Redmine show endpoint)
- **`issues list`**: `--attachments`, `--relations` (only values supported by the Redmine list endpoint)
- The `--include` flag remains available for full control (e.g., `--include journals,children,relations`)
- Adds `Includes` field to `IssueFilter` so the list API can pass `include` params
- Updates command docs and skill file

## Examples

```bash
# Before
redmine issues get 123 --include journals
redmine issues get 123 --include journals,children,relations

# After (shorthands)
redmine issues get 123 --journals
redmine issues get 123 --journals --children --relations

# List with relations
redmine issues list --project myproject --relations -o json
```

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `redmine issues get <id> --journals` includes journals
- [ ] Manual: `redmine issues list --project <p> --relations` includes relations