### PR TITLE
[codex] Fix issue filter name resolution

### DIFF
--- a/internal/cmd/issue/browse.go
+++ b/internal/cmd/issue/browse.go
@@ -2,6 +2,7 @@ package issue
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aarondpn/redmine-cli/internal/cmdutil"
 	"github.com/aarondpn/redmine-cli/internal/models"
@@ -21,7 +22,8 @@ func NewCmdBrowse(f *cmdutil.Factory) *cobra.Command {
 		Use:   "browse",
 		Short: "Interactive issue browser (TUI)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			project, err := cmdutil.DefaultProjectID(context.Background(), f, project)
+			ctx := context.Background()
+			project, err := cmdutil.DefaultProjectID(ctx, f, project)
 			if err != nil {
 				return err
 			}
@@ -37,16 +39,25 @@ func NewCmdBrowse(f *cmdutil.Factory) *cobra.Command {
 			}
 			printer := f.Printer("")
 
+			resolvedStatus, err := resolveIssueStatusFilter(ctx, client, status)
+			if err != nil {
+				return err
+			}
+			resolvedAssignee, err := resolveIssueAssigneeFilter(ctx, client, assignee, printer)
+			if err != nil {
+				return err
+			}
+
 			stop := printer.Spinner("Loading issues...")
-			issues, _, err := client.Issues.List(context.Background(), models.IssueFilter{
+			issues, _, err := client.Issues.List(ctx, models.IssueFilter{
 				ProjectID:    project,
-				StatusID:     status,
-				AssignedToID: assignee,
+				StatusID:     resolvedStatus,
+				AssignedToID: resolvedAssignee,
 				Limit:        100,
 			})
 			stop()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to browse issues: %w", err)
 			}
 
 			return tui.RunBrowser(issues, cfg.Server)
@@ -54,8 +65,8 @@ func NewCmdBrowse(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Filter by project name, identifier, or ID")
-	cmd.Flags().StringVar(&status, "status", "open", "Filter by status")
-	cmd.Flags().StringVar(&assignee, "assignee", "", "Filter by assignee")
+	cmd.Flags().StringVar(&status, "status", "open", "Filter by status: open, closed, *, status name, or ID")
+	cmd.Flags().StringVar(&assignee, "assignee", "", "Filter by assignee: me, name, login, or ID")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
 	_ = cmd.RegisterFlagCompletionFunc("status", cmdutil.CompleteIssueListStatus(f))

--- a/internal/cmd/issue/filter_resolution.go
+++ b/internal/cmd/issue/filter_resolution.go
@@ -1,0 +1,44 @@
+package issue
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aarondpn/redmine-cli/internal/api"
+	"github.com/aarondpn/redmine-cli/internal/output"
+	"github.com/aarondpn/redmine-cli/internal/resolver"
+)
+
+func resolveIssueStatusFilter(ctx context.Context, client *api.Client, status string) (string, error) {
+	if status == "" || status == "open" || status == "closed" || status == "*" {
+		return status, nil
+	}
+
+	id, err := resolver.ResolveStatus(ctx, client, status)
+	if err != nil {
+		return "", fmt.Errorf("resolving status: %w", err)
+	}
+	return strconv.Itoa(id), nil
+}
+
+func resolveIssueAssigneeFilter(ctx context.Context, client *api.Client, assignee string, printer output.Printer) (string, error) {
+	if assignee == "" || assignee == "me" {
+		return assignee, nil
+	}
+
+	if _, err := strconv.Atoi(assignee); err == nil {
+		return assignee, nil
+	}
+
+	id, err := resolver.ResolveAssignee(ctx, client, assignee)
+	if err != nil {
+		if resolver.IsNameResolutionPermissionError(err) {
+			printer.Warning("Could not resolve --assignee by name because user lookup requires admin privileges; ignoring the assignee filter. Use a numeric user ID or 'me' instead.")
+			return "", nil
+		}
+		return "", fmt.Errorf("resolving assignee: %w", err)
+	}
+
+	return strconv.Itoa(id), nil
+}

--- a/internal/cmd/issue/filter_resolution_test.go
+++ b/internal/cmd/issue/filter_resolution_test.go
@@ -1,0 +1,45 @@
+package issue
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/output"
+	"github.com/aarondpn/redmine-cli/internal/testutil"
+)
+
+func TestResolveIssueAssigneeFilter_MeBypassesLookup(t *testing.T) {
+	f := testutil.NewFactory(t, "https://example.invalid")
+	printer := output.NewStdPrinter(f.IOStreams.Out, f.IOStreams.ErrOut, false, true, "")
+
+	got, err := resolveIssueAssigneeFilter(context.Background(), nil, "me", printer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "me" {
+		t.Fatalf("got %q, want %q", got, "me")
+	}
+}
+
+func TestResolveIssueStatusFilter_PreservesSpecialValue(t *testing.T) {
+	got, err := resolveIssueStatusFilter(context.Background(), nil, "*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "*" {
+		t.Fatalf("got %q, want %q", got, "*")
+	}
+}
+
+func TestResolveIssueAssigneeFilter_NumericBypassesLookup(t *testing.T) {
+	f := testutil.NewFactory(t, "https://example.invalid")
+	printer := output.NewStdPrinter(f.IOStreams.Out, f.IOStreams.ErrOut, false, true, "")
+
+	got, err := resolveIssueAssigneeFilter(context.Background(), nil, "42", printer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "42" {
+		t.Fatalf("got %q, want %q", got, "42")
+	}
+}

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -61,6 +61,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			ctx := context.Background()
+			printer := f.Printer(format)
 
 			project, err = cmdutil.DefaultProjectID(ctx, f, project)
 			if err != nil {
@@ -75,13 +76,14 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			resolvedStatus := status
-			if status != "" && status != "open" && status != "closed" && status != "*" {
-				id, err := resolver.ResolveStatus(ctx, client, status)
-				if err != nil {
-					return fmt.Errorf("resolving status: %w", err)
-				}
-				resolvedStatus = fmt.Sprintf("%d", id)
+			resolvedStatus, err := resolveIssueStatusFilter(ctx, client, status)
+			if err != nil {
+				return err
+			}
+
+			resolvedAssignee, err := resolveIssueAssigneeFilter(ctx, client, assignee, printer)
+			if err != nil {
+				return err
 			}
 
 			var versionID int
@@ -108,7 +110,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				ProjectID:      project,
 				TrackerID:      trackerID,
 				StatusID:       resolvedStatus,
-				AssignedToID:   assignee,
+				AssignedToID:   resolvedAssignee,
 				FixedVersionID: versionID,
 				Sort:           sort,
 				Includes:       includes,
@@ -116,7 +118,6 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				Offset:         offset,
 			}
 
-			printer := f.Printer(format)
 			stop := printer.Spinner("Fetching issues...")
 			issues, total, err := client.Issues.List(ctx, filter)
 			stop()

--- a/internal/cmd/issue/list_test.go
+++ b/internal/cmd/issue/list_test.go
@@ -171,3 +171,72 @@ func TestCmdIssueList_ResolvesStatusNameToID(t *testing.T) {
 		t.Fatalf("issues query = %q, did not expect raw status name", issuesQuery)
 	}
 }
+
+func TestCmdIssueList_ResolvesAssigneeNameToID(t *testing.T) {
+	var issuesQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.json":
+			_, _ = w.Write([]byte(`{"users":[{"id":7,"login":"jdoe","firstname":"John","lastname":"Doe","mail":"john@example.com","status":1}],"total_count":1}`))
+		case "/issues.json":
+			issuesQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"issues":[],"total_count":0}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdList(f)
+	cmd.SetArgs([]string{"--assignee", "John Doe", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(issuesQuery, "assigned_to_id=7") {
+		t.Fatalf("issues query = %q, want assigned_to_id=7", issuesQuery)
+	}
+	if strings.Contains(issuesQuery, "assigned_to_id=John") {
+		t.Fatalf("issues query = %q, did not expect raw assignee name", issuesQuery)
+	}
+}
+
+func TestCmdIssueList_IgnoresAssigneeNameWhenUserLookupForbidden(t *testing.T) {
+	var issuesQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users.json":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":["Forbidden"]}`))
+		case "/issues.json":
+			issuesQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"issues":[],"total_count":0}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdList(f)
+	cmd.SetArgs([]string{"--assignee", "John Doe", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(issuesQuery, "assigned_to_id=") {
+		t.Fatalf("issues query = %q, did not expect assigned_to_id filter", issuesQuery)
+	}
+	if stderr := testutil.Stderr(f); !strings.Contains(stderr, "ignoring the assignee filter") {
+		t.Fatalf("stderr = %q, want assignee fallback warning", stderr)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -30,6 +30,23 @@ type suggestion struct {
 	distance int
 }
 
+// NameResolutionPermissionError indicates that a name lookup could not be
+// completed because the API does not allow listing the candidate resource.
+type NameResolutionPermissionError struct {
+	message string
+}
+
+func (e *NameResolutionPermissionError) Error() string {
+	return e.message
+}
+
+// IsNameResolutionPermissionError reports whether err indicates that a
+// human-readable lookup was blocked by permissions.
+func IsNameResolutionPermissionError(err error) bool {
+	var target *NameResolutionPermissionError
+	return errors.As(err, &target)
+}
+
 // buildSuggestions generates a helpful error message when no exact match is found.
 // For small lists (<=10 items) it shows all options. For larger lists it uses
 // Levenshtein distance to suggest close matches.
@@ -100,7 +117,9 @@ func Resolve(input string, resourceType string, client *api.Client, fetcher func
 	options, err := fetcher()
 	if err != nil {
 		if isForbiddenErr(err) {
-			return 0, fmt.Errorf("cannot resolve %s by name (insufficient permissions). Use a numeric ID instead", resourceType)
+			return 0, &NameResolutionPermissionError{
+				message: fmt.Sprintf("cannot resolve %s by name (insufficient permissions). Use a numeric ID instead", resourceType),
+			}
 		}
 		return 0, err
 	}
@@ -388,7 +407,9 @@ func resolveUser(ctx context.Context, client *api.Client, input string, label st
 	users, _, err := client.Users.List(ctx, models.UserFilter{Name: input})
 	if err != nil {
 		if isForbiddenErr(err) {
-			return 0, fmt.Errorf("cannot resolve %s by name (listing users requires admin privileges). Use a numeric user ID instead, or \"me\" for yourself", label)
+			return 0, &NameResolutionPermissionError{
+				message: fmt.Sprintf("cannot resolve %s by name (listing users requires admin privileges). Use a numeric user ID instead, or \"me\" for yourself", label),
+			}
 		}
 		return 0, fmt.Errorf("failed to search users: %w", err)
 	}


### PR DESCRIPTION
## What changed
- add shared resolution for issue filter values so `issues list` and `issues browse` handle status names and assignee names consistently
- resolve assignee names to numeric IDs before calling Redmine instead of forwarding raw names to `assigned_to_id`
- gracefully handle admin-only user lookup for assignee filters by warning and continuing without the assignee filter when name resolution is forbidden
- add regression coverage for status-name resolution, assignee-name resolution, and the permission-denied fallback path

## Why
The previous fix covered `issues list --status`, but two related filter paths were still inconsistent:
- `issues list --assignee <name>` still sent a raw assignee string where the Redmine API expects `me` or a numeric ID
- `issues browse` still bypassed name resolution for both `--status` and `--assignee`

Assignee lookup is special because some Redmine instances only allow user listing for admins. In that case, the CLI now degrades gracefully instead of failing or sending an invalid query.

## Impact
Issue filtering by human-readable status and assignee values is now consistent across `list` and `browse`. When assignee name resolution is blocked by permissions, the user gets a warning with guidance to use a numeric ID or `me`.

## Validation
- `go test ./internal/cmd/issue ./internal/resolver`
- `golangci-lint run`
