### PR TITLE
fix: correct pagination issues across pageable elements

### DIFF
--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -143,12 +143,15 @@ func FetchAllFiltered[T any](ctx context.Context, c *Client, path string, params
 			return nil, false, fmt.Errorf("decoding %s: %w", key, err)
 		}
 
-		for _, item := range items {
+		for i, item := range items {
 			if filter(item) {
 				matched = append(matched, item)
 				if maxResults > 0 && len(matched) >= maxResults {
-					// We have enough, but there may be more on remaining pages.
-					hasMore := offset+len(items) < totalCount || len(matched) > maxResults
+					// We have enough, but there may be more on the rest
+					// of this page or on subsequent pages.
+					moreItemsOnPage := i < len(items)-1
+					morePagesExist := offset+len(items) < totalCount
+					hasMore := moreItemsOnPage || morePagesExist
 					c.debugLog.Printf("Pagination (filtered): matched %d items (limit reached)", len(matched))
 					return matched[:maxResults], hasMore, nil
 				}

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -476,6 +476,68 @@ func TestFetchAll_UnpaginatedWithOffsetAndMaxResults(t *testing.T) {
 	}
 }
 
+func TestFetchAllFiltered_UnpaginatedWithMaxResults_HasMore(t *testing.T) {
+	// Bug fix: when maxResults is reached mid-page on an unpaginated endpoint,
+	// hasMore should be true if there are unscanned items remaining on the page.
+	allItems := make([]testItem, 50)
+	openCount := 0
+	for i := range allItems {
+		if i%5 == 0 {
+			allItems[i] = testItem{ID: i + 1, Status: "open"}
+			openCount++
+		} else {
+			allItems[i] = testItem{ID: i + 1, Status: "closed"}
+		}
+	}
+	// openCount = 10 (items at index 0,5,10,...,45)
+
+	ts := httptest.NewServer(unpaginatedHandler("things", allItems))
+	defer ts.Close()
+
+	// Request only 3 matching items — more open items exist beyond that.
+	got, hasMore, err := FetchAllFiltered[testItem](context.Background(), newTestClient(ts), "/things.json", nil, "things", 3, func(i testItem) bool {
+		return i.Status == "open"
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("len(got) = %d, want 3", len(got))
+	}
+	if !hasMore {
+		t.Error("hasMore = false, want true (there are 10 open items but we only asked for 3)")
+	}
+}
+
+func TestFetchAllFiltered_SinglePageExactMatch_NoHasMore(t *testing.T) {
+	// When maxResults exactly matches the total number of filtered items on a
+	// single page and we finish scanning the last item, hasMore should be false.
+	allItems := []testItem{
+		{ID: 1, Status: "closed"},
+		{ID: 2, Status: "closed"},
+		{ID: 3, Status: "open"}, // match #1
+		{ID: 4, Status: "closed"},
+		{ID: 5, Status: "open"}, // match #2 — last item
+	}
+
+	ts := httptest.NewServer(paginatedHandler("things", allItems))
+	defer ts.Close()
+
+	got, hasMore, err := FetchAllFiltered[testItem](context.Background(), newTestClient(ts), "/things.json", nil, "things", 2, func(i testItem) bool {
+		return i.Status == "open"
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got) = %d, want 2", len(got))
+	}
+	// The last match was the last item on the only page, so no more.
+	if hasMore {
+		t.Error("hasMore = true, want false (all items scanned, all matches consumed)")
+	}
+}
+
 func TestFetchAll_MissingKey(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/project/list.go
+++ b/internal/cmd/project/list.go
@@ -34,6 +34,10 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
+			if cmdutil.HandleEmpty(printer, projects, "projects") {
+				return nil
+			}
+
 			headers := []string{"ID", "Identifier", "Name", "Status", "Public"}
 
 			switch printer.Format() {

--- a/internal/cmd/project/list_test.go
+++ b/internal/cmd/project/list_test.go
@@ -9,6 +9,50 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/testutil"
 )
 
+func TestCmdProjectList_EmptyTableWarning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"projects":[],"total_count":0}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdList(f)
+	cmd.SetArgs([]string{"--output", "table"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := testutil.Stderr(f)
+	if !strings.Contains(stderr, "No projects found") {
+		t.Fatalf("stderr = %q, want warning about no projects found", stderr)
+	}
+}
+
+func TestCmdProjectList_EmptyJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"projects":[],"total_count":0}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdList(f)
+	cmd.SetArgs([]string{"--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := testutil.Stdout(f); got != "[]\n" {
+		t.Fatalf("stdout = %q, want %q", got, "[]\n")
+	}
+	if got := testutil.Stderr(f); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
 func TestCmdProjectList_CSVConfigDoesNotEmitANSI(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/projects.json" {

--- a/internal/cmd/version/list.go
+++ b/internal/cmd/version/list.go
@@ -82,6 +82,7 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 
 			var versions []models.Version
 			var hasMore bool
+			var total int
 			if statusFilter != "" {
 				// Page through the API, collecting only matching versions
 				// until we have enough for offset + limit.
@@ -107,13 +108,12 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 					versions = nil
 				}
 			} else {
-				fetched, total, err := client.Versions.List(context.Background(), project, limit, offset)
+				var err error
+				versions, total, err = client.Versions.List(context.Background(), project, limit, offset)
 				stop()
 				if err != nil {
 					return fmt.Errorf("failed to list versions: %s", cmdutil.FormatError(err))
 				}
-				versions = fetched
-				hasMore = limit > 0 && total > limit+offset
 			}
 
 			if cmdutil.HandleEmpty(printer, versions, "versions") {
@@ -153,8 +153,15 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 				printer.Table(headers, rows)
 			}
 
-			if hasMore && output.SupportsWarnings(printer.Format()) {
-				printer.Warning("More versions available. Use --limit and --offset to paginate.")
+			if statusFilter != "" {
+				// Filtered path: we don't have a total count, just a hasMore hint.
+				if hasMore && output.SupportsWarnings(printer.Format()) {
+					printer.Warning("More versions available. Use --limit and --offset to paginate.")
+				}
+			} else {
+				cmdutil.WarnPagination(printer, cmdutil.PaginationResult{
+					Shown: len(versions), Total: total, Limit: limit, Offset: offset, Noun: "versions",
+				})
 			}
 
 			return nil

--- a/internal/cmd/version/version_test.go
+++ b/internal/cmd/version/version_test.go
@@ -149,7 +149,7 @@ func TestVersionList_UnfilteredPaginationWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 	stderr := testutil.Stderr(f)
-	if !strings.Contains(stderr, "More versions available") {
+	if !strings.Contains(stderr, "Showing 1 of 5 versions") {
 		t.Errorf("stderr = %q, want pagination warning", stderr)
 	}
 }


### PR DESCRIPTION
## Summary

Audited all 14 pageable elements in the CLI and found 3 issues. This PR fixes all three with accompanying tests.

### Fixes

1. **`FetchAllFiltered` `hasMore` under-reporting** (`internal/api/pagination.go`)
   - **Bug**: When `maxResults` was reached mid-page on a single-page or unpaginated endpoint (like the versions API), `hasMore` was always `false` — even if more matching items existed on the unscanned remainder of the page.
   - **Fix**: Now checks `i < len(items)-1` (unscanned items on current page) in addition to `offset+len(items) < totalCount` (more pages exist).

2. **Missing `HandleEmpty` in project list** (`internal/cmd/project/list.go`)
   - **Bug**: Unlike all other list commands, `project list` didn't call `HandleEmpty`, so empty results produced an empty table with just headers instead of a "No projects found" warning.
   - **Fix**: Added the `HandleEmpty` call consistent with every other list command.

3. **Inconsistent pagination warning in version list** (`internal/cmd/version/list.go`)
   - **Issue**: The unfiltered path used a custom warning message ("More versions available...") instead of the standard `WarnPagination` helper used everywhere else.
   - **Fix**: Unfiltered path now uses `WarnPagination` for the consistent "Showing N of M versions" format. The filtered path retains its custom message since no total count is available from `FetchAllFiltered`.

### Tests Added

- `TestFetchAllFiltered_UnpaginatedWithMaxResults_HasMore` — 50 items, 10 match, request 3 → verifies `hasMore=true`
- `TestFetchAllFiltered_SinglePageExactMatch_NoHasMore` — last match is last item → verifies no false positive (`hasMore=false`)
- `TestCmdProjectList_EmptyTableWarning` — verifies "No projects found" warning
- `TestCmdProjectList_EmptyJSON` — verifies `[]` JSON output for empty list
