### PR TITLE
Add EXTRA_LDFLAGS to reduce binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY_NAME=redmine
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS=-ldflags "-X main.version=$(VERSION)"
+LDFLAGS=-ldflags "-X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 
 .PHONY: build test lint clean install
 


### PR DESCRIPTION
## Summary
- Add `EXTRA_LDFLAGS` Makefile variable to allow passing additional linker flags, enabling smaller binary builds

## Test plan
- [x] Verify `make EXTRA_LDFLAGS="-s -w"` produces a smaller binary
- [x] Verify default `make` still works without EXTRA_LDFLAGS set