### PR TITLE
feat: multi-profile auth system

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Downloads and verifies the latest release via SHA256 checksum before replacing t
 
 ```bash
 # Configure your Redmine server and API key
-redmine init
+redmine auth login
 
 # List issues
 redmine issues list

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,6 +23,7 @@ export default defineConfig({
 				{
 					label: 'Commands',
 					items: [
+						{ label: 'Auth', slug: 'commands/auth' },
 						{ label: 'Issues', slug: 'commands/issues' },
 						{ label: 'Projects', slug: 'commands/projects' },
 						{ label: 'Time Entries', slug: 'commands/time' },

--- a/docs/src/content/docs/commands/auth.md
+++ b/docs/src/content/docs/commands/auth.md
@@ -1,0 +1,88 @@
+---
+title: Authentication
+description: Manage multiple Redmine authentication profiles.
+---
+
+The `auth` command manages authentication profiles for connecting to multiple Redmine instances.
+
+## login
+
+Start an interactive login wizard to authenticate with a Redmine server:
+
+```bash
+redmine auth login
+```
+
+If you work with multiple Redmine instances, run this command again to create additional profiles.
+
+| Flag | Description |
+|------|-------------|
+| `--name` | Profile name (default: derived from server hostname) |
+
+## list
+
+List all saved authentication profiles:
+
+```bash
+redmine auth list
+```
+
+Shows each profile's server URL and which one is currently active.
+
+## switch
+
+Switch the active authentication profile:
+
+```bash
+redmine auth switch
+```
+
+Opens an interactive selector to choose which profile to use. The selected profile becomes the default for all subsequent commands.
+
+## status
+
+Check the current authentication status:
+
+```bash
+redmine auth status
+```
+
+Displays the active profile name, server URL, and authentication method.
+
+## logout
+
+Remove an authentication profile:
+
+```bash
+redmine auth logout [profile-name]
+```
+
+If no profile name is given, removes the currently active profile. You'll be prompted to confirm before removal.
+
+## Quick Reference
+
+```bash
+# Login to a new instance
+redmine auth login
+
+# Login with a specific profile name
+redmine auth login --name work
+
+# List all profiles
+redmine auth list
+
+# Switch active profile
+redmine auth switch
+
+# Check current status
+redmine auth status
+
+# Logout (remove current profile)
+redmine auth logout
+
+# Logout a specific profile
+redmine auth logout work
+
+# Use a specific profile for one command
+redmine --profile work issues list
+```

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -5,28 +5,59 @@ description: Configuring redmine-cli to connect to your Redmine server.
 
 ## Interactive Setup
 
-The easiest way to configure redmine-cli is the interactive wizard:
+The easiest way to configure redmine-cli is the interactive login wizard:
 
 ```bash
-redmine init
+redmine auth login
 ```
 
-This walks you through setting your server URL, authentication method, and optionally selecting a default project. Configuration is saved to `~/.redmine-cli.yaml`.
+This walks you through setting your server URL, authentication method, and optionally selecting a default project. The profile is saved to `~/.redmine-cli.yaml`.
+
+## Multiple Profiles
+
+You can authenticate to multiple Redmine instances. Each login creates a named profile:
+
+```bash
+# Login to a second instance
+redmine auth login
+
+# List all profiles
+redmine auth list
+
+# Switch active profile
+redmine auth switch
+
+# Use a specific profile for one command
+redmine --profile work issues list
+
+# Check current auth status
+redmine auth status
+
+# Remove a profile
+redmine auth logout work
+```
 
 ## Configuration File
 
-The config file (`~/.redmine-cli.yaml`) supports the following settings:
+The config file (`~/.redmine-cli.yaml`) uses a profile-based format:
 
 ```yaml
-server: https://redmine.example.com
-auth_method: apikey        # "apikey" or "basic"
-api_key: your-api-key
-username: ""               # for basic auth
-password: ""               # for basic auth
-default_project: myproject # optional
-output_format: table       # table, wide, json, csv
-no_color: false
+active_profile: work
+profiles:
+  work:
+    server: https://redmine.work.com
+    auth_method: apikey
+    api_key: your-api-key
+    default_project: myproject
+    output_format: table
+  personal:
+    server: https://redmine.personal.com
+    auth_method: apikey
+    api_key: another-key
+    output_format: wide
 ```
+
+All settings are scoped per profile.
 
 ## Environment Variables
 
@@ -54,6 +85,7 @@ These flags can be used with any command to override config values:
 |------|------------|
 | `-s, --server` | Redmine server URL |
 | `-k, --api-key` | API key for authentication |
+| `-p, --profile` | Use a specific auth profile |
 | `--config` | Config file path (default `~/.redmine-cli.yaml`) |
 | `--no-color` | Disable colored output |
 | `-v, --verbose` | Enable debug logging |
@@ -64,4 +96,4 @@ These flags can be used with any command to override config values:
 redmine config
 ```
 
-Displays the active server, auth method, default project, and output format.
+Displays the active profile, server, auth method, default project, and output format.

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ description: Get up and running with redmine-cli in minutes.
 Configure your Redmine server connection:
 
 ```bash
-redmine init
+redmine auth login
 ```
 
 ## Common Tasks

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -27,6 +27,8 @@ Once installed, the agent will:
 - Handle pagination with `--limit` and `--offset`
 - Use name resolution (e.g. `--assignee "John Smith"` instead of `--assignee 42`)
 - Use the `me` shorthand for `--assignee me`
+- Use `redmine auth login` for initial setup and `redmine auth switch` to change servers
+- Use `redmine --profile <name>` to target a specific Redmine instance when multiple are configured
 
 ## Manual Setup
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -78,7 +78,7 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // NewClient creates a new Redmine API client from configuration.
 func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	if cfg.Server == "" {
-		return nil, fmt.Errorf("server URL not configured. Run 'redmine init' to set up")
+		return nil, fmt.Errorf("server URL not configured. Run 'redmine auth login' to set up")
 	}
 
 	baseURL := strings.TrimRight(cfg.Server, "/")

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+// NewCmdAuth creates the auth command group.
+func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage authentication profiles",
+		Long:  "Login, logout, and switch between Redmine server profiles.",
+	}
+
+	cmd.AddCommand(NewCmdLogin(f))
+	cmd.AddCommand(NewCmdLogout(f))
+	cmd.AddCommand(NewCmdList(f))
+	cmd.AddCommand(NewCmdSwitch(f))
+	cmd.AddCommand(NewCmdStatus(f))
+
+	return cmd
+}

--- a/internal/cmd/auth/list.go
+++ b/internal/cmd/auth/list.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/config"
+	"github.com/aarondpn/redmine-cli/internal/debug"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+// NewCmdList creates the auth list command.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List authentication profiles",
+		Long:  "Show all configured profiles with their server URLs.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(f)
+		},
+	}
+
+	return cmd
+}
+
+func runList(f *cmdutil.Factory) error {
+	configPath := config.DefaultConfigPath()
+	if f.ConfigPath != "" {
+		configPath = f.ConfigPath
+	}
+
+	pc, err := config.LoadProfiles(configPath, debug.New(nil))
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if len(pc.Profiles) == 0 {
+		printer := f.Printer("")
+		printer.Warning("No profiles configured. Run 'redmine auth login' to add one.")
+		return nil
+	}
+
+	// Sort profile names for stable output
+	names := make([]string, 0, len(pc.Profiles))
+	for name := range pc.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	printer := f.Printer("")
+
+	var kvs []output.KeyValue
+	for _, name := range names {
+		p := pc.Profiles[name]
+		marker := "  "
+		if name == pc.ActiveProfile {
+			marker = "* "
+		}
+		label := marker + name
+		kvs = append(kvs, output.KeyValue{Key: label, Value: p.Server})
+	}
+
+	printer.Detail(kvs)
+	return nil
+}

--- a/internal/cmd/auth/list.go
+++ b/internal/cmd/auth/list.go
@@ -39,7 +39,7 @@ func runList(f *cmdutil.Factory) error {
 
 	if len(pc.Profiles) == 0 {
 		printer := f.Printer("")
-		printer.Warning("No profiles configured. Run 'redmine auth login' to add one.")
+		printer.Warning(noProfilesConfiguredMessage)
 		return nil
 	}
 

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -1,9 +1,8 @@
-package initialize
+package auth
 
 import (
 	"context"
 	"fmt"
-	"os/exec"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
@@ -13,20 +12,25 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/config"
 )
 
-// NewCmdInit creates the init command for first-time setup.
-func NewCmdInit(f *cmdutil.Factory) *cobra.Command {
+// NewCmdLogin creates the auth login command.
+func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
+	var name string
+
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Set up Redmine CLI configuration",
-		Long:  "Interactive setup wizard to configure your Redmine server connection.",
+		Use:   "login",
+		Short: "Log in to a Redmine instance",
+		Long:  "Interactive setup to authenticate with a Redmine server and save the profile.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInit(f)
+			return runLogin(f, name)
 		},
 	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Profile name (default: derived from server hostname)")
+
 	return cmd
 }
 
-func runInit(f *cmdutil.Factory) error {
+func runLogin(f *cmdutil.Factory, profileName string) error {
 	var (
 		server     string
 		authMethod string
@@ -62,7 +66,32 @@ func runInit(f *cmdutil.Factory) error {
 		return err
 	}
 
-	// Step 2: Credentials
+	// Derive default profile name from server URL
+	defaultName := config.ProfileNameFromURL(server)
+	if defaultName == "" {
+		defaultName = "default"
+	}
+
+	// Step 2: Profile name (with default from hostname)
+	if profileName == "" {
+		err = huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Profile name").
+					Description("A short name for this connection").
+					Placeholder(defaultName).
+					Value(&profileName),
+			),
+		).Run()
+		if err != nil {
+			return err
+		}
+		if profileName == "" {
+			profileName = defaultName
+		}
+	}
+
+	// Step 3: Credentials
 	if authMethod == "apikey" {
 		err = huh.NewForm(
 			huh.NewGroup(
@@ -95,7 +124,7 @@ func runInit(f *cmdutil.Factory) error {
 		return err
 	}
 
-	// Step 3: Test connection
+	// Step 4: Test connection
 	cfg := &config.Config{
 		Server:     server,
 		AuthMethod: authMethod,
@@ -122,7 +151,7 @@ func runInit(f *cmdutil.Factory) error {
 
 	printer.Success(fmt.Sprintf("Connected as %s %s (%s)", user.FirstName, user.LastName, user.Login))
 
-	// Step 4: Default project (optional)
+	// Step 5: Default project (optional)
 	stop = printer.Spinner("Fetching projects...")
 	projects, _, err := client.Projects.List(context.Background(), nil, 100, 0)
 	stop()
@@ -149,42 +178,22 @@ func runInit(f *cmdutil.Factory) error {
 	cfg.DefaultProject = defProject
 	cfg.OutputFormat = "table"
 
-	// Step 5: Save config
+	// Step 6: Save profile
 	configPath := config.DefaultConfigPath()
 	if f.ConfigPath != "" {
 		configPath = f.ConfigPath
 	}
 
-	if err := config.Save(cfg, configPath); err != nil {
-		return fmt.Errorf("saving config: %w", err)
+	if err := config.SaveProfile(profileName, cfg, configPath); err != nil {
+		return fmt.Errorf("saving profile: %w", err)
 	}
 
-	printer.Success(fmt.Sprintf("Configuration saved to %s", configPath))
-
-	// Step 6: Offer agent skill installation
-	if _, err := exec.LookPath("npx"); err == nil {
-		var installSkill bool
-		_ = huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title("Install AI agent skill?").
-					Description("Installs a skill that teaches AI coding agents (Claude Code, Cursor, etc.) how to use redmine-cli effectively.").
-					Value(&installSkill),
-			),
-		).Run()
-
-		if installSkill {
-			stop := printer.Spinner("Installing agent skill...")
-			out, err := exec.Command("npx", "-y", "skills", "add", "aarondpn/redmine-cli", "--skill", "redmine-cli", "-g", "-y").CombinedOutput()
-			stop()
-			if err != nil {
-				printer.Warning(fmt.Sprintf("Could not install agent skill: %s\n%s", err, string(out)))
-				printer.Warning("You can install it manually: npx skills add aarondpn/redmine-cli --skill redmine-cli -g")
-			} else {
-				printer.Success("Agent skill installed globally. AI agents will now know how to use redmine-cli.")
-			}
-		}
+	// Set as active profile
+	if err := config.SetActiveProfile(profileName, configPath); err != nil {
+		return fmt.Errorf("setting active profile: %w", err)
 	}
+
+	printer.Success(fmt.Sprintf("Profile %q saved and activated (%s)", profileName, configPath))
 
 	return nil
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -170,7 +170,8 @@ func runLogin(f *cmdutil.Factory, profileName string) error {
 					Title("Default Project (optional)").
 					Description("Used when --project is not specified").
 					Options(options...).
-					Value(&defProject),
+					Value(&defProject).
+					Height(5),
 			),
 		).Run()
 	}

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/config"
+	"github.com/aarondpn/redmine-cli/internal/debug"
+)
+
+// NewCmdLogout creates the auth logout command.
+func NewCmdLogout(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logout [profile]",
+		Short: "Remove a profile",
+		Long:  "Remove the specified profile (or the active profile if none specified).",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogout(f, args)
+		},
+	}
+
+	return cmd
+}
+
+func runLogout(f *cmdutil.Factory, args []string) error {
+	configPath := config.DefaultConfigPath()
+	if f.ConfigPath != "" {
+		configPath = f.ConfigPath
+	}
+
+	pc, err := config.LoadProfiles(configPath, debug.New(nil))
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	var name string
+	if len(args) > 0 {
+		name = args[0]
+	} else {
+		name = pc.ActiveProfile
+	}
+
+	if name == "" {
+		return fmt.Errorf("no profile specified and no active profile set")
+	}
+
+	if _, ok := pc.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found", name)
+	}
+
+	// Confirm deletion
+	var confirm bool
+	err = huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("Remove profile %q (%s)?", name, pc.Profiles[name].Server)).
+				Value(&confirm),
+		),
+	).Run()
+	if err != nil {
+		return err
+	}
+
+	if !confirm {
+		return nil
+	}
+
+	printer := f.Printer("")
+
+	if err := config.DeleteProfile(name, configPath); err != nil {
+		return fmt.Errorf("removing profile: %w", err)
+	}
+
+	printer.Success(fmt.Sprintf("Profile %q removed", name))
+	return nil
+}

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/charmbracelet/huh"
@@ -37,19 +38,18 @@ func runLogout(f *cmdutil.Factory, args []string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	var name string
-	if len(args) > 0 {
-		name = args[0]
-	} else {
-		name = pc.ActiveProfile
-	}
-
-	if name == "" {
-		return fmt.Errorf("no profile specified and no active profile set")
+	name, err := resolveLogoutProfileName(pc, args, f.ProfileOverride)
+	if err != nil {
+		if err.Error() == noProfilesConfiguredMessage {
+			printer := f.Printer("")
+			printer.Warning(noProfilesConfiguredMessage)
+			return nil
+		}
+		return err
 	}
 
 	if _, ok := pc.Profiles[name]; !ok {
-		return fmt.Errorf("profile %q not found", name)
+		return profileNotFoundError(name)
 	}
 
 	// Confirm deletion
@@ -77,4 +77,20 @@ func runLogout(f *cmdutil.Factory, args []string) error {
 
 	printer.Success(fmt.Sprintf("Profile %q removed", name))
 	return nil
+}
+
+func resolveLogoutProfileName(pc *config.ProfileConfig, args []string, override string) (string, error) {
+	if len(args) > 0 {
+		return args[0], nil
+	}
+
+	name := config.EffectiveProfileName(pc, override)
+	if name == "" {
+		if pc != nil && len(pc.Profiles) == 0 {
+			return "", errors.New(noProfilesConfiguredMessage)
+		}
+		return "", errors.New(noActiveProfileMessage)
+	}
+
+	return name, nil
 }

--- a/internal/cmd/auth/logout_test.go
+++ b/internal/cmd/auth/logout_test.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/config"
+)
+
+func TestResolveLogoutProfileName_HonorsProfileOverride(t *testing.T) {
+	pc := &config.ProfileConfig{
+		ActiveProfile: "work",
+		Profiles: map[string]config.Config{
+			"work":     {Server: "https://work.example.com"},
+			"personal": {Server: "https://personal.example.com"},
+		},
+	}
+
+	got, err := resolveLogoutProfileName(pc, nil, "personal")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "personal" {
+		t.Fatalf("resolveLogoutProfileName() = %q, want %q", got, "personal")
+	}
+}
+
+func TestResolveLogoutProfileName_ArgsTakePrecedence(t *testing.T) {
+	pc := &config.ProfileConfig{
+		ActiveProfile: "work",
+		Profiles: map[string]config.Config{
+			"work":     {Server: "https://work.example.com"},
+			"personal": {Server: "https://personal.example.com"},
+		},
+	}
+
+	got, err := resolveLogoutProfileName(pc, []string{"explicit"}, "personal")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "explicit" {
+		t.Fatalf("resolveLogoutProfileName() = %q, want %q", got, "explicit")
+	}
+}
+
+func TestResolveLogoutProfileName_NoProfilesConfigured(t *testing.T) {
+	pc := &config.ProfileConfig{Profiles: map[string]config.Config{}}
+
+	_, err := resolveLogoutProfileName(pc, nil, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != noProfilesConfiguredMessage {
+		t.Fatalf("error = %q, want %q", got, noProfilesConfiguredMessage)
+	}
+}
+
+func TestResolveLogoutProfileName_NoActiveProfile(t *testing.T) {
+	pc := &config.ProfileConfig{
+		Profiles: map[string]config.Config{
+			"work":     {Server: "https://work.example.com"},
+			"personal": {Server: "https://personal.example.com"},
+		},
+	}
+
+	_, err := resolveLogoutProfileName(pc, nil, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != noActiveProfileMessage {
+		t.Fatalf("error = %q, want %q", got, noActiveProfileMessage)
+	}
+}
+
+func TestLogout_NoProfilesConfiguredWarns(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("profiles: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdLogout(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error for empty profiles, got: %v", err)
+	}
+
+	output := f.IOStreams.ErrOut.(*strings.Builder).String()
+	if !strings.Contains(output, noProfilesConfiguredMessage) {
+		t.Fatalf("expected warning %q, got:\n%s", noProfilesConfiguredMessage, output)
+	}
+}

--- a/internal/cmd/auth/messages.go
+++ b/internal/cmd/auth/messages.go
@@ -1,0 +1,12 @@
+package auth
+
+import "fmt"
+
+const (
+	noProfilesConfiguredMessage = "No profiles configured. Run 'redmine auth login' to add one."
+	noActiveProfileMessage      = "No active profile selected. Run 'redmine auth switch' to select one."
+)
+
+func profileNotFoundError(name string) error {
+	return fmt.Errorf("profile %q not found. Run 'redmine auth list' to see available profiles", name)
+}

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -45,6 +45,13 @@ func runStatus(f *cmdutil.Factory) error {
 		profileName = pc.ActiveProfile
 	}
 
+	// Fall back to sole profile if no active profile set (matching Load behavior)
+	if profileName == "" && len(pc.Profiles) == 1 {
+		for profileName = range pc.Profiles {
+			// take the only key
+		}
+	}
+
 	if len(pc.Profiles) == 0 || profileName == "" {
 		printer.Warning("No active profile. Run 'redmine auth login' to set up.")
 		return nil

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -39,18 +39,24 @@ func runStatus(f *cmdutil.Factory) error {
 
 	printer := f.Printer("")
 
-	if len(pc.Profiles) == 0 || pc.ActiveProfile == "" {
+	// Honor --profile override, falling back to active profile
+	profileName := f.ProfileOverride
+	if profileName == "" {
+		profileName = pc.ActiveProfile
+	}
+
+	if len(pc.Profiles) == 0 || profileName == "" {
 		printer.Warning("No active profile. Run 'redmine auth login' to set up.")
 		return nil
 	}
 
-	profile, ok := pc.Profiles[pc.ActiveProfile]
+	profile, ok := pc.Profiles[profileName]
 	if !ok {
-		return fmt.Errorf("active profile %q not found in config", pc.ActiveProfile)
+		return fmt.Errorf("profile %q not found in config", profileName)
 	}
 
 	kvs := []output.KeyValue{
-		{Key: "Profile", Value: pc.ActiveProfile},
+		{Key: "Profile", Value: profileName},
 		{Key: "Server", Value: profile.Server},
 		{Key: "Auth Method", Value: profile.AuthMethod},
 	}

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -32,6 +32,16 @@ func runStatus(f *cmdutil.Factory) error {
 		configPath = f.ConfigPath
 	}
 
+	cfg, err := f.Config()
+	if err != nil {
+		if config.IsNoActiveProfileError(err) {
+			printer := f.Printer("")
+			printer.Warning(noActiveProfileMessage)
+			return nil
+		}
+		return err
+	}
+
 	pc, err := config.LoadProfiles(configPath, debug.New(nil))
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -40,21 +50,25 @@ func runStatus(f *cmdutil.Factory) error {
 	printer := f.Printer("")
 
 	profileName := config.EffectiveProfileName(pc, f.ProfileOverride)
-
-	if len(pc.Profiles) == 0 || profileName == "" {
-		printer.Warning("No active profile. Run 'redmine auth login' to set up.")
+	if profileName == "" && cfg.Server == "" {
+		if len(pc.Profiles) == 0 {
+			printer.Warning(noProfilesConfiguredMessage)
+		} else {
+			printer.Warning(noActiveProfileMessage)
+		}
 		return nil
 	}
 
-	profile, ok := pc.Profiles[profileName]
-	if !ok {
-		return fmt.Errorf("profile %q not found in config", profileName)
+	if profileName == "" {
+		profileName = "(override)"
+	} else if _, ok := pc.Profiles[profileName]; !ok {
+		return profileNotFoundError(profileName)
 	}
 
 	kvs := []output.KeyValue{
 		{Key: "Profile", Value: profileName},
-		{Key: "Server", Value: profile.Server},
-		{Key: "Auth Method", Value: profile.AuthMethod},
+		{Key: "Server", Value: cfg.Server},
+		{Key: "Auth Method", Value: cfg.AuthMethod},
 	}
 
 	// Try to fetch current user
@@ -68,8 +82,8 @@ func runStatus(f *cmdutil.Factory) error {
 		}
 	}
 
-	if profile.DefaultProject != "" {
-		kvs = append(kvs, output.KeyValue{Key: "Default Project", Value: profile.DefaultProject})
+	if cfg.DefaultProject != "" {
+		kvs = append(kvs, output.KeyValue{Key: "Default Project", Value: cfg.DefaultProject})
 	}
 
 	printer.Detail(kvs)

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -39,18 +39,7 @@ func runStatus(f *cmdutil.Factory) error {
 
 	printer := f.Printer("")
 
-	// Honor --profile override, falling back to active profile
-	profileName := f.ProfileOverride
-	if profileName == "" {
-		profileName = pc.ActiveProfile
-	}
-
-	// Fall back to sole profile if no active profile set (matching Load behavior)
-	if profileName == "" && len(pc.Profiles) == 1 {
-		for profileName = range pc.Profiles {
-			// take the only key
-		}
-	}
+	profileName := config.EffectiveProfileName(pc, f.ProfileOverride)
 
 	if len(pc.Profiles) == 0 || profileName == "" {
 		printer.Warning("No active profile. Run 'redmine auth login' to set up.")

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/config"
+	"github.com/aarondpn/redmine-cli/internal/debug"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+// NewCmdStatus creates the auth status command.
+func NewCmdStatus(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show current authentication status",
+		Long:  "Display the active profile, server, and authenticated user.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(f)
+		},
+	}
+
+	return cmd
+}
+
+func runStatus(f *cmdutil.Factory) error {
+	configPath := config.DefaultConfigPath()
+	if f.ConfigPath != "" {
+		configPath = f.ConfigPath
+	}
+
+	pc, err := config.LoadProfiles(configPath, debug.New(nil))
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	printer := f.Printer("")
+
+	if len(pc.Profiles) == 0 || pc.ActiveProfile == "" {
+		printer.Warning("No active profile. Run 'redmine auth login' to set up.")
+		return nil
+	}
+
+	profile, ok := pc.Profiles[pc.ActiveProfile]
+	if !ok {
+		return fmt.Errorf("active profile %q not found in config", pc.ActiveProfile)
+	}
+
+	kvs := []output.KeyValue{
+		{Key: "Profile", Value: pc.ActiveProfile},
+		{Key: "Server", Value: profile.Server},
+		{Key: "Auth Method", Value: profile.AuthMethod},
+	}
+
+	// Try to fetch current user
+	client, err := f.ApiClient()
+	if err == nil {
+		user, err := client.Users.Current(context.Background())
+		if err == nil {
+			kvs = append(kvs, output.KeyValue{Key: "User", Value: fmt.Sprintf("%s %s (%s)", user.FirstName, user.LastName, user.Login)})
+		} else {
+			kvs = append(kvs, output.KeyValue{Key: "User", Value: "authentication failed"})
+		}
+	}
+
+	if profile.DefaultProject != "" {
+		kvs = append(kvs, output.KeyValue{Key: "Default Project", Value: profile.DefaultProject})
+	}
+
+	printer.Detail(kvs)
+	return nil
+}

--- a/internal/cmd/auth/status_test.go
+++ b/internal/cmd/auth/status_test.go
@@ -1,0 +1,154 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+func TestStatus_HonorsProfileOverride(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: work
+profiles:
+  work:
+    server: https://work.example.com
+    auth_method: apikey
+    api_key: work-key
+  personal:
+    server: https://personal.example.com
+    auth_method: apikey
+    api_key: personal-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath:      cfgPath,
+		ProfileOverride: "personal",
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := f.IOStreams.Out.(*strings.Builder).String()
+	// Should show personal profile's server, not work's
+	if !strings.Contains(output, "https://personal.example.com") {
+		t.Errorf("output should contain personal server URL, got:\n%s", output)
+	}
+	if strings.Contains(output, "https://work.example.com") {
+		t.Errorf("output should NOT contain work server URL, got:\n%s", output)
+	}
+	// Should show "personal" as the profile name
+	if !strings.Contains(output, "personal") {
+		t.Errorf("output should contain 'personal' profile name, got:\n%s", output)
+	}
+}
+
+func TestStatus_NoActiveProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	// Empty profiles config (new format, no profiles defined)
+	if err := os.WriteFile(cfgPath, []byte("profiles: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error for empty profiles, got: %v", err)
+	}
+
+	output := f.IOStreams.ErrOut.(*strings.Builder).String()
+	if !strings.Contains(output, "No active profile") {
+		t.Errorf("expected 'No active profile' warning in stderr, got:\n%s", output)
+	}
+}
+
+func TestStatus_NonExistentConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	// Should not error, should show "no active profile" warning
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error for nonexistent config, got: %v", err)
+	}
+
+	output := f.IOStreams.ErrOut.(*strings.Builder).String()
+	if !strings.Contains(output, "No active profile") {
+		t.Errorf("expected 'No active profile' warning in stderr, got:\n%s", output)
+	}
+}
+
+func TestStatus_ProfileOverrideWithNonexistentProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: work
+profiles:
+  work:
+    server: https://work.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath:      cfgPath,
+		ProfileOverride: "nonexistent",
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}

--- a/internal/cmd/auth/status_test.go
+++ b/internal/cmd/auth/status_test.go
@@ -85,8 +85,8 @@ func TestStatus_NoActiveProfile(t *testing.T) {
 	}
 
 	output := f.IOStreams.ErrOut.(*strings.Builder).String()
-	if !strings.Contains(output, "No active profile") {
-		t.Errorf("expected 'No active profile' warning in stderr, got:\n%s", output)
+	if !strings.Contains(output, noProfilesConfiguredMessage) {
+		t.Errorf("expected %q warning in stderr, got:\n%s", noProfilesConfiguredMessage, output)
 	}
 }
 
@@ -113,8 +113,8 @@ func TestStatus_NonExistentConfig(t *testing.T) {
 	}
 
 	output := f.IOStreams.ErrOut.(*strings.Builder).String()
-	if !strings.Contains(output, "No active profile") {
-		t.Errorf("expected 'No active profile' warning in stderr, got:\n%s", output)
+	if !strings.Contains(output, noProfilesConfiguredMessage) {
+		t.Errorf("expected %q warning in stderr, got:\n%s", noProfilesConfiguredMessage, output)
 	}
 }
 
@@ -148,8 +148,8 @@ profiles:
 	if err == nil {
 		t.Fatal("expected error for nonexistent profile")
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("expected 'not found' in error, got: %v", err)
+	if got := err.Error(); got != profileNotFoundError("nonexistent").Error() {
+		t.Errorf("expected %q, got %q", profileNotFoundError("nonexistent").Error(), got)
 	}
 }
 
@@ -192,5 +192,98 @@ func TestStatus_FallsBackToSoleProfile(t *testing.T) {
 	// Should show the profile name
 	if !strings.Contains(output, "only") {
 		t.Errorf("output should contain profile name 'only', got:\n%s", output)
+	}
+}
+
+func TestStatus_UsesCLIOverridesWithoutActiveProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `profiles:
+  work:
+    server: https://work.example.com
+    auth_method: apikey
+    api_key: work-key
+  personal:
+    server: https://personal.example.com
+    auth_method: apikey
+    api_key: personal-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath:     cfgPath,
+		ServerOverride: "http://127.0.0.1:1",
+		APIKeyOverride: "override-key",
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := f.IOStreams.Out.(*strings.Builder).String()
+	if !strings.Contains(output, "http://127.0.0.1:1") {
+		t.Errorf("output should contain overridden server URL, got:\n%s", output)
+	}
+	if !strings.Contains(output, "(override)") {
+		t.Errorf("output should identify override-based config, got:\n%s", output)
+	}
+
+	errOutput := f.IOStreams.ErrOut.(*strings.Builder).String()
+	if strings.Contains(errOutput, noActiveProfileMessage) {
+		t.Errorf("status should not warn about missing active profile when CLI overrides are provided, got:\n%s", errOutput)
+	}
+}
+
+func TestStatus_ShowsEffectiveServerAfterEnvOverride(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: work
+profiles:
+  work:
+    server: https://work.example.com
+    auth_method: apikey
+    api_key: work-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("REDMINE_SERVER", "http://127.0.0.1:1")
+	t.Setenv("REDMINE_API_KEY", "env-key")
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := f.IOStreams.Out.(*strings.Builder).String()
+	if !strings.Contains(output, "http://127.0.0.1:1") {
+		t.Errorf("output should contain env-overridden server URL, got:\n%s", output)
+	}
+	if strings.Contains(output, "https://work.example.com") {
+		t.Errorf("output should not contain stored profile server after env override, got:\n%s", output)
 	}
 }

--- a/internal/cmd/auth/status_test.go
+++ b/internal/cmd/auth/status_test.go
@@ -152,3 +152,45 @@ profiles:
 		t.Errorf("expected 'not found' in error, got: %v", err)
 	}
 }
+
+func TestStatus_FallsBackToSoleProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	// Single profile but no active_profile set
+	content := `profiles:
+  only:
+    server: https://only.example.com
+    auth_method: apikey
+    api_key: only-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdStatus(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := f.IOStreams.Out.(*strings.Builder).String()
+	// Should show the sole profile's server
+	if !strings.Contains(output, "https://only.example.com") {
+		t.Errorf("output should contain sole profile's server URL, got:\n%s", output)
+	}
+	// Should show the profile name
+	if !strings.Contains(output, "only") {
+		t.Errorf("output should contain profile name 'only', got:\n%s", output)
+	}
+}

--- a/internal/cmd/auth/switch.go
+++ b/internal/cmd/auth/switch.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/config"
+	"github.com/aarondpn/redmine-cli/internal/debug"
+)
+
+// NewCmdSwitch creates the auth switch command.
+func NewCmdSwitch(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "switch [profile]",
+		Short: "Switch the active profile",
+		Long:  "Set which profile to use by default. Shows an interactive selector if no name given.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSwitch(f, args)
+		},
+	}
+
+	return cmd
+}
+
+func runSwitch(f *cmdutil.Factory, args []string) error {
+	configPath := config.DefaultConfigPath()
+	if f.ConfigPath != "" {
+		configPath = f.ConfigPath
+	}
+
+	pc, err := config.LoadProfiles(configPath, debug.New(nil))
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if len(pc.Profiles) == 0 {
+		return fmt.Errorf("no profiles configured. Run 'redmine auth login' to add one")
+	}
+
+	var name string
+	if len(args) > 0 {
+		name = args[0]
+	} else {
+		// Interactive selection
+		names := make([]string, 0, len(pc.Profiles))
+		for n := range pc.Profiles {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+
+		options := make([]huh.Option[string], 0, len(names))
+		for _, n := range names {
+			label := n
+			if n == pc.ActiveProfile {
+				label += " (active)"
+			}
+			p := pc.Profiles[n]
+			label += " — " + p.Server
+			options = append(options, huh.NewOption(label, n))
+		}
+
+		err = huh.NewForm(
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Select profile").
+					Options(options...).
+					Value(&name),
+			),
+		).Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := config.SetActiveProfile(name, configPath); err != nil {
+		return err
+	}
+
+	printer := f.Printer("")
+	printer.Success(fmt.Sprintf("Switched to profile %q (%s)", name, pc.Profiles[name].Server))
+	return nil
+}

--- a/internal/cmd/auth/switch.go
+++ b/internal/cmd/auth/switch.go
@@ -71,7 +71,8 @@ func runSwitch(f *cmdutil.Factory, args []string) error {
 				huh.NewSelect[string]().
 					Title("Select profile").
 					Options(options...).
-					Value(&name),
+					Value(&name).
+					Height(5),
 			),
 		).Run()
 		if err != nil {

--- a/internal/cmd/auth/switch.go
+++ b/internal/cmd/auth/switch.go
@@ -39,7 +39,9 @@ func runSwitch(f *cmdutil.Factory, args []string) error {
 	}
 
 	if len(pc.Profiles) == 0 {
-		return fmt.Errorf("no profiles configured. Run 'redmine auth login' to add one")
+		printer := f.Printer("")
+		printer.Warning(noProfilesConfiguredMessage)
+		return nil
 	}
 
 	var name string

--- a/internal/cmd/auth/switch_test.go
+++ b/internal/cmd/auth/switch_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+func TestSwitch_NoProfilesConfiguredWarns(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("profiles: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := NewCmdSwitch(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected no error for empty profiles, got: %v", err)
+	}
+
+	output := f.IOStreams.ErrOut.(*strings.Builder).String()
+	if !strings.Contains(output, noProfilesConfiguredMessage) {
+		t.Fatalf("expected warning %q, got:\n%s", noProfilesConfiguredMessage, output)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -103,16 +103,13 @@ func newCmdConfig(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			// Determine active profile name
 			profileName := f.ProfileOverride
-			if profileName == "" {
-				configPath := f.ConfigPath
-				if configPath == "" {
-					configPath = config.DefaultConfigPath()
-				}
-				if pc, err := config.LoadProfiles(configPath, debug.New(nil)); err == nil {
-					profileName = pc.ActiveProfile
-				}
+			configPath := f.ConfigPath
+			if configPath == "" {
+				configPath = config.DefaultConfigPath()
+			}
+			if pc, err := config.LoadProfiles(configPath, debug.New(nil)); err == nil {
+				profileName = config.EffectiveProfileName(pc, f.ProfileOverride)
 			}
 
 			printer := f.Printer("")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,10 +6,10 @@ import (
 	"github.com/spf13/cobra"
 
 	apicmd "github.com/aarondpn/redmine-cli/internal/cmd/api"
+	"github.com/aarondpn/redmine-cli/internal/cmd/auth"
 	"github.com/aarondpn/redmine-cli/internal/cmd/category"
 	"github.com/aarondpn/redmine-cli/internal/cmd/completion"
 	"github.com/aarondpn/redmine-cli/internal/cmd/group"
-	initcmd "github.com/aarondpn/redmine-cli/internal/cmd/initialize"
 	"github.com/aarondpn/redmine-cli/internal/cmd/installskill"
 	"github.com/aarondpn/redmine-cli/internal/cmd/issue"
 	"github.com/aarondpn/redmine-cli/internal/cmd/membership"
@@ -22,6 +22,8 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/cmd/user"
 	versioncmd "github.com/aarondpn/redmine-cli/internal/cmd/version"
 	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/config"
+	"github.com/aarondpn/redmine-cli/internal/debug"
 	"github.com/aarondpn/redmine-cli/internal/output"
 )
 
@@ -32,6 +34,7 @@ func NewRootCmd(version string) *cobra.Command {
 	var (
 		server  string
 		apiKey  string
+		profile string
 		noColor bool
 		verbose bool
 		cfgFile string
@@ -43,6 +46,7 @@ func NewRootCmd(version string) *cobra.Command {
 		Long:  "A command-line interface for interacting with Redmine's REST API.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			f.ConfigPath = cfgFile
+			f.ProfileOverride = profile
 			f.ServerOverride = server
 			f.APIKeyOverride = apiKey
 			if noColor {
@@ -59,6 +63,7 @@ func NewRootCmd(version string) *cobra.Command {
 	// Global flags
 	cmd.PersistentFlags().StringVarP(&server, "server", "s", "", "Redmine server URL")
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "k", "", "API key for authentication")
+	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "", "Use a specific auth profile")
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logging")
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default ~/.redmine-cli.yaml)")
@@ -68,7 +73,7 @@ func NewRootCmd(version string) *cobra.Command {
 
 	// Subcommands
 	cmd.AddCommand(apicmd.NewCmdAPI(f))
-	cmd.AddCommand(initcmd.NewCmdInit(f))
+	cmd.AddCommand(auth.NewCmdAuth(f))
 	cmd.AddCommand(issue.NewCmdIssue(f))
 	cmd.AddCommand(group.NewCmdGroup(f))
 	cmd.AddCommand(membership.NewCmdMemberships(f))
@@ -97,8 +102,22 @@ func newCmdConfig(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Determine active profile name
+			profileName := f.ProfileOverride
+			if profileName == "" {
+				configPath := f.ConfigPath
+				if configPath == "" {
+					configPath = config.DefaultConfigPath()
+				}
+				if pc, err := config.LoadProfiles(configPath, debug.New(nil)); err == nil {
+					profileName = pc.ActiveProfile
+				}
+			}
+
 			printer := f.Printer("")
 			printer.Detail([]output.KeyValue{
+				{Key: "Profile", Value: profileName},
 				{Key: "Server", Value: cfg.Server},
 				{Key: "Auth Method", Value: cfg.AuthMethod},
 				{Key: "Default Project", Value: cfg.DefaultProject},

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -47,4 +47,3 @@ func TestConfigCommandShowsSoleProfileName(t *testing.T) {
 		t.Errorf("expected config output to contain the sole profile server, got:\n%s", output)
 	}
 }
-

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+func TestConfigCommandShowsSoleProfileName(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `profiles:
+  only:
+    server: https://only.example.com
+    auth_method: apikey
+    api_key: only-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &cmdutil.Factory{
+		ConfigPath: cfgPath,
+		IOStreams: &cmdutil.IOStreams{
+			In:     strings.NewReader(""),
+			Out:    &strings.Builder{},
+			ErrOut: &strings.Builder{},
+			IsTTY:  false,
+		},
+	}
+
+	cmd := newCmdConfig(f)
+	cmd.SetOut(f.IOStreams.Out)
+	cmd.SetErr(f.IOStreams.ErrOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := f.IOStreams.Out.(*strings.Builder).String()
+	if !strings.Contains(output, "only") {
+		t.Errorf("expected config output to contain the sole profile name, got:\n%s", output)
+	}
+	if !strings.Contains(output, "https://only.example.com") {
+		t.Errorf("expected config output to contain the sole profile server, got:\n%s", output)
+	}
+}
+

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -22,7 +22,7 @@ func FormatError(err error) string {
 
 	switch {
 	case apiErr.IsAuthError():
-		return "Authentication failed. Run 'redmine init' to reconfigure your credentials."
+		return "Authentication failed. Run 'redmine auth login' to reconfigure your credentials."
 	case apiErr.IsForbidden():
 		return "Permission denied: you don't have the required permissions for this action. Check your Redmine role permissions or contact your administrator."
 	case apiErr.IsNotFound():

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -70,7 +70,12 @@ func (f *Factory) Config() (*config.Config, error) {
 	if f.config != nil {
 		return f.config, nil
 	}
-	cfg, err := config.Load(f.ConfigPath, f.ProfileOverride, f.DebugLogger())
+	loadFn := config.Load
+	if f.ServerOverride != "" || f.APIKeyOverride != "" {
+		loadFn = config.LoadAllowNoActiveProfile
+	}
+
+	cfg, err := loadFn(f.ConfigPath, f.ProfileOverride, f.DebugLogger())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -25,6 +25,7 @@ type Factory struct {
 	Verbose    bool
 
 	// Runtime overrides from CLI flags (highest precedence).
+	ProfileOverride string
 	ServerOverride  string
 	APIKeyOverride  string
 	NoColorOverride bool
@@ -69,7 +70,7 @@ func (f *Factory) Config() (*config.Config, error) {
 	if f.config != nil {
 		return f.config, nil
 	}
-	cfg, err := config.Load(f.ConfigPath, f.DebugLogger())
+	cfg, err := config.Load(f.ConfigPath, f.ProfileOverride, f.DebugLogger())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ func Load(configPath string, profileName string, log *debug.Logger) (*Config, er
 
 // LoadProfiles reads the full profile configuration from disk.
 // It handles both legacy flat format and new profile format.
+// If the config file does not exist, it returns an empty ProfileConfig.
 func LoadProfiles(configPath string, log *debug.Logger) (*ProfileConfig, error) {
 	if configPath == "" {
 		configPath = DefaultConfigPath()
@@ -87,6 +88,9 @@ func LoadProfiles(configPath string, log *debug.Logger) (*ProfileConfig, error) 
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return &ProfileConfig{Profiles: make(map[string]Config)}, nil
+		}
 		return nil, err
 	}
 
@@ -210,10 +214,19 @@ func DeleteProfile(name string, path string) error {
 
 	if pc.ActiveProfile == name {
 		pc.ActiveProfile = ""
-		// If there's exactly one profile left, make it active
-		for remaining := range pc.Profiles {
-			pc.ActiveProfile = remaining
+		// Only set active profile when exactly one remains
+		if len(pc.Profiles) == 1 {
+			for remaining := range pc.Profiles {
+				pc.ActiveProfile = remaining
+			}
 		}
+	}
+
+	// If no profiles remain, remove the config file entirely
+	// to avoid serializing an empty config that would be
+	// misinterpreted as legacy format on next load.
+	if len(pc.Profiles) == 0 {
+		return os.Remove(path)
 	}
 
 	return SaveProfiles(pc, path)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,6 +12,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var errNoActiveProfile = errors.New("multiple profiles exist but no active profile set")
+
 func DefaultConfigPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".redmine-cli.yaml")
@@ -20,6 +23,16 @@ func DefaultConfigPath() string {
 // If profileName is non-empty, that profile is used instead of the active one.
 // Environment variables (REDMINE_*) override file values.
 func Load(configPath string, profileName string, log *debug.Logger) (*Config, error) {
+	return load(configPath, profileName, false, log)
+}
+
+// LoadAllowNoActiveProfile reads configuration while allowing the caller to
+// recover with explicit CLI credentials when no active profile is selected.
+func LoadAllowNoActiveProfile(configPath string, profileName string, log *debug.Logger) (*Config, error) {
+	return load(configPath, profileName, true, log)
+}
+
+func load(configPath string, profileName string, allowNoActiveProfile bool, log *debug.Logger) (*Config, error) {
 	if configPath == "" {
 		configPath = DefaultConfigPath()
 	}
@@ -62,14 +75,15 @@ func Load(configPath string, profileName string, log *debug.Logger) (*Config, er
 	} else if len(pc.Profiles) == 0 {
 		log.Printf("Config: no profiles configured")
 	} else {
-		// No active profile with multiple profiles exist.
-		// Apply env overrides first - if REDMINE_SERVER is set, the user
-		// is explicitly providing credentials and wants to bypass profile selection.
+		// Apply env overrides first so explicit environment credentials can bypass
+		// profile selection when requested.
 		applyEnvOverrides(&cfg, log)
-		if cfg.Server == "" {
-			return nil, fmt.Errorf("multiple profiles exist but no active profile set. Run 'redmine auth switch' to select one")
+		if cfg.Server == "" && !allowNoActiveProfile {
+			return nil, fmt.Errorf("%w. Run 'redmine auth switch' to select one", errNoActiveProfile)
 		}
-		log.Printf("Config: using env overrides, no active profile")
+		if cfg.Server != "" || allowNoActiveProfile {
+			log.Printf("Config: proceeding without active profile selection")
+		}
 	}
 
 	// Apply env overrides (may have been applied above, idempotent)
@@ -84,6 +98,31 @@ func Load(configPath string, profileName string, log *debug.Logger) (*Config, er
 	}
 
 	return &cfg, nil
+}
+
+// IsNoActiveProfileError reports whether err is the missing-active-profile error.
+func IsNoActiveProfileError(err error) bool {
+	return errors.Is(err, errNoActiveProfile)
+}
+
+// EffectiveProfileName resolves which profile name should be displayed or used
+// for commands that mirror Load's profile selection behavior.
+func EffectiveProfileName(pc *ProfileConfig, override string) string {
+	if override != "" {
+		return override
+	}
+	if pc == nil {
+		return ""
+	}
+	if pc.ActiveProfile != "" {
+		return pc.ActiveProfile
+	}
+	if len(pc.Profiles) == 1 {
+		for name := range pc.Profiles {
+			return name
+		}
+	}
+	return ""
 }
 
 // LoadProfiles reads the full profile configuration from disk.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,8 +62,18 @@ func Load(configPath string, profileName string, log *debug.Logger) (*Config, er
 	} else if len(pc.Profiles) == 0 {
 		log.Printf("Config: no profiles configured")
 	} else {
-		return nil, fmt.Errorf("multiple profiles exist but no active profile set. Run 'redmine auth switch' to select one")
+		// No active profile with multiple profiles exist.
+		// Apply env overrides first - if REDMINE_SERVER is set, the user
+		// is explicitly providing credentials and wants to bypass profile selection.
+		applyEnvOverrides(&cfg, log)
+		if cfg.Server == "" {
+			return nil, fmt.Errorf("multiple profiles exist but no active profile set. Run 'redmine auth switch' to select one")
+		}
+		log.Printf("Config: using env overrides, no active profile")
 	}
+
+	// Apply env overrides (may have been applied above, idempotent)
+	applyEnvOverrides(&cfg, log)
 
 	// Apply defaults
 	if cfg.AuthMethod == "" {
@@ -72,8 +82,6 @@ func Load(configPath string, profileName string, log *debug.Logger) (*Config, er
 	if cfg.OutputFormat == "" {
 		cfg.OutputFormat = "table"
 	}
-
-	applyEnvOverrides(&cfg, log)
 
 	return &cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aarondpn/redmine-cli/internal/debug"
-	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 func DefaultConfigPath() string {
@@ -14,76 +16,267 @@ func DefaultConfigPath() string {
 	return filepath.Join(home, ".redmine-cli.yaml")
 }
 
-// Load reads configuration from file, environment variables, and defaults.
-func Load(configPath string, log *debug.Logger) (*Config, error) {
-	v := viper.New()
-
-	// Defaults
-	v.SetDefault("auth_method", "apikey")
-	v.SetDefault("output_format", "table")
-
-	// Config file
-	if configPath != "" {
-		v.SetConfigFile(configPath)
-		log.Printf("Config: using explicit path %s", configPath)
-	} else {
-		v.SetConfigName(".redmine-cli")
-		v.SetConfigType("yaml")
-		home, err := os.UserHomeDir()
-		if err == nil {
-			v.AddConfigPath(home)
-		}
-		v.AddConfigPath(".")
+// Load reads configuration and returns the active profile's Config.
+// If profileName is non-empty, that profile is used instead of the active one.
+// Environment variables (REDMINE_*) override file values.
+func Load(configPath string, profileName string, log *debug.Logger) (*Config, error) {
+	if configPath == "" {
+		configPath = DefaultConfigPath()
 	}
 
-	// Environment variables
-	v.SetEnvPrefix("REDMINE")
-	v.AutomaticEnv()
-
-	// Read config file (ignore "not found" errors)
-	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			// Only fail on errors other than "file not found"
-			if _, err2 := os.Stat(v.ConfigFileUsed()); err2 == nil {
-				return nil, fmt.Errorf("reading config: %w", err)
+	pc, err := LoadProfiles(configPath, log)
+	if err != nil {
+		// If no config file exists, return defaults with env overrides
+		if os.IsNotExist(err) {
+			log.Printf("Config: no config file found")
+			cfg := &Config{
+				AuthMethod:   "apikey",
+				OutputFormat: "table",
 			}
+			applyEnvOverrides(cfg, log)
+			return cfg, nil
 		}
-		log.Printf("Config: no config file found")
-	} else {
-		log.Printf("Config: loaded from %s", v.ConfigFileUsed())
+		return nil, err
 	}
 
-	// Log environment variable overrides
-	for _, envVar := range []string{"REDMINE_SERVER", "REDMINE_API_KEY", "REDMINE_AUTH_METHOD"} {
-		if val := os.Getenv(envVar); val != "" {
-			log.Printf("Config: env override %s is set", envVar)
-		}
+	// Determine which profile to use
+	name := profileName
+	if name == "" {
+		name = pc.ActiveProfile
 	}
 
 	var cfg Config
-	if err := v.Unmarshal(&cfg); err != nil {
-		return nil, fmt.Errorf("parsing config: %w", err)
+	if name != "" {
+		p, ok := pc.Profiles[name]
+		if !ok {
+			return nil, fmt.Errorf("profile %q not found. Run 'redmine auth list' to see available profiles", name)
+		}
+		cfg = p
+		log.Printf("Config: loaded profile %q from %s", name, configPath)
+	} else if len(pc.Profiles) == 1 {
+		// Single profile, use it even without active_profile set
+		for n, p := range pc.Profiles {
+			cfg = p
+			log.Printf("Config: loaded only profile %q from %s", n, configPath)
+		}
+	} else if len(pc.Profiles) == 0 {
+		log.Printf("Config: no profiles configured")
+	} else {
+		return nil, fmt.Errorf("multiple profiles exist but no active profile set. Run 'redmine auth switch' to select one")
 	}
 
-	log.Printf("Config: server=%s auth_method=%s", cfg.Server, cfg.AuthMethod)
+	// Apply defaults
+	if cfg.AuthMethod == "" {
+		cfg.AuthMethod = "apikey"
+	}
+	if cfg.OutputFormat == "" {
+		cfg.OutputFormat = "table"
+	}
+
+	applyEnvOverrides(&cfg, log)
 
 	return &cfg, nil
 }
 
-// Save writes configuration to the given path.
-func Save(cfg *Config, path string) error {
-	v := viper.New()
-	v.Set("server", cfg.Server)
-	v.Set("api_key", cfg.APIKey)
-	v.Set("username", cfg.Username)
-	v.Set("password", cfg.Password)
-	v.Set("auth_method", cfg.AuthMethod)
-	v.Set("default_project", cfg.DefaultProject)
-	v.Set("output_format", cfg.OutputFormat)
-	v.Set("no_color", cfg.NoColor)
+// LoadProfiles reads the full profile configuration from disk.
+// It handles both legacy flat format and new profile format.
+func LoadProfiles(configPath string, log *debug.Logger) (*ProfileConfig, error) {
+	if configPath == "" {
+		configPath = DefaultConfigPath()
+	}
 
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to detect format by checking for "profiles" key
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	if _, hasProfiles := raw["profiles"]; hasProfiles {
+		// New profile format
+		var pc ProfileConfig
+		if err := yaml.Unmarshal(data, &pc); err != nil {
+			return nil, fmt.Errorf("parsing config profiles: %w", err)
+		}
+		if pc.Profiles == nil {
+			pc.Profiles = make(map[string]Config)
+		}
+		return &pc, nil
+	}
+
+	// Legacy flat format — convert to profile
+	var legacy Config
+	if err := yaml.Unmarshal(data, &legacy); err != nil {
+		return nil, fmt.Errorf("parsing legacy config: %w", err)
+	}
+
+	profileName := ProfileNameFromURL(legacy.Server)
+	if profileName == "" {
+		profileName = "default"
+	}
+
+	pc := &ProfileConfig{
+		ActiveProfile: profileName,
+		Profiles: map[string]Config{
+			profileName: legacy,
+		},
+	}
+
+	// Auto-migrate: write back in new format
+	log.Printf("Config: migrating legacy format to profile %q", profileName)
+	if err := SaveProfiles(pc, configPath); err != nil {
+		log.Printf("Config: migration write failed: %v", err)
+		// Non-fatal: still return the parsed config
+	}
+
+	return pc, nil
+}
+
+// SaveProfiles writes the full profile configuration to disk.
+func SaveProfiles(pc *ProfileConfig, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return v.WriteConfigAs(path)
+
+	data, err := yaml.Marshal(pc)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Save writes a single profile's configuration (used by auth login).
+func Save(cfg *Config, path string) error {
+	// Load existing profiles or create new
+	log := debug.New(nil)
+	pc, err := LoadProfiles(path, log)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		pc = &ProfileConfig{Profiles: make(map[string]Config)}
+	}
+
+	name := ProfileNameFromURL(cfg.Server)
+	if name == "" {
+		name = "default"
+	}
+
+	pc.Profiles[name] = *cfg
+	if pc.ActiveProfile == "" {
+		pc.ActiveProfile = name
+	}
+
+	return SaveProfiles(pc, path)
+}
+
+// SaveProfile writes a named profile to the config file.
+func SaveProfile(name string, cfg *Config, path string) error {
+	log := debug.New(nil)
+	pc, err := LoadProfiles(path, log)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		pc = &ProfileConfig{Profiles: make(map[string]Config)}
+	}
+
+	pc.Profiles[name] = *cfg
+	if pc.ActiveProfile == "" || len(pc.Profiles) == 1 {
+		pc.ActiveProfile = name
+	}
+
+	return SaveProfiles(pc, path)
+}
+
+// DeleteProfile removes a profile from the config file.
+func DeleteProfile(name string, path string) error {
+	log := debug.New(nil)
+	pc, err := LoadProfiles(path, log)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := pc.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found", name)
+	}
+
+	delete(pc.Profiles, name)
+
+	if pc.ActiveProfile == name {
+		pc.ActiveProfile = ""
+		// If there's exactly one profile left, make it active
+		for remaining := range pc.Profiles {
+			pc.ActiveProfile = remaining
+		}
+	}
+
+	return SaveProfiles(pc, path)
+}
+
+// SetActiveProfile sets the active profile in the config file.
+func SetActiveProfile(name string, path string) error {
+	log := debug.New(nil)
+	pc, err := LoadProfiles(path, log)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := pc.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found", name)
+	}
+
+	pc.ActiveProfile = name
+	return SaveProfiles(pc, path)
+}
+
+// ProfileNameFromURL derives a profile name from a server URL.
+func ProfileNameFromURL(serverURL string) string {
+	if serverURL == "" {
+		return ""
+	}
+
+	u, err := url.Parse(serverURL)
+	if err != nil || u.Host == "" {
+		// Try adding scheme
+		u, err = url.Parse("https://" + serverURL)
+		if err != nil || u.Host == "" {
+			return strings.ReplaceAll(serverURL, "/", "-")
+		}
+	}
+
+	host := u.Hostname()
+	// Remove common prefixes/suffixes for cleaner names
+	host = strings.TrimPrefix(host, "www.")
+
+	return strings.ReplaceAll(host, ".", "-")
+}
+
+// applyEnvOverrides applies REDMINE_* environment variables to the config.
+func applyEnvOverrides(cfg *Config, log *debug.Logger) {
+	envMap := map[string]*string{
+		"REDMINE_SERVER":          &cfg.Server,
+		"REDMINE_API_KEY":         &cfg.APIKey,
+		"REDMINE_AUTH_METHOD":     &cfg.AuthMethod,
+		"REDMINE_USERNAME":        &cfg.Username,
+		"REDMINE_PASSWORD":        &cfg.Password,
+		"REDMINE_DEFAULT_PROJECT": &cfg.DefaultProject,
+		"REDMINE_OUTPUT_FORMAT":   &cfg.OutputFormat,
+	}
+
+	for envVar, field := range envMap {
+		if val := os.Getenv(envVar); val != "" {
+			*field = val
+			log.Printf("Config: env override %s is set", envVar)
+		}
+	}
+
+	if os.Getenv("REDMINE_NO_COLOR") != "" {
+		cfg.NoColor = true
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,13 +9,122 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/debug"
 )
 
-func TestLoadDefaultsOutputFormat(t *testing.T) {
+func TestLoadLegacyFlatFormat(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server: https://redmine.example.com\nauth_method: apikey\n"), 0o644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte("server: https://redmine.example.com\nauth_method: apikey\napi_key: test-key\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg, err := Load(cfgPath, debug.New(nil))
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Server != "https://redmine.example.com" {
+		t.Fatalf("Server = %q, want %q", cfg.Server, "https://redmine.example.com")
+	}
+	if cfg.OutputFormat != "table" {
+		t.Fatalf("OutputFormat = %q, want %q", cfg.OutputFormat, "table")
+	}
+
+	// Verify it was migrated to profile format
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "profiles:") {
+		t.Fatal("expected legacy config to be migrated to profile format")
+	}
+}
+
+func TestLoadProfileFormat(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: work
+profiles:
+  work:
+    server: https://work.example.com
+    api_key: work-key
+    auth_method: apikey
+  personal:
+    server: https://personal.example.com
+    api_key: personal-key
+    auth_method: apikey
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Server != "https://work.example.com" {
+		t.Fatalf("Server = %q, want %q", cfg.Server, "https://work.example.com")
+	}
+	if cfg.APIKey != "work-key" {
+		t.Fatalf("APIKey = %q, want %q", cfg.APIKey, "work-key")
+	}
+}
+
+func TestLoadProfileOverride(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: work
+profiles:
+  work:
+    server: https://work.example.com
+    api_key: work-key
+  personal:
+    server: https://personal.example.com
+    api_key: personal-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath, "personal", debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Server != "https://personal.example.com" {
+		t.Fatalf("Server = %q, want %q", cfg.Server, "https://personal.example.com")
+	}
+}
+
+func TestLoadProfileNotFound(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: work
+profiles:
+  work:
+    server: https://work.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgPath, "nonexistent", debug.New(nil))
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' in error, got %q", err.Error())
+	}
+}
+
+func TestLoadDefaultsOutputFormat(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: test
+profiles:
+  test:
+    server: https://redmine.example.com
+    auth_method: apikey
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +134,7 @@ func TestLoadDefaultsOutputFormat(t *testing.T) {
 	}
 }
 
-func TestSaveOmitsPageSize(t *testing.T) {
+func TestSaveProfile(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
 	cfg := &Config{
 		Server:         "https://redmine.example.com",
@@ -36,20 +145,148 @@ func TestSaveOmitsPageSize(t *testing.T) {
 		NoColor:        true,
 	}
 
-	if err := Save(cfg, cfgPath); err != nil {
+	if err := SaveProfile("test", cfg, cfgPath); err != nil {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(cfgPath)
+	// Verify the profile was saved
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	text := string(data)
-	if strings.Contains(text, "page_size:") {
-		t.Fatalf("saved config unexpectedly contains page_size:\n%s", text)
+	if _, ok := pc.Profiles["test"]; !ok {
+		t.Fatal("expected profile 'test' to exist")
 	}
-	if !strings.Contains(text, "output_format: json") {
-		t.Fatalf("saved config missing output_format:\n%s", text)
+	if pc.ActiveProfile != "test" {
+		t.Fatalf("ActiveProfile = %q, want %q", pc.ActiveProfile, "test")
+	}
+	if pc.Profiles["test"].Server != "https://redmine.example.com" {
+		t.Fatalf("Server = %q, want %q", pc.Profiles["test"].Server, "https://redmine.example.com")
+	}
+}
+
+func TestDeleteProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: a
+profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteProfile("a", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := pc.Profiles["a"]; ok {
+		t.Fatal("expected profile 'a' to be deleted")
+	}
+	if pc.ActiveProfile != "b" {
+		t.Fatalf("ActiveProfile = %q, want %q after deleting active", pc.ActiveProfile, "b")
+	}
+}
+
+func TestSetActiveProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: a
+profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetActiveProfile("b", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pc.ActiveProfile != "b" {
+		t.Fatalf("ActiveProfile = %q, want %q", pc.ActiveProfile, "b")
+	}
+}
+
+func TestProfileNameFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://redmine.example.com", "redmine-example-com"},
+		{"https://www.redmine.io", "redmine-io"},
+		{"https://redmine.work.com:8080", "redmine-work-com"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := ProfileNameFromURL(tt.url)
+		if got != tt.want {
+			t.Errorf("ProfileNameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestLoadEnvOverrides(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: test
+profiles:
+  test:
+    server: https://file.example.com
+    api_key: file-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("REDMINE_SERVER", "https://env.example.com")
+	t.Setenv("REDMINE_API_KEY", "env-key")
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Server != "https://env.example.com" {
+		t.Errorf("expected server from env, got %q", cfg.Server)
+	}
+	if cfg.APIKey != "env-key" {
+		t.Errorf("expected api_key from env, got %q", cfg.APIKey)
+	}
+}
+
+func TestLoadSingleProfileNoActive(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `profiles:
+  only:
+    server: https://only.example.com
+    api_key: only-key
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Server != "https://only.example.com" {
+		t.Fatalf("Server = %q, want %q", cfg.Server, "https://only.example.com")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -270,6 +270,59 @@ profiles:
 	}
 }
 
+func TestLoadNoActiveProfileWithEnvOverrides(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("REDMINE_SERVER", "https://env.example.com")
+	t.Setenv("REDMINE_API_KEY", "env-key")
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatalf("Load with no active profile and env overrides failed: %v", err)
+	}
+
+	if cfg.Server != "https://env.example.com" {
+		t.Errorf("expected server from env, got %q", cfg.Server)
+	}
+	if cfg.APIKey != "env-key" {
+		t.Errorf("expected api_key from env, got %q", cfg.APIKey)
+	}
+}
+
+func TestLoadNoActiveProfileNoEnvOverridesFails(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure no env overrides
+	t.Setenv("REDMINE_SERVER", "")
+	t.Setenv("REDMINE_API_KEY", "")
+
+	_, err := Load(cfgPath, "", debug.New(nil))
+	if err == nil {
+		t.Fatal("expected error for no active profile without env overrides")
+	}
+	if !strings.Contains(err.Error(), "multiple profiles exist but no active profile") {
+		t.Errorf("expected 'multiple profiles' error, got: %v", err)
+	}
+}
+
 func TestLoadSingleProfileNoActive(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
 	content := `profiles:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -323,6 +323,34 @@ func TestLoadNoActiveProfileNoEnvOverridesFails(t *testing.T) {
 	}
 }
 
+func TestLoadAllowNoActiveProfile(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadAllowNoActiveProfile(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatalf("LoadAllowNoActiveProfile failed: %v", err)
+	}
+
+	if cfg.Server != "" {
+		t.Fatalf("Server = %q, want empty string when no explicit credentials are provided", cfg.Server)
+	}
+	if cfg.AuthMethod != "apikey" {
+		t.Fatalf("AuthMethod = %q, want %q", cfg.AuthMethod, "apikey")
+	}
+	if cfg.OutputFormat != "table" {
+		t.Fatalf("OutputFormat = %q, want %q", cfg.OutputFormat, "table")
+	}
+}
+
 func TestLoadSingleProfileNoActive(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
 	content := `profiles:
@@ -357,6 +385,21 @@ func TestLoadProfilesNonExistent(t *testing.T) {
 	}
 	if pc.ActiveProfile != "" {
 		t.Fatalf("ActiveProfile = %q, want empty string", pc.ActiveProfile)
+	}
+}
+
+func TestEffectiveProfileName(t *testing.T) {
+	pc := &ProfileConfig{
+		Profiles: map[string]Config{
+			"only": {Server: "https://only.example.com"},
+		},
+	}
+
+	if got := EffectiveProfileName(pc, ""); got != "only" {
+		t.Fatalf("EffectiveProfileName(single profile) = %q, want %q", got, "only")
+	}
+	if got := EffectiveProfileName(pc, "override"); got != "override" {
+		t.Fatalf("EffectiveProfileName(override) = %q, want %q", got, "override")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -290,3 +290,117 @@ func TestLoadSingleProfileNoActive(t *testing.T) {
 		t.Fatalf("Server = %q, want %q", cfg.Server, "https://only.example.com")
 	}
 }
+
+func TestLoadProfilesNonExistent(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
+
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
+	if err != nil {
+		t.Fatalf("LoadProfiles on nonexistent file returned error: %v", err)
+	}
+
+	if len(pc.Profiles) != 0 {
+		t.Fatalf("Profiles count = %d, want 0", len(pc.Profiles))
+	}
+	if pc.ActiveProfile != "" {
+		t.Fatalf("ActiveProfile = %q, want empty string", pc.ActiveProfile)
+	}
+}
+
+func TestDeleteProfileActiveWithMultipleRemaining(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: a
+profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+  c:
+    server: https://c.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteProfile("a", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := pc.Profiles["a"]; ok {
+		t.Fatal("profile 'a' should be deleted")
+	}
+	// ActiveProfile should be cleared, not set to a random remaining profile
+	if pc.ActiveProfile != "" {
+		t.Fatalf("ActiveProfile = %q, want empty string when multiple profiles remain after deleting active", pc.ActiveProfile)
+	}
+}
+
+func TestDeleteLastProfileRemovesConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: only
+profiles:
+  only:
+    server: https://only.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteProfile("only", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Config file should be removed
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatal("expected config file to be removed after deleting last profile")
+	}
+
+	// LoadProfiles should return empty config, not error
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
+	if err != nil {
+		t.Fatalf("LoadProfiles after last profile deleted returned error: %v", err)
+	}
+	if len(pc.Profiles) != 0 {
+		t.Fatalf("Profiles count = %d, want 0", len(pc.Profiles))
+	}
+}
+
+func TestDeleteProfileNonActivePreservesOthers(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `active_profile: a
+profiles:
+  a:
+    server: https://a.example.com
+  b:
+    server: https://b.example.com
+  c:
+    server: https://c.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteProfile("b", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := LoadProfiles(cfgPath, debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := pc.Profiles["a"]; !ok {
+		t.Fatal("profile 'a' should still exist")
+	}
+	if _, ok := pc.Profiles["c"]; !ok {
+		t.Fatal("profile 'c' should still exist")
+	}
+	if pc.ActiveProfile != "a" {
+		t.Fatalf("ActiveProfile = %q, want %q", pc.ActiveProfile, "a")
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,13 +1,19 @@
 package config
 
-// Config holds the CLI configuration.
+// Config holds the CLI configuration for a single profile.
 type Config struct {
-	Server         string `mapstructure:"server"`
-	APIKey         string `mapstructure:"api_key"`
-	Username       string `mapstructure:"username"`
-	Password       string `mapstructure:"password"`
-	AuthMethod     string `mapstructure:"auth_method"` // "apikey" or "basic"
-	DefaultProject string `mapstructure:"default_project"`
-	OutputFormat   string `mapstructure:"output_format"` // "table", "wide", "json", "csv"
-	NoColor        bool   `mapstructure:"no_color"`
+	Server         string `mapstructure:"server" yaml:"server,omitempty"`
+	APIKey         string `mapstructure:"api_key" yaml:"api_key,omitempty"`
+	Username       string `mapstructure:"username" yaml:"username,omitempty"`
+	Password       string `mapstructure:"password" yaml:"password,omitempty"`
+	AuthMethod     string `mapstructure:"auth_method" yaml:"auth_method,omitempty"` // "apikey" or "basic"
+	DefaultProject string `mapstructure:"default_project" yaml:"default_project,omitempty"`
+	OutputFormat   string `mapstructure:"output_format" yaml:"output_format,omitempty"` // "table", "wide", "json", "csv"
+	NoColor        bool   `mapstructure:"no_color" yaml:"no_color,omitempty"`
+}
+
+// ProfileConfig holds the top-level configuration with multiple profiles.
+type ProfileConfig struct {
+	ActiveProfile string            `yaml:"active_profile,omitempty"`
+	Profiles      map[string]Config `yaml:"profiles,omitempty"`
 }

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -24,6 +24,7 @@ Only these top-level commands exist. Do NOT invent subcommands that aren't liste
 | `trackers` | List trackers |
 | `statuses` | List issue statuses |
 | `search` | Search issues, wiki, news, messages, or browse results |
+| `auth` | Login, logout, list, switch, and check status of authentication profiles |
 | `api` | Make raw authenticated API requests |
 
 ## Setup
@@ -34,7 +35,7 @@ If the `redmine` command is not found, install it:
 curl -fsSL https://raw.githubusercontent.com/aarondpn/redmine-cli/main/install.sh | bash
 ```
 
-Then run `redmine init` for interactive configuration. Use `redmine config` to verify an existing setup.
+Then run `redmine auth login` for interactive configuration. Use `redmine config` to verify an existing setup.
 
 ## Critical Rules
 
@@ -91,5 +92,5 @@ Get the server URL from `redmine config` (or from the JSON output's hints). Alwa
 - `redmine issues list` defaults to `--status open`. Use `--status closed`, `--status "*"`, or a specific status name.
 - `redmine issues get <id> --journals` includes comments/history. Also available: `--children`, `--relations`.
 - `redmine issues update` only sends flags you explicitly pass — omitted flags are not changed.
-- If `--project` is omitted, the configured default project is used (set via `redmine init`).
+- If `--project` is omitted, the configured default project is used (set via `redmine auth login`).
 - Version status filters (`--open`, `--closed`, `--locked`) on `redmine versions list` are applied client-side.


### PR DESCRIPTION
## Summary

- Adds `redmine auth` command group with `login`, `logout`, `list`, `switch`, and `status` subcommands for managing multiple Redmine instance profiles
- Introduces `--profile/-p` global flag to use a specific profile for a single command without changing the default
- Evolves the config format from a flat single-instance YAML to a profile-based structure, with automatic migration of legacy configs on first load
- Removes `redmine init` in favor of `redmine auth login`
- All settings (default project, output format, etc.) are now scoped per profile