### PR TITLE
feat(update): add 24-hour version-aware cache for update checks

### DIFF
--- a/internal/cmd/update/check.go
+++ b/internal/cmd/update/check.go
@@ -107,7 +107,10 @@ func PrintNotice(w io.Writer, currentVersion string, result *CheckResult) {
 var cachePath = defaultCachePath
 
 func defaultCachePath() string {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
 	return filepath.Join(home, ".redmine-cli-update-check.json")
 }
 
@@ -121,6 +124,9 @@ func normalizeVersion(version string) string {
 // Returns nil if the file does not exist or is corrupt.
 func readCache() *updateCheckCache {
 	path := cachePath()
+	if path == "" {
+		return nil
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -138,6 +144,9 @@ func readCache() *updateCheckCache {
 // Errors are silently ignored.
 func writeCache(cache *updateCheckCache) {
 	path := cachePath()
+	if path == "" {
+		return
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
 	}

--- a/internal/cmd/update/check.go
+++ b/internal/cmd/update/check.go
@@ -2,10 +2,13 @@ package update
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/term"
 )
@@ -14,6 +17,17 @@ import (
 type CheckResult struct {
 	NewVersion string // e.g. "1.3.0" (without "v" prefix)
 	ReleaseURL string // full GitHub release page URL
+}
+
+// updateCheckCache is the on-disk cache for update check results.
+// Version-aware: the cache is invalidated when the binary version changes
+// (e.g. after running `redmine update`).
+type updateCheckCache struct {
+	CheckedAt          time.Time `json:"checked_at"`
+	CheckedFromVersion string    `json:"checked_from_version"` // normalized current version the check was run from
+	LatestVersion      string    `json:"latest_version"`       // normalized latest version per GitHub
+	ReleaseURL         string    `json:"release_url"`
+	UpdateAvailable    bool      `json:"update_available"` // true if LatestVersion is newer than CheckedFromVersion
 }
 
 // isTerminal reports whether stderr is a terminal. It is a variable so tests
@@ -86,4 +100,129 @@ func PrintNotice(w io.Writer, currentVersion string, result *CheckResult) {
 	current := strings.TrimPrefix(currentVersion, "v")
 	fmt.Fprintf(w, "\nA new version of redmine is available: v%s → v%s\n%s\nRun \"redmine update\" to upgrade\n",
 		current, result.NewVersion, result.ReleaseURL)
+}
+
+// cachePath returns the path to the update check cache file.
+// It is a variable so tests can override it.
+var cachePath = defaultCachePath
+
+func defaultCachePath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".redmine-cli-update-check.json")
+}
+
+const updateCheckCacheAge = 24 * time.Hour
+
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+// readCache loads the update check cache from disk.
+// Returns nil if the file does not exist or is corrupt.
+func readCache() *updateCheckCache {
+	path := cachePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var cache updateCheckCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil
+	}
+
+	return &cache
+}
+
+// writeCache saves the update check cache to disk.
+// Errors are silently ignored.
+func writeCache(cache *updateCheckCache) {
+	path := cachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return
+	}
+}
+
+// CheckForUpdateCached checks GitHub for a newer release, caching the result
+// for 24 hours. Cache is version-aware: entries from a different binary
+// version are ignored.
+//
+// Failure semantics (Option B): Only successful checks are cached.
+// A "successful check" means the GitHub API responded. The result may indicate
+// no update is available (update_available=false) or an update is available
+// (update_available=true, with version fields). Network errors and timeouts
+// are NOT cached, so a retry happens on the next invocation.
+//
+// Cached positive results are defensively revalidated with IsNewer before
+// being returned, ensuring stale cache entries (e.g. after a GitHub release
+// rollback) do not surface a false upgrade notice.
+func CheckForUpdateCached(ctx context.Context, currentVersion string) *CheckResult {
+	currentClean := normalizeVersion(currentVersion)
+
+	// Try version-aware cache first.
+	if cache := readCache(); cache != nil {
+		// Invalidate if cache is expired.
+		if time.Since(cache.CheckedAt) > updateCheckCacheAge {
+			cache = nil
+		}
+		// Invalidate if binary version changed (e.g. after running `redmine update`).
+		if cache != nil && cache.CheckedFromVersion != currentClean {
+			cache = nil
+		}
+		// If we have a positive cached result, defensively revalidate.
+		if cache != nil && cache.UpdateAvailable {
+			if !IsNewer(cache.LatestVersion, currentClean) {
+				// Cache is stale (e.g. version was bumped, then rolled back).
+				// Ignore it and perform a fresh check.
+				cache = nil
+			} else {
+				return &CheckResult{
+					NewVersion: cache.LatestVersion,
+					ReleaseURL: cache.ReleaseURL,
+				}
+			}
+		}
+		if cache != nil {
+			// Valid negative cache (checked successfully, no update available).
+			return nil
+		}
+	}
+
+	// Perform a live check.
+	release, err := fetchRelease(ctx)
+	if err != nil {
+		// Network error or timeout: do not cache, return nil.
+		return nil
+	}
+
+	latestVersion := normalizeVersion(release.TagName)
+	updateAvailable := IsNewer(latestVersion, currentClean)
+	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", RepoOwner, RepoName, release.TagName)
+
+	// Persist the cache entry (even when no update available).
+	writeCache(&updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: currentClean,
+		LatestVersion:      latestVersion,
+		ReleaseURL:         releaseURL,
+		UpdateAvailable:    updateAvailable,
+	})
+
+	if !updateAvailable {
+		return nil
+	}
+
+	return &CheckResult{
+		NewVersion: latestVersion,
+		ReleaseURL: releaseURL,
+	}
 }

--- a/internal/cmd/update/check_test.go
+++ b/internal/cmd/update/check_test.go
@@ -163,7 +163,17 @@ func readTestCache(t *testing.T) *updateCheckCache {
 func clearTestCache(t *testing.T) {
 	t.Helper()
 	path := cachePath()
+	if path == "" {
+		return
+	}
 	os.Remove(path)
+}
+
+func setEmptyCachePath(t *testing.T) {
+	t.Helper()
+	orig := cachePath
+	cachePath = func() string { return "" }
+	t.Cleanup(func() { cachePath = orig })
 }
 
 // Test 1: positive cache hit
@@ -396,6 +406,29 @@ func TestCheckForUpdateCached_NetworkErrorNoCache(t *testing.T) {
 	cache := readTestCache(t)
 	if cache != nil {
 		t.Errorf("expected no cache on network error, got %+v", cache)
+	}
+}
+
+func TestCheckForUpdateCached_EmptyCachePathDisablesCaching(t *testing.T) {
+	var fetchCalls int
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		fetchCalls++
+		return &GithubRelease{TagName: "v2.0.0"}, nil
+	})
+
+	setEmptyCachePath(t)
+
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result == nil {
+		t.Fatal("expected live result")
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("expected exactly one live fetch, got %d", fetchCalls)
+	}
+
+	cache := readTestCache(t)
+	if cache != nil {
+		t.Fatalf("expected caching to be disabled when cache path is empty, got %+v", cache)
 	}
 }
 

--- a/internal/cmd/update/check_test.go
+++ b/internal/cmd/update/check_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -136,5 +138,332 @@ func TestPrintNotice_Nil(t *testing.T) {
 	PrintNotice(&buf, "1.0.0", nil)
 	if buf.Len() != 0 {
 		t.Errorf("expected no output for nil result, got %q", buf.String())
+	}
+}
+
+// --- Cache tests ---
+
+func setCachePath(t *testing.T, dir string) {
+	t.Helper()
+	orig := cachePath
+	cachePath = func() string { return filepath.Join(dir, ".redmine-cli-update-check.json") }
+	t.Cleanup(func() { cachePath = orig })
+}
+
+func writeTestCache(t *testing.T, c *updateCheckCache) {
+	t.Helper()
+	writeCache(c)
+}
+
+func readTestCache(t *testing.T) *updateCheckCache {
+	t.Helper()
+	return readCache()
+}
+
+func clearTestCache(t *testing.T) {
+	t.Helper()
+	path := cachePath()
+	os.Remove(path)
+}
+
+// Test 1: positive cache hit
+func TestCheckForUpdateCached_PositiveCacheHit(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		t.Fatal("unexpected network call")
+		return nil, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "2.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v2.0.0",
+		UpdateAvailable:    true,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result == nil {
+		t.Fatal("expected cached result")
+	}
+	if result.NewVersion != "2.0.0" {
+		t.Errorf("NewVersion = %q, want %q", result.NewVersion, "2.0.0")
+	}
+}
+
+// Test 2: stale cache after version mismatch (simulates self-upgrade)
+func TestCheckForUpdateCached_VersionMismatch(t *testing.T) {
+	var fetchCalled bool
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		fetchCalled = true
+		return &GithubRelease{TagName: "v2.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "2.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v2.0.0",
+		UpdateAvailable:    true,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "2.0.0")
+	if result != nil {
+		t.Errorf("expected nil result for same version, got %+v", result)
+	}
+	if !fetchCalled {
+		t.Error("expected live fetch to run due to version mismatch")
+	}
+}
+
+// Test 3: invalid positive cache should fall back to a live check.
+func TestCheckForUpdateCached_InvalidPositiveCacheFallsBackToFetch(t *testing.T) {
+	var fetchCalls int
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		fetchCalls++
+		return &GithubRelease{TagName: "v1.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "1.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v2.0.0",
+		UpdateAvailable:    true,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result != nil {
+		t.Errorf("expected nil result after refreshing invalid cache, got %+v", result)
+	}
+	if fetchCalls != 1 {
+		t.Errorf("expected 1 live fetch, got %d", fetchCalls)
+	}
+
+	cache := readTestCache(t)
+	if cache == nil {
+		t.Fatal("expected cache to be rewritten")
+	}
+	if cache.UpdateAvailable {
+		t.Errorf("cache should reflect no update available, got update_available=true")
+	}
+}
+
+// Test 4: negative cache hit
+func TestCheckForUpdateCached_NegativeCacheHit(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		t.Fatal("unexpected network call")
+		return nil, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "1.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v1.0.0",
+		UpdateAvailable:    false,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result != nil {
+		t.Errorf("expected nil result for negative cache, got %+v", result)
+	}
+}
+
+// Test 5: expired cache forces live fetch
+func TestCheckForUpdateCached_ExpiredCache(t *testing.T) {
+	var fetchCalled bool
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		fetchCalled = true
+		return &GithubRelease{TagName: "v1.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now().Add(-updateCheckCacheAge - time.Hour),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "1.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v1.0.0",
+		UpdateAvailable:    false,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+	if !fetchCalled {
+		t.Error("expected live fetch for expired cache")
+	}
+}
+
+// Test 6: corrupt cache file falls back to live fetch
+func TestCheckForUpdateCached_CorruptCache(t *testing.T) {
+	var fetchCalled bool
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		fetchCalled = true
+		return &GithubRelease{TagName: "v1.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	if err := os.WriteFile(cachePath(), []byte("not valid json{"), 0o644); err != nil {
+		t.Fatalf("write corrupt cache: %v", err)
+	}
+
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+	if !fetchCalled {
+		t.Error("expected live fetch for corrupt cache")
+	}
+}
+
+// Test 7: cache write path on positive result
+func TestCheckForUpdateCached_CacheWritePositive(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		return &GithubRelease{TagName: "v2.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	cache := readTestCache(t)
+	if cache == nil {
+		t.Fatal("expected cache to be written")
+	}
+	if cache.CheckedFromVersion != "1.0.0" {
+		t.Errorf("CheckedFromVersion = %q, want %q", cache.CheckedFromVersion, "1.0.0")
+	}
+	if cache.LatestVersion != "2.0.0" {
+		t.Errorf("LatestVersion = %q, want %q", cache.LatestVersion, "2.0.0")
+	}
+	if cache.UpdateAvailable != true {
+		t.Errorf("UpdateAvailable = %v, want true", cache.UpdateAvailable)
+	}
+	if cache.ReleaseURL == "" {
+		t.Error("ReleaseURL should be non-empty")
+	}
+}
+
+// Test 8: cache write path on no-update result
+func TestCheckForUpdateCached_CacheWriteNoUpdate(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		return &GithubRelease{TagName: "v1.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+
+	cache := readTestCache(t)
+	if cache == nil {
+		t.Fatal("expected cache to be written")
+	}
+	if cache.UpdateAvailable {
+		t.Errorf("UpdateAvailable = %v, want false", cache.UpdateAvailable)
+	}
+}
+
+// Test 9: network error does NOT write cache
+func TestCheckForUpdateCached_NetworkErrorNoCache(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		return nil, fmt.Errorf("network error")
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	result := CheckForUpdateCached(context.Background(), "1.0.0")
+	if result != nil {
+		t.Errorf("expected nil result on network error, got %+v", result)
+	}
+
+	cache := readTestCache(t)
+	if cache != nil {
+		t.Errorf("expected no cache on network error, got %+v", cache)
+	}
+}
+
+// Test 10: cache bypass by version mismatch
+func TestCheckForUpdateCached_CacheBypassByVersionMismatch(t *testing.T) {
+	var fetchCalled bool
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		fetchCalled = true
+		return &GithubRelease{TagName: "v2.0.0"}, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	clearTestCache(t)
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "1.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v1.0.0",
+		UpdateAvailable:    false,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "1.1.0")
+	if result == nil {
+		t.Fatal("expected live result after version mismatch invalidated the cache")
+	}
+	if result.NewVersion != "2.0.0" {
+		t.Errorf("NewVersion = %q, want %q", result.NewVersion, "2.0.0")
+	}
+	if !fetchCalled {
+		t.Error("expected live fetch for version mismatch")
+	}
+}
+
+func TestCheckForUpdateCached_PositiveCacheHitWithVPrefixVersion(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		t.Fatal("unexpected network call")
+		return nil, nil
+	})
+
+	setCachePath(t, t.TempDir())
+	writeTestCache(t, &updateCheckCache{
+		CheckedAt:          time.Now(),
+		CheckedFromVersion: "1.0.0",
+		LatestVersion:      "2.0.0",
+		ReleaseURL:         "https://github.com/aarondpn/redmine-cli/releases/tag/v2.0.0",
+		UpdateAvailable:    true,
+	})
+
+	result := CheckForUpdateCached(context.Background(), "v1.0.0")
+	if result == nil {
+		t.Fatal("expected cached result")
+	}
+	if result.NewVersion != "2.0.0" {
+		t.Errorf("NewVersion = %q, want %q", result.NewVersion, "2.0.0")
+	}
+}
+
+// Regression: CheckForUpdate still works without cache
+func TestCheckForUpdate_Regression(t *testing.T) {
+	stubFetchRelease(t, func(ctx context.Context) (*GithubRelease, error) {
+		return &GithubRelease{TagName: "v2.0.0"}, nil
+	})
+
+	result := CheckForUpdate(context.Background(), "1.0.0")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.NewVersion != "2.0.0" {
+		t.Errorf("NewVersion = %q, want %q", result.NewVersion, "2.0.0")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -36,9 +36,10 @@ func main() {
 	rootCmd := cmd.NewRootCmd(version)
 	err := rootCmd.Execute()
 
-	waitForStartupUpdate(os.Stderr, version, updateDone, cancelUpdateCheck, updateCheckHintDelay, updateCheckMaxWait)
-
 	if err != nil {
+		if cancelUpdateCheck != nil {
+			cancelUpdateCheck()
+		}
 		var silent *cmdutil.SilentError
 		if errors.As(err, &silent) {
 			os.Exit(silent.Code)
@@ -46,6 +47,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", cmdutil.FormatError(err))
 		os.Exit(1)
 	}
+
+	waitForStartupUpdate(os.Stderr, version, updateDone, cancelUpdateCheck, updateCheckHintDelay, updateCheckMaxWait)
 }
 
 func waitForStartupUpdate(w io.Writer, currentVersion string, updateDone <-chan *update.CheckResult, cancel context.CancelFunc, hintDelay, maxWait time.Duration) {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -14,31 +15,28 @@ import (
 
 var version = "dev"
 
+const (
+	updateCheckHintDelay = 200 * time.Millisecond
+	updateCheckMaxWait   = 2 * time.Second
+)
+
 func main() {
 	// Start background update check.
 	var updateDone chan *update.CheckResult
+	var cancelUpdateCheck context.CancelFunc
 	if update.ShouldCheck(version, os.Args[1:]) {
 		updateDone = make(chan *update.CheckResult, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), updateCheckMaxWait)
+		cancelUpdateCheck = cancel
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer cancel()
-			updateDone <- update.CheckForUpdate(ctx, version)
+			updateDone <- update.CheckForUpdateCached(ctx, version)
 		}()
 	}
 
 	rootCmd := cmd.NewRootCmd(version)
 	err := rootCmd.Execute()
 
-	// Print update notice if the check already finished; never block exit.
-	if updateDone != nil {
-		select {
-		case result := <-updateDone:
-			if result != nil {
-				update.PrintNotice(os.Stderr, version, result)
-			}
-		default:
-		}
-	}
+	waitForStartupUpdate(os.Stderr, version, updateDone, cancelUpdateCheck, updateCheckHintDelay, updateCheckMaxWait)
 
 	if err != nil {
 		var silent *cmdutil.SilentError
@@ -47,5 +45,40 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "Error: %s\n", cmdutil.FormatError(err))
 		os.Exit(1)
+	}
+}
+
+func waitForStartupUpdate(w io.Writer, currentVersion string, updateDone <-chan *update.CheckResult, cancel context.CancelFunc, hintDelay, maxWait time.Duration) {
+	if updateDone == nil {
+		return
+	}
+	if cancel != nil {
+		defer cancel()
+	}
+
+	select {
+	case result := <-updateDone:
+		if result != nil {
+			update.PrintNotice(w, currentVersion, result)
+		}
+		return
+	case <-time.After(hintDelay):
+		fmt.Fprintln(w, "Checking for updates...")
+	case <-time.After(maxWait):
+		if cancel != nil {
+			cancel()
+		}
+		return
+	}
+
+	select {
+	case result := <-updateDone:
+		if result != nil {
+			update.PrintNotice(w, currentVersion, result)
+		}
+	case <-time.After(maxWait - hintDelay):
+		if cancel != nil {
+			cancel()
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aarondpn/redmine-cli/internal/cmd/update"
+)
+
+func TestWaitForStartupUpdate_FastResult_NoHint(t *testing.T) {
+	updateDone := make(chan *update.CheckResult, 1)
+	updateDone <- &update.CheckResult{
+		NewVersion: "2.0.0",
+		ReleaseURL: "https://github.com/aarondpn/redmine-cli/releases/tag/v2.0.0",
+	}
+
+	var buf bytes.Buffer
+	waitForStartupUpdate(&buf, "1.0.0", updateDone, nil, 10*time.Millisecond, 50*time.Millisecond)
+
+	out := buf.String()
+	if strings.Contains(out, "Checking for updates...") {
+		t.Fatalf("unexpected progress hint in output: %q", out)
+	}
+	if !strings.Contains(out, "v1.0.0") || !strings.Contains(out, "v2.0.0") {
+		t.Fatalf("expected update notice in output, got %q", out)
+	}
+}
+
+func TestWaitForStartupUpdate_SlowResult_PrintsHintAndNotice(t *testing.T) {
+	updateDone := make(chan *update.CheckResult, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		updateDone <- &update.CheckResult{
+			NewVersion: "2.0.0",
+			ReleaseURL: "https://github.com/aarondpn/redmine-cli/releases/tag/v2.0.0",
+		}
+	}()
+
+	var buf bytes.Buffer
+	waitForStartupUpdate(&buf, "1.0.0", updateDone, nil, 10*time.Millisecond, 100*time.Millisecond)
+
+	out := buf.String()
+	if !strings.Contains(out, "Checking for updates...") {
+		t.Fatalf("expected progress hint in output, got %q", out)
+	}
+	if !strings.Contains(out, "v1.0.0") || !strings.Contains(out, "v2.0.0") {
+		t.Fatalf("expected update notice in output, got %q", out)
+	}
+}
+
+func TestWaitForStartupUpdate_SlowNilResult_PrintsHintOnly(t *testing.T) {
+	updateDone := make(chan *update.CheckResult, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		updateDone <- nil
+	}()
+
+	var buf bytes.Buffer
+	waitForStartupUpdate(&buf, "1.0.0", updateDone, nil, 10*time.Millisecond, 100*time.Millisecond)
+
+	out := buf.String()
+	if !strings.Contains(out, "Checking for updates...") {
+		t.Fatalf("expected progress hint in output, got %q", out)
+	}
+	if strings.Contains(out, "A new version of redmine is available") {
+		t.Fatalf("did not expect update notice in output, got %q", out)
+	}
+}
+
+func TestWaitForStartupUpdate_TimeoutCancelsCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	updateDone := make(chan *update.CheckResult, 1)
+	canceled := make(chan struct{})
+
+	go func() {
+		<-ctx.Done()
+		close(canceled)
+	}()
+
+	var buf bytes.Buffer
+	waitForStartupUpdate(&buf, "1.0.0", updateDone, cancel, 10*time.Millisecond, 40*time.Millisecond)
+
+	select {
+	case <-canceled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected update check context to be canceled")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Checking for updates...") {
+		t.Fatalf("expected progress hint in output, got %q", out)
+	}
+	if strings.Contains(out, "A new version of redmine is available") {
+		t.Fatalf("did not expect update notice in output, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a persistent cache for GitHub update checks to avoid unnecessary API calls.

### Changes

- **`CheckForUpdateCached()`**: New function that caches update check results for 24 hours
- **Version-aware invalidation**: Cache is automatically invalidated when binary version changes (e.g. after running `redmine update`)
- **Defensive revalidation**: Positive cache entries are checked with `IsNewer()` before being returned, preventing stale upgrade notices after version rollbacks
- **Network error handling**: Errors are NOT cached, ensuring retries on next invocation
- **Progress hint**: Added "Checking for updates..." message when the check takes >200ms during startup (improves UX on slower networks)

### Testing

Added comprehensive tests covering:
- Positive/negative cache hits
- Version mismatch scenarios
- Expired cache handling
- Corrupt cache file handling
- Network error behavior
- v-prefix version normalization