### PR TITLE
Fix #44: update install.sh to match actual release asset filenames

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,12 +33,12 @@ TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '
 info "Latest version: ${TAG}"
 
 # Download
-ARCHIVE="redmine-${OS}-${ARCH}.tar.gz"
+ARCHIVE="redmine-cli-${OS}-${ARCH}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/checksums.txt"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/redmine-cli_${TAG#v}_checksums.txt"
 
 info "Downloading ${URL}..."
 curl -fsSL -o "${TMPDIR}/${ARCHIVE}" "$URL"


### PR DESCRIPTION
## Summary

- Fix archive filename prefix from `redmine-` to `redmine-cli-` to match GoReleaser output
- Fix checksums URL to use the actual pattern `redmine-cli_{version}_checksums.txt`

Closes #44

## Test plan

- [x] Verify `install.sh` downloads the correct archive for your platform
- [x] Verify checksum verification passes against the actual checksums file
- [x] Test on both macOS and Ubuntu