### PR TITLE
feat(issue): support file attachments on create/update

### DIFF
--- a/docs/src/content/docs/commands/issues.md
+++ b/docs/src/content/docs/commands/issues.md
@@ -71,9 +71,13 @@ redmine issues create [flags]
 | `--version` | Target version (name or ID) |
 | `--estimated-hours` | Estimated hours |
 | `--private` | Mark as private |
+| `--attach` | File path to attach (repeatable) |
 
 ```bash
 redmine issues create --project myproject --subject "Add search" --tracker Feature --priority High
+
+# Create an issue with attachments
+redmine issues create --project myproject --subject "Bug report" --attach /path/to/screenshot.png --attach /path/to/log.txt
 ```
 
 ## Update an Issue
@@ -89,6 +93,12 @@ Accepts the same flags as `create` (except `--project`) plus:
 | `--notes` | Add a comment |
 | `--done-ratio` | Completion percentage (0-100) |
 | `--due-date` | Due date (YYYY-MM-DD) |
+| `--attach` | File path to attach (repeatable) |
+
+```bash
+# Update an issue and add an attachment
+redmine issues update 123 --notes "Fixed the bug" --attach /path/to/fixed_code.patch
+```
 
 ## Close an Issue
 

--- a/internal/api/attachments.go
+++ b/internal/api/attachments.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/aarondpn/redmine-cli/internal/debug"
+)
+
+// AttachmentService handles file upload API calls.
+type AttachmentService struct {
+	client *Client
+}
+
+// Upload streams body (of known size) to Redmine's /uploads.json endpoint and
+// returns the upload token. filename is sent as a query parameter per the
+// Redmine REST docs so the server records the original name.
+func (s *AttachmentService) Upload(ctx context.Context, filename string, body io.Reader, size int64) (string, error) {
+	u := s.client.baseURL + "/uploads.json"
+	if filename != "" {
+		u += "?filename=" + url.QueryEscape(filename)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	if size >= 0 {
+		req.ContentLength = size
+	}
+
+	start := time.Now()
+	resp, err := s.client.httpClient.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		s.client.debugLog.Printf("HTTP %s %s -> error (%s): %v", req.Method, debug.ScrubURL(req.URL.String()), duration.Round(time.Millisecond), err)
+		return "", fmt.Errorf("upload request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	s.client.debugLog.Printf("HTTP %s %s -> %d (%s)", req.Method, debug.ScrubURL(req.URL.String()), resp.StatusCode, duration.Round(time.Millisecond))
+
+	if resp.StatusCode >= 400 {
+		return "", parseErrorResponse(resp)
+	}
+
+	var out struct {
+		Upload struct {
+			Token string `json:"token"`
+		} `json:"upload"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decoding upload response: %w", err)
+	}
+	if out.Upload.Token == "" {
+		return "", fmt.Errorf("upload response missing token")
+	}
+	return out.Upload.Token, nil
+}

--- a/internal/api/attachments_test.go
+++ b/internal/api/attachments_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAttachmentUpload_Success(t *testing.T) {
+	const wantBody = "hello world"
+	const wantFilename = "notes with, comma.txt"
+	var gotMethod, gotPath, gotCT, gotFilename, gotBody string
+	var gotLen int64
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotCT = r.Header.Get("Content-Type")
+		gotFilename = r.URL.Query().Get("filename")
+		gotLen = r.ContentLength
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"upload":{"token":"abc123"}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Attachments = &AttachmentService{client: c}
+
+	tok, err := c.Attachments.Upload(context.Background(), wantFilename, strings.NewReader(wantBody), int64(len(wantBody)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "abc123" {
+		t.Errorf("token = %q, want abc123", tok)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/uploads.json" {
+		t.Errorf("path = %q, want /uploads.json", gotPath)
+	}
+	if gotCT != "application/octet-stream" {
+		t.Errorf("content-type = %q, want application/octet-stream", gotCT)
+	}
+	if gotFilename != wantFilename {
+		t.Errorf("filename query = %q, want %q", gotFilename, wantFilename)
+	}
+	if gotLen != int64(len(wantBody)) {
+		t.Errorf("Content-Length = %d, want %d", gotLen, len(wantBody))
+	}
+	if gotBody != wantBody {
+		t.Errorf("body = %q, want %q", gotBody, wantBody)
+	}
+}
+
+func TestAttachmentUpload_SizeExceeded(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"errors":["This file cannot be uploaded because it exceeds the maximum allowed file size (1024000)"]}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Attachments = &AttachmentService{client: c}
+
+	_, err := c.Attachments.Upload(context.Background(), "big.bin", strings.NewReader("x"), 1)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if !apiErr.IsValidationError() {
+		t.Errorf("IsValidationError = false, want true (status %d)", apiErr.StatusCode)
+	}
+	if len(apiErr.Errors) == 0 || !strings.Contains(apiErr.Errors[0], "maximum allowed file size") {
+		t.Errorf("errors = %v, want size-exceeded message", apiErr.Errors)
+	}
+}
+
+func TestAttachmentUpload_MissingToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"upload":{}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Attachments = &AttachmentService{client: c}
+
+	_, err := c.Attachments.Upload(context.Background(), "x.bin", strings.NewReader("x"), 1)
+	if err == nil || !strings.Contains(err.Error(), "missing token") {
+		t.Fatalf("want missing-token error, got %v", err)
+	}
+}
+
+func TestAttachmentUpload_EmptyFilenameOmitsQuery(t *testing.T) {
+	var gotRawQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"upload":{"token":"t"}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Attachments = &AttachmentService{client: c}
+
+	if _, err := c.Attachments.Upload(context.Background(), "", strings.NewReader("x"), 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRawQuery != "" {
+		t.Errorf("raw query = %q, want empty", gotRawQuery)
+	}
+}
+
+func TestAttachmentUpload_AuthTransportDoesNotOverrideContentType(t *testing.T) {
+	// Regression test for the authTransport change: octet-stream must not be
+	// replaced with application/json.
+	var gotCT string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"upload":{"token":"t"}}`))
+	}))
+	defer ts.Close()
+
+	transport := &authTransport{base: http.DefaultTransport, authMethod: "apikey", apiKey: "k"}
+	c := newTestClient(ts)
+	c.httpClient = &http.Client{Transport: transport}
+	c.Attachments = &AttachmentService{client: c}
+
+	if _, err := c.Attachments.Upload(context.Background(), "f.bin", strings.NewReader("x"), 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCT != "application/octet-stream" {
+		t.Errorf("content-type = %q, want application/octet-stream (authTransport must not override)", gotCT)
+	}
+}
+
+func TestAuthTransport_DefaultsContentTypeToJSON(t *testing.T) {
+	var gotCT string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	transport := &authTransport{base: http.DefaultTransport, authMethod: "apikey", apiKey: "k"}
+	client := &http.Client{Transport: transport}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if gotCT != "application/json" {
+		t.Errorf("content-type = %q, want application/json", gotCT)
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -41,6 +41,7 @@ type Client struct {
 	Groups       *GroupService
 	Search       *SearchService
 	Memberships  *MembershipService
+	Attachments  *AttachmentService
 }
 
 // DebugLog returns the client's debug logger.
@@ -59,7 +60,9 @@ type authTransport struct {
 
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.Header.Set("Content-Type", "application/json")
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	switch t.authMethod {
 	case "basic":
@@ -109,6 +112,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Groups = &GroupService{client: c}
 	c.Search = &SearchService{client: c}
 	c.Memberships = &MembershipService{client: c}
+	c.Attachments = &AttachmentService{client: c}
 
 	return c, nil
 }

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/aarondpn/redmine-cli/internal/debug"
+)
+
+// NewTestClient constructs a Client wired to a given http.Client and base URL
+// without requiring a full config. It is exported only for use in tests of
+// other packages (e.g. cmdutil) that need a working *Client.
+func NewTestClient(httpClient *http.Client, baseURL string, log *debug.Logger) *Client {
+	c := &Client{
+		httpClient: httpClient,
+		baseURL:    baseURL,
+		debugLog:   log,
+	}
+	c.Attachments = &AttachmentService{client: c}
+	c.Issues = &IssueService{client: c}
+	return c
+}

--- a/internal/cmd/issue/create.go
+++ b/internal/cmd/issue/create.go
@@ -27,6 +27,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		parent         int
 		estimatedHours float64
 		private        bool
+		attach         []string
 		format         string
 	)
 
@@ -126,6 +127,14 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				create.IsPrivate = &private
 			}
 
+			if len(attach) > 0 {
+				uploads, err := cmdutil.UploadAttachments(ctx, client, attach)
+				if err != nil {
+					return err
+				}
+				create.Uploads = uploads
+			}
+
 			printer := f.Printer(format)
 			stop := printer.Spinner("Creating issue...")
 			issue, err := client.Issues.Create(ctx, create)
@@ -167,6 +176,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVar(&parent, "parent", 0, "Parent issue ID")
 	cmd.Flags().Float64Var(&estimatedHours, "estimated-hours", 0, "Estimated hours")
 	cmd.Flags().BoolVar(&private, "private", false, "Mark issue as private")
+	cmd.Flags().StringArrayVar(&attach, "attach", nil, "Path to file to attach (repeatable)")
 	cmdutil.AddOutputFlag(cmd, &format)
 
 	_ = cmd.MarkFlagRequired("subject")

--- a/internal/cmd/issue/update.go
+++ b/internal/cmd/issue/update.go
@@ -28,6 +28,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		private        bool
 		doneRatio      int
 		note           string
+		attach         []string
 	)
 
 	cmd := &cobra.Command{
@@ -144,6 +145,14 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				update.FixedVersionID = &vid
 			}
 
+			if len(attach) > 0 {
+				uploads, err := cmdutil.UploadAttachments(ctx, client, attach)
+				if err != nil {
+					return err
+				}
+				update.Uploads = uploads
+			}
+
 			printer := f.Printer("")
 			stop := printer.Spinner("Updating issue...")
 			err = client.Issues.Update(ctx, id, update)
@@ -170,6 +179,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&private, "private", false, "Mark issue as private")
 	cmd.Flags().IntVar(&doneRatio, "done-ratio", 0, "Done ratio (0-100)")
 	cmd.Flags().StringVar(&note, "note", "", "Add a note to the issue")
+	cmd.Flags().StringArrayVar(&attach, "attach", nil, "Path to file to attach (repeatable)")
 
 	_ = cmd.RegisterFlagCompletionFunc("tracker", cmdutil.CompleteTrackers(f))
 	_ = cmd.RegisterFlagCompletionFunc("status", cmdutil.CompleteStatuses(f))

--- a/internal/cmdutil/uploads.go
+++ b/internal/cmdutil/uploads.go
@@ -1,0 +1,75 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/aarondpn/redmine-cli/internal/api"
+	"github.com/aarondpn/redmine-cli/internal/models"
+)
+
+// UploadAttachments uploads each given file path and returns Upload references
+// suitable for inclusion in an issue create/update payload.
+func UploadAttachments(ctx context.Context, client *api.Client, paths []string) ([]models.Upload, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	uploads := make([]models.Upload, 0, len(paths))
+	for _, p := range paths {
+		up, err := uploadOne(ctx, client, p)
+		if err != nil {
+			return nil, fmt.Errorf("uploading %s: %w", p, err)
+		}
+		uploads = append(uploads, up)
+	}
+	return uploads, nil
+}
+
+func uploadOne(ctx context.Context, client *api.Client, path string) (models.Upload, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return models.Upload{}, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return models.Upload{}, err
+	}
+
+	ct := detectContentType(f, path)
+	if _, err := f.Seek(0, 0); err != nil {
+		return models.Upload{}, err
+	}
+
+	name := filepath.Base(path)
+	token, err := client.Attachments.Upload(ctx, name, f, info.Size())
+	if err != nil {
+		return models.Upload{}, err
+	}
+
+	return models.Upload{
+		Token:       token,
+		Filename:    name,
+		ContentType: ct,
+	}, nil
+}
+
+// detectContentType resolves a MIME type from the file extension, falling back
+// to sniffing the first 512 bytes. The file position is left unspecified; the
+// caller must seek before reading the file for upload.
+func detectContentType(f *os.File, path string) string {
+	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
+		return ct
+	}
+	var sniff [512]byte
+	n, _ := f.Read(sniff[:])
+	if n == 0 {
+		return ""
+	}
+	return http.DetectContentType(sniff[:n])
+}

--- a/internal/cmdutil/uploads_test.go
+++ b/internal/cmdutil/uploads_test.go
@@ -1,0 +1,217 @@
+package cmdutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/api"
+	"github.com/aarondpn/redmine-cli/internal/debug"
+)
+
+// pngSignature is a 1x1 transparent PNG used to verify content-type sniffing
+// for files with no recognizable extension.
+var pngSignature = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG header
+	0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+	0x89,
+}
+
+type uploadRecord struct {
+	filename string
+	body     []byte
+	length   int64
+	ct       string
+}
+
+func newUploadServer(t *testing.T, tokens []string) (*httptest.Server, *[]uploadRecord) {
+	t.Helper()
+	var recs []uploadRecord
+	var idx int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, r.ContentLength)
+		if r.ContentLength > 0 {
+			_, _ = r.Body.Read(b)
+		}
+		recs = append(recs, uploadRecord{
+			filename: r.URL.Query().Get("filename"),
+			body:     b,
+			length:   r.ContentLength,
+			ct:       r.Header.Get("Content-Type"),
+		})
+		i := int(atomic.AddInt32(&idx, 1)) - 1
+		tok := "tok"
+		if i < len(tokens) {
+			tok = tokens[i]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"upload":{"token":"` + tok + `"}}`))
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &recs
+}
+
+func newClientFor(ts *httptest.Server) *api.Client {
+	// Build a Client manually, bypassing NewClient (which requires a full
+	// config). We only need the Attachments service wired to the test server.
+	httpClient := ts.Client()
+	u, _ := url.Parse(ts.URL)
+	_ = u
+	c := apiClientForTest(httpClient, ts.URL)
+	return c
+}
+
+func writeTempFile(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return p
+}
+
+func TestUploadAttachments_Empty(t *testing.T) {
+	// No server hit, no error, nil result.
+	ups, err := UploadAttachments(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ups != nil {
+		t.Errorf("ups = %v, want nil", ups)
+	}
+}
+
+func TestUploadAttachments_SingleFile_ExtensionCT(t *testing.T) {
+	ts, recs := newUploadServer(t, []string{"tkA"})
+	c := newClientFor(ts)
+
+	data := []byte("some text content")
+	p := writeTempFile(t, "notes.txt", data)
+
+	ups, err := UploadAttachments(context.Background(), c, []string{p})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ups) != 1 {
+		t.Fatalf("len(ups) = %d, want 1", len(ups))
+	}
+	u := ups[0]
+	if u.Token != "tkA" {
+		t.Errorf("token = %q, want tkA", u.Token)
+	}
+	if u.Filename != "notes.txt" {
+		t.Errorf("filename = %q, want notes.txt", u.Filename)
+	}
+	if !strings.HasPrefix(u.ContentType, "text/plain") {
+		t.Errorf("content-type = %q, want text/plain*", u.ContentType)
+	}
+
+	if len(*recs) != 1 {
+		t.Fatalf("server got %d requests, want 1", len(*recs))
+	}
+	r := (*recs)[0]
+	if r.filename != "notes.txt" {
+		t.Errorf("server filename = %q, want notes.txt", r.filename)
+	}
+	if string(r.body) != string(data) {
+		t.Errorf("server body mismatch")
+	}
+	if r.length != int64(len(data)) {
+		t.Errorf("server length = %d, want %d", r.length, len(data))
+	}
+	if r.ct != "application/octet-stream" {
+		t.Errorf("server content-type = %q, want octet-stream", r.ct)
+	}
+}
+
+func TestUploadAttachments_MultipleFiles_PathWithComma(t *testing.T) {
+	ts, recs := newUploadServer(t, []string{"tk1", "tk2"})
+	c := newClientFor(ts)
+
+	p1 := writeTempFile(t, "a,b.txt", []byte("one"))
+	p2 := writeTempFile(t, "second.bin", []byte("two"))
+
+	ups, err := UploadAttachments(context.Background(), c, []string{p1, p2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ups) != 2 {
+		t.Fatalf("len(ups) = %d, want 2", len(ups))
+	}
+	if ups[0].Filename != "a,b.txt" {
+		t.Errorf("filename[0] = %q, want a,b.txt", ups[0].Filename)
+	}
+	if ups[1].Token != "tk2" {
+		t.Errorf("token[1] = %q, want tk2", ups[1].Token)
+	}
+	if (*recs)[0].filename != "a,b.txt" {
+		t.Errorf("server filename[0] = %q, want a,b.txt", (*recs)[0].filename)
+	}
+}
+
+func TestUploadAttachments_SniffsContentTypeWhenExtensionUnknown(t *testing.T) {
+	ts, _ := newUploadServer(t, []string{"tk"})
+	c := newClientFor(ts)
+
+	p := writeTempFile(t, "blob", pngSignature)
+
+	ups, err := UploadAttachments(context.Background(), c, []string{p})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ups[0].ContentType != "image/png" {
+		t.Errorf("content-type = %q, want image/png (sniffed)", ups[0].ContentType)
+	}
+}
+
+func TestUploadAttachments_MissingFile(t *testing.T) {
+	ts, _ := newUploadServer(t, []string{"tk"})
+	c := newClientFor(ts)
+
+	_, err := UploadAttachments(context.Background(), c, []string{"/nonexistent/path/does/not/exist.bin"})
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "uploading") {
+		t.Errorf("error should wrap path, got: %v", err)
+	}
+}
+
+func TestUploadAttachments_StopsOnError(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"errors":["too big"]}`))
+	}))
+	defer ts.Close()
+	c := apiClientForTest(ts.Client(), ts.URL)
+
+	p1 := writeTempFile(t, "first.txt", []byte("one"))
+	p2 := writeTempFile(t, "second.txt", []byte("two"))
+
+	_, err := UploadAttachments(context.Background(), c, []string{p1, p2})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("server calls = %d, want 1 (must stop after first failure)", got)
+	}
+}
+
+// apiClientForTest constructs an *api.Client wired to the test server without
+// requiring a full config. Defined in attachments_helper_test.go.
+var apiClientForTest = func(httpClient *http.Client, baseURL string) *api.Client {
+	return api.NewTestClient(httpClient, baseURL, debug.New(nil))
+}

--- a/internal/models/issue.go
+++ b/internal/models/issue.go
@@ -46,20 +46,29 @@ type IssueFilter struct {
 	Offset         int
 }
 
+// Upload represents a file attachment reference for an issue create/update.
+type Upload struct {
+	Token       string `json:"token"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 // IssueCreate defines fields for creating a new issue.
 type IssueCreate struct {
-	ProjectID      int     `json:"project_id"`
-	TrackerID      int     `json:"tracker_id,omitempty"`
-	StatusID       int     `json:"status_id,omitempty"`
-	PriorityID     int     `json:"priority_id,omitempty"`
-	Subject        string  `json:"subject"`
-	Description    string  `json:"description,omitempty"`
-	AssignedToID   int     `json:"assigned_to_id,omitempty"`
-	ParentIssueID  int     `json:"parent_issue_id,omitempty"`
-	CategoryID     int     `json:"category_id,omitempty"`
-	FixedVersionID int     `json:"fixed_version_id,omitempty"`
-	EstimatedHours float64 `json:"estimated_hours,omitempty"`
-	IsPrivate      *bool   `json:"is_private,omitempty"`
+	ProjectID      int      `json:"project_id"`
+	TrackerID      int      `json:"tracker_id,omitempty"`
+	StatusID       int      `json:"status_id,omitempty"`
+	PriorityID     int      `json:"priority_id,omitempty"`
+	Subject        string   `json:"subject"`
+	Description    string   `json:"description,omitempty"`
+	AssignedToID   int      `json:"assigned_to_id,omitempty"`
+	ParentIssueID  int      `json:"parent_issue_id,omitempty"`
+	CategoryID     int      `json:"category_id,omitempty"`
+	FixedVersionID int      `json:"fixed_version_id,omitempty"`
+	EstimatedHours float64  `json:"estimated_hours,omitempty"`
+	IsPrivate      *bool    `json:"is_private,omitempty"`
+	Uploads        []Upload `json:"uploads,omitempty"`
 }
 
 // IssueUpdate defines fields for updating an issue. Nil fields are not sent.
@@ -78,4 +87,5 @@ type IssueUpdate struct {
 	FixedVersionID *int     `json:"fixed_version_id,omitempty"`
 	EstimatedHours *float64 `json:"estimated_hours,omitempty"`
 	IsPrivate      *bool    `json:"is_private,omitempty"`
+	Uploads        []Upload `json:"uploads,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Adds `--attach <path>` flag (repeatable) to `issue create` and `issue update` to upload local files as Redmine issue attachments.
- Implements `AttachmentService.Upload` using Redmine's two-step upload flow: `POST /uploads.json?filename=...` with `Content-Type: application/octet-stream`, then reference the returned token in the issue payload via a new `Upload` model.
- Streams the file with a known `Content-Length` rather than buffering it in memory.
- Resolves `content_type` from the file extension, falling back to sniffing the first 512 bytes when unknown.
- Uses `StringArrayVar` for `--attach` so paths containing commas are not split.
- Relaxes `authTransport` to only default `Content-Type` to `application/json` when unset, preserving `application/octet-stream` for uploads.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/` clean
- [x] New tests: `AttachmentService.Upload` — success (method, path, query filename, Content-Type, Content-Length, body, token), 422 size-exceeded → `*APIError.IsValidationError`, missing token error, empty filename omits query param, `authTransport` preserves octet-stream, `authTransport` still defaults to JSON otherwise.
- [x] New tests: `UploadAttachments` — empty input, single file with extension-derived Content-Type, multi-file with comma-in-filename path, Content-Type sniffing fallback (PNG magic bytes on extensionless file), missing file error, stop-on-first-error.
- [x] Manual smoke test against a live Redmine instance: `redmine issue create --project X --subject Y --attach ./file.png` and `redmine issue update <id> --attach ./file.pdf`.