### PR TITLE
Add wiki command with full CRUD functionality

### DIFF
--- a/docs/src/content/docs/commands/wiki.md
+++ b/docs/src/content/docs/commands/wiki.md
@@ -1,0 +1,117 @@
+---
+title: Wiki
+description: Manage project wiki pages.
+---
+
+The `wiki` command (alias: `w`) manages wiki pages within a project.
+
+All subcommands require a project — either via `--project`/`-p` or the configured default project.
+
+## List Wiki Pages
+
+```bash
+redmine wiki list --project <identifier> [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `--project` | `-p` Project identifier — **required** if no default |
+| `--limit` | Maximum number of results |
+| `--offset` | Result offset |
+| `-o, --output` | Output format |
+
+```bash
+# List wiki pages
+redmine wiki list -p myproject
+
+# JSON output
+redmine wiki list -p myproject -o json
+```
+
+## View a Wiki Page
+
+```bash
+redmine wiki get <page-title> --project <identifier> [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `--project` | `-p` Project identifier — **required** if no default |
+| `--version` | Page version number (default: latest) |
+| `--include` | Include additional data (e.g. `attachments`) |
+| `-o, --output` | Output format |
+
+```bash
+# View a wiki page
+redmine wiki get WikiStart -p myproject
+
+# View a specific version
+redmine wiki get WikiStart -p myproject --version 3
+
+# Include attachments
+redmine wiki get WikiStart -p myproject --include attachments
+```
+
+## Create a Wiki Page
+
+```bash
+redmine wiki create <page-title> --project <identifier> --text "content" [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `--project` | `-p` Project identifier — **required** if no default |
+| `--text` | `-t` Page content in Textile/Markdown — **required** |
+| `--title` | Display title (defaults to page name) |
+| `--comments` | Change comment |
+| `-o, --output` | Output format |
+
+```bash
+# Create a new wiki page
+redmine wiki create MyPage -p myproject -t "h1. Hello World"
+
+# With title and comment
+redmine wiki create MyPage -p myproject -t "Content here" --title "My Page" --comments "Initial draft"
+```
+
+## Update a Wiki Page
+
+```bash
+redmine wiki update <page-title> --project <identifier> [flags]
+```
+
+Only flags you explicitly pass are sent — omitted flags are not changed.
+
+| Flag | Description |
+|------|------------|
+| `--project` | `-p` Project identifier — **required** if no default |
+| `--text` | `-t` Page content in Textile/Markdown |
+| `--title` | Display title |
+| `--comments` | Change comment |
+
+```bash
+# Update page content
+redmine wiki update MyPage -p myproject --text "Updated content"
+
+# Update with a change comment
+redmine wiki update MyPage -p myproject -t "New text" --comments "Fixed typo"
+```
+
+## Delete a Wiki Page
+
+```bash
+redmine wiki delete <page-title> --project <identifier> [flags]
+```
+
+| Flag | Description |
+|------|------------|
+| `--project` | `-p` Project identifier — **required** if no default |
+| `--force` | `-f` Skip confirmation prompt |
+
+```bash
+# Delete with confirmation
+redmine wiki delete MyPage -p myproject
+
+# Skip confirmation
+redmine wiki delete MyPage -p myproject --force
+```

--- a/docs/src/content/docs/commands/wiki.md
+++ b/docs/src/content/docs/commands/wiki.md
@@ -5,7 +5,7 @@ description: Manage project wiki pages.
 
 The `wiki` command (alias: `w`) manages wiki pages within a project.
 
-All subcommands require a project — either via `--project`/`-p` or the configured default project.
+All subcommands require a project — either via `--project` or the configured default project.
 
 ## List Wiki Pages
 
@@ -15,17 +15,17 @@ redmine wiki list --project <identifier> [flags]
 
 | Flag | Description |
 |------|------------|
-| `--project` | `-p` Project identifier — **required** if no default |
+| `--project` | Project identifier — **required** if no default |
 | `--limit` | Maximum number of results |
 | `--offset` | Result offset |
 | `-o, --output` | Output format |
 
 ```bash
 # List wiki pages
-redmine wiki list -p myproject
+redmine wiki list --project myproject
 
 # JSON output
-redmine wiki list -p myproject -o json
+redmine wiki list --project myproject -o json
 ```
 
 ## View a Wiki Page
@@ -36,20 +36,20 @@ redmine wiki get <page-title> --project <identifier> [flags]
 
 | Flag | Description |
 |------|------------|
-| `--project` | `-p` Project identifier — **required** if no default |
+| `--project` | Project identifier — **required** if no default |
 | `--version` | Page version number (default: latest) |
 | `--include` | Include additional data (e.g. `attachments`) |
 | `-o, --output` | Output format |
 
 ```bash
 # View a wiki page
-redmine wiki get WikiStart -p myproject
+redmine wiki get WikiStart --project myproject
 
 # View a specific version
-redmine wiki get WikiStart -p myproject --version 3
+redmine wiki get WikiStart --project myproject --version 3
 
 # Include attachments
-redmine wiki get WikiStart -p myproject --include attachments
+redmine wiki get WikiStart --project myproject --include attachments
 ```
 
 ## Create a Wiki Page
@@ -60,18 +60,22 @@ redmine wiki create <page-title> --project <identifier> --text "content" [flags]
 
 | Flag | Description |
 |------|------------|
-| `--project` | `-p` Project identifier — **required** if no default |
-| `--text` | `-t` Page content in Textile/Markdown — **required** |
+| `--project` | Project identifier — **required** if no default |
+| `-t, --text` | Page content in Textile/Markdown — **required** |
 | `--title` | Display title (defaults to page name) |
 | `--comments` | Change comment |
+| `--attach` | Path to file to attach (repeatable) |
 | `-o, --output` | Output format |
 
 ```bash
 # Create a new wiki page
-redmine wiki create MyPage -p myproject -t "h1. Hello World"
+redmine wiki create MyPage --project myproject --text "h1. Hello World"
 
 # With title and comment
-redmine wiki create MyPage -p myproject -t "Content here" --title "My Page" --comments "Initial draft"
+redmine wiki create MyPage --project myproject --text "Content here" --title "My Page" --comments "Initial draft"
+
+# Attach a file
+redmine wiki create MyPage --project myproject --text "See diagram" --attach ./diagram.png
 ```
 
 ## Update a Wiki Page
@@ -84,17 +88,21 @@ Only flags you explicitly pass are sent — omitted flags are not changed.
 
 | Flag | Description |
 |------|------------|
-| `--project` | `-p` Project identifier — **required** if no default |
-| `--text` | `-t` Page content in Textile/Markdown |
+| `--project` | Project identifier — **required** if no default |
+| `-t, --text` | Page content in Textile/Markdown |
 | `--title` | Display title |
 | `--comments` | Change comment |
+| `--attach` | Path to file to attach (repeatable) |
 
 ```bash
 # Update page content
-redmine wiki update MyPage -p myproject --text "Updated content"
+redmine wiki update MyPage --project myproject --text "Updated content"
 
 # Update with a change comment
-redmine wiki update MyPage -p myproject -t "New text" --comments "Fixed typo"
+redmine wiki update MyPage --project myproject --text "New text" --comments "Fixed typo"
+
+# Attach a file
+redmine wiki update MyPage --project myproject --comments "Added diagram" --attach ./diagram.png
 ```
 
 ## Delete a Wiki Page
@@ -103,15 +111,17 @@ redmine wiki update MyPage -p myproject -t "New text" --comments "Fixed typo"
 redmine wiki delete <page-title> --project <identifier> [flags]
 ```
 
+This also removes all attachments and the page history. Any child pages will be re-parented to the wiki root.
+
 | Flag | Description |
 |------|------------|
-| `--project` | `-p` Project identifier — **required** if no default |
-| `--force` | `-f` Skip confirmation prompt |
+| `--project` | Project identifier — **required** if no default |
+| `--force` | Skip confirmation prompt |
 
 ```bash
 # Delete with confirmation
-redmine wiki delete MyPage -p myproject
+redmine wiki delete MyPage --project myproject
 
 # Skip confirmation
-redmine wiki delete MyPage -p myproject --force
+redmine wiki delete MyPage --project myproject --force
 ```

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -42,6 +42,7 @@ type Client struct {
 	Search       *SearchService
 	Memberships  *MembershipService
 	Attachments  *AttachmentService
+	Wikis        *WikiService
 }
 
 // DebugLog returns the client's debug logger.
@@ -113,6 +114,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Search = &SearchService{client: c}
 	c.Memberships = &MembershipService{client: c}
 	c.Attachments = &AttachmentService{client: c}
+	c.Wikis = &WikiService{client: c}
 
 	return c, nil
 }

--- a/internal/api/wiki.go
+++ b/internal/api/wiki.go
@@ -66,7 +66,13 @@ func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki m
 		return &resp.WikiPage, nil
 	}
 	// Fallback: some Redmine versions return an empty body; fetch the page back.
-	return s.Get(ctx, projectID, page, nil)
+	// Use the effective title when --title was set, since Redmine may store
+	// the page under a different slug than the original <page> argument.
+	effective := page
+	if wiki.Title != "" {
+		effective = wiki.Title
+	}
+	return s.Get(ctx, projectID, effective, nil)
 }
 
 // Update updates an existing wiki page.

--- a/internal/api/wiki.go
+++ b/internal/api/wiki.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/aarondpn/redmine-cli/internal/models"
+)
+
+// WikiService handles wiki-related API calls.
+type WikiService struct {
+	client *Client
+}
+
+// List retrieves the wiki page index for a project.
+func (s *WikiService) List(ctx context.Context, projectID string, limit, offset int) ([]models.WikiPageIndex, int, error) {
+	path := fmt.Sprintf("/projects/%s/wiki/index.json", projectID)
+	var params url.Values
+	if offset > 0 {
+		params = url.Values{}
+		params.Set("offset", strconv.Itoa(offset))
+	}
+	return FetchAll[models.WikiPageIndex](ctx, s.client, path, params, "wiki_pages", limit)
+}
+
+// Get retrieves a single wiki page by title.
+func (s *WikiService) Get(ctx context.Context, projectID, page string, includes []string) (*models.WikiPage, error) {
+	params := url.Values{}
+	if len(includes) > 0 {
+		params.Set("include", joinStrings(includes, ","))
+	}
+	var resp struct {
+		WikiPage models.WikiPage `json:"wiki_page"`
+	}
+	if err := s.client.Get(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), params, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.WikiPage, nil
+}
+
+// GetVersion retrieves a specific version of a wiki page.
+func (s *WikiService) GetVersion(ctx context.Context, projectID, page string, version int) (*models.WikiPage, error) {
+	var resp struct {
+		WikiPage models.WikiPage `json:"wiki_page"`
+	}
+	if err := s.client.Get(ctx, fmt.Sprintf("/projects/%s/wiki/%s/%d.json", projectID, page, version), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.WikiPage, nil
+}
+
+// Create creates a new wiki page (or overwrites an existing one).
+func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki models.WikiPageCreate) (*models.WikiPage, error) {
+	body := map[string]interface{}{"wiki_page": wiki}
+	if err := s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), body); err != nil {
+		return nil, err
+	}
+	// Redmine returns 201/200 with no body for wiki PUT; fetch the page back.
+	return s.Get(ctx, projectID, page, nil)
+}
+
+// Update updates an existing wiki page.
+func (s *WikiService) Update(ctx context.Context, projectID, page string, update models.WikiPageUpdate) error {
+	body := map[string]interface{}{"wiki_page": update}
+	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), body)
+}
+
+// Delete deletes a wiki page.
+func (s *WikiService) Delete(ctx context.Context, projectID, page string) error {
+	return s.client.Delete(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page))
+}

--- a/internal/api/wiki.go
+++ b/internal/api/wiki.go
@@ -52,13 +52,9 @@ func (s *WikiService) GetVersion(ctx context.Context, projectID, page string, ve
 }
 
 // Create creates a new wiki page (or overwrites an existing one).
-func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki models.WikiPageCreate) (*models.WikiPage, error) {
+func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki models.WikiPageCreate) error {
 	body := map[string]interface{}{"wiki_page": wiki}
-	if err := s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), body); err != nil {
-		return nil, err
-	}
-	// Redmine returns 201/200 with no body for wiki PUT; fetch the page back.
-	return s.Get(ctx, projectID, page, nil)
+	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), body)
 }
 
 // Update updates an existing wiki page.

--- a/internal/api/wiki.go
+++ b/internal/api/wiki.go
@@ -16,7 +16,7 @@ type WikiService struct {
 
 // List retrieves the wiki page index for a project.
 func (s *WikiService) List(ctx context.Context, projectID string, limit, offset int) ([]models.WikiPageIndex, int, error) {
-	path := fmt.Sprintf("/projects/%s/wiki/index.json", projectID)
+	path := fmt.Sprintf("/projects/%s/wiki/index.json", url.PathEscape(projectID))
 	var params url.Values
 	if offset > 0 {
 		params = url.Values{}
@@ -34,7 +34,7 @@ func (s *WikiService) Get(ctx context.Context, projectID, page string, includes 
 	var resp struct {
 		WikiPage models.WikiPage `json:"wiki_page"`
 	}
-	if err := s.client.Get(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), params, &resp); err != nil {
+	if err := s.client.Get(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", url.PathEscape(projectID), url.PathEscape(page)), params, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.WikiPage, nil
@@ -45,7 +45,7 @@ func (s *WikiService) GetVersion(ctx context.Context, projectID, page string, ve
 	var resp struct {
 		WikiPage models.WikiPage `json:"wiki_page"`
 	}
-	if err := s.client.Get(ctx, fmt.Sprintf("/projects/%s/wiki/%s/%d.json", projectID, page, version), nil, &resp); err != nil {
+	if err := s.client.Get(ctx, fmt.Sprintf("/projects/%s/wiki/%s/%d.json", url.PathEscape(projectID), url.PathEscape(page), version), nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.WikiPage, nil
@@ -54,16 +54,16 @@ func (s *WikiService) GetVersion(ctx context.Context, projectID, page string, ve
 // Create creates a new wiki page (or overwrites an existing one).
 func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki models.WikiPageCreate) error {
 	body := map[string]interface{}{"wiki_page": wiki}
-	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), body)
+	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", url.PathEscape(projectID), url.PathEscape(page)), body)
 }
 
 // Update updates an existing wiki page.
 func (s *WikiService) Update(ctx context.Context, projectID, page string, update models.WikiPageUpdate) error {
 	body := map[string]interface{}{"wiki_page": update}
-	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page), body)
+	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", url.PathEscape(projectID), url.PathEscape(page)), body)
 }
 
 // Delete deletes a wiki page.
 func (s *WikiService) Delete(ctx context.Context, projectID, page string) error {
-	return s.client.Delete(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", projectID, page))
+	return s.client.Delete(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", url.PathEscape(projectID), url.PathEscape(page)))
 }

--- a/internal/api/wiki.go
+++ b/internal/api/wiki.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -52,9 +53,20 @@ func (s *WikiService) GetVersion(ctx context.Context, projectID, page string, ve
 }
 
 // Create creates a new wiki page (or overwrites an existing one).
-func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki models.WikiPageCreate) error {
+func (s *WikiService) Create(ctx context.Context, projectID, page string, wiki models.WikiPageCreate) (*models.WikiPage, error) {
 	body := map[string]interface{}{"wiki_page": wiki}
-	return s.client.Put(ctx, fmt.Sprintf("/projects/%s/wiki/%s.json", url.PathEscape(projectID), url.PathEscape(page)), body)
+	path := fmt.Sprintf("/projects/%s/wiki/%s.json", url.PathEscape(projectID), url.PathEscape(page))
+	var resp struct {
+		WikiPage models.WikiPage `json:"wiki_page"`
+	}
+	if err := s.client.doWithBody(ctx, http.MethodPut, path, body, &resp); err != nil {
+		return nil, err
+	}
+	if resp.WikiPage.Title != "" {
+		return &resp.WikiPage, nil
+	}
+	// Fallback: some Redmine versions return an empty body; fetch the page back.
+	return s.Get(ctx, projectID, page, nil)
 }
 
 // Update updates an existing wiki page.

--- a/internal/api/wiki_test.go
+++ b/internal/api/wiki_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/internal/models"
+)
+
+func TestWikiService_Get_URLEscaping(t *testing.T) {
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use EscapedPath to see the %-encoded form; r.URL.Path is decoded.
+		gotPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"wiki_page":{"title":"My Page/Draft","version":1}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	_, err := c.Wikis.Get(context.Background(), "foo", "My Page/Draft", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "My Page/Draft" must be a single escaped path segment, not split into "My Page" and "Draft".
+	want := "/projects/foo/wiki/My%20Page%2FDraft.json"
+	if gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestWikiService_Get_WithIncludes(t *testing.T) {
+	var gotQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"wiki_page":{"title":"Test","version":1}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	_, err := c.Wikis.Get(context.Background(), "proj", "Test", []string{"attachments"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotQuery != "include=attachments" {
+		t.Errorf("query = %q, want include=attachments", gotQuery)
+	}
+}
+
+func TestWikiService_GetVersion(t *testing.T) {
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"wiki_page":{"title":"Test","version":3}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	_, err := c.Wikis.GetVersion(context.Background(), "proj", "Test", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "/projects/proj/wiki/Test/3.json"
+	if gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestWikiService_Create_Body(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]interface{}
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"wiki_page":{"title":"NewPage","version":1}}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	page, err := c.Wikis.Create(context.Background(), "proj", "NewPage", models.WikiPageCreate{
+		Text:     "Hello world",
+		Comments: "created",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page == nil {
+		t.Fatal("expected non-nil page")
+	}
+	if page.Title != "NewPage" {
+		t.Errorf("page.Title = %q, want NewPage", page.Title)
+	}
+	if page.Version != 1 {
+		t.Errorf("page.Version = %d, want 1", page.Version)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	wantPath := "/projects/proj/wiki/NewPage.json"
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+	wp, ok := gotBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing wiki_page key")
+	}
+	if wp["text"] != "Hello world" {
+		t.Errorf("text = %v, want Hello world", wp["text"])
+	}
+	if wp["comments"] != "created" {
+		t.Errorf("comments = %v, want created", wp["comments"])
+	}
+}
+
+func TestWikiService_Update_TextFallback(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]interface{}
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	existingText := "the original page content"
+	err := c.Wikis.Update(context.Background(), "proj", "MyPage", models.WikiPageUpdate{
+		Text: &existingText,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	wantPath := "/projects/proj/wiki/MyPage.json"
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+	wp, ok := gotBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing wiki_page key")
+	}
+	if wp["text"] != existingText {
+		t.Errorf("text = %v, want %q", wp["text"], existingText)
+	}
+}
+
+func TestWikiService_Delete(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	err := c.Wikis.Delete(context.Background(), "proj", "OldPage")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	wantPath := "/projects/proj/wiki/OldPage.json"
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aarondpn/redmine-cli/internal/cmd/update"
 	"github.com/aarondpn/redmine-cli/internal/cmd/user"
 	versioncmd "github.com/aarondpn/redmine-cli/internal/cmd/version"
+	"github.com/aarondpn/redmine-cli/internal/cmd/wiki"
 	"github.com/aarondpn/redmine-cli/internal/cmdutil"
 	"github.com/aarondpn/redmine-cli/internal/config"
 	"github.com/aarondpn/redmine-cli/internal/debug"
@@ -85,6 +86,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(status.NewCmdStatuses(f))
 	cmd.AddCommand(versioncmd.NewCmdVersions(f))
 	cmd.AddCommand(search.NewCmdSearch(f))
+	cmd.AddCommand(wiki.NewCmdWiki(f))
 	cmd.AddCommand(completion.NewCmdCompletion())
 	cmd.AddCommand(installskill.NewCmdInstallSkill(f))
 	cmd.AddCommand(update.NewCmdUpdate(version))

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -75,7 +75,7 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
 	cmd.Flags().StringVarP(&text, "text", "t", "", "Page content in Textile/Markdown (required)")
 	cmd.Flags().StringVar(&title, "title", "", "Display title (defaults to page name)")
 	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -1,0 +1,76 @@
+package wiki
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/models"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project  string
+		text     string
+		title    string
+		comments string
+		format   string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "create <page>",
+		Aliases: []string{"new"},
+		Short:   "Create a wiki page",
+		Long:    "Create a new Redmine wiki page (or overwrite an existing one).",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			create := models.WikiPageCreate{
+				Text: text,
+			}
+			if title != "" {
+				create.Title = title
+			}
+			if comments != "" {
+				create.Comments = comments
+			}
+
+			page, err := client.Wikis.Create(context.Background(), projectID, args[0], create)
+			if err != nil {
+				return err
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(page)
+				return nil
+			}
+
+			printer.Success(fmt.Sprintf("Wiki page %q created (version %d)", args[0], page.Version))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVarP(&text, "text", "t", "", "Page content in Textile/Markdown (required)")
+	cmd.Flags().StringVar(&title, "title", "", "Display title (defaults to page name)")
+	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")
+	cmdutil.AddOutputFlag(cmd, &format)
+
+	_ = cmd.MarkFlagRequired("text")
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+
+	return cmd
+}

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -40,10 +40,6 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			if text == "" {
-				return fmt.Errorf("--text must not be empty")
-			}
-
 			create := models.WikiPageCreate{
 				Text: text,
 			}

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -59,9 +59,11 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				create.Uploads = uploads
 			}
 
+			stop := printer.Spinner("Creating wiki page...")
 			err = client.Wikis.Create(ctx, projectID, args[0], create)
+			stop()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create wiki page %q: %w", args[0], err)
 			}
 
 			if printer.Format() == output.FormatJSON {

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -26,7 +26,17 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"new"},
 		Short:   "Create a wiki page",
 		Long:    "Create a new Redmine wiki page (or overwrite an existing one).",
-		Args:    cobra.ExactArgs(1),
+		Example: `  # Create a new wiki page
+  redmine wiki create MyPage --project myproject --text "h1. Hello World"
+
+  # With display title and change comment
+  redmine wiki create MyPage --project myproject --text "Content here" \
+    --title "My Page" --comments "Initial draft"
+
+  # Attach a file
+  redmine wiki create MyPage --project myproject --text "See diagram" \
+    --attach ./diagram.png`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -70,14 +70,13 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			stop := printer.Spinner("Creating wiki page...")
-			err = client.Wikis.Create(ctx, projectID, args[0], create)
+			page, err := client.Wikis.Create(ctx, projectID, args[0], create)
 			stop()
 			if err != nil {
 				return fmt.Errorf("failed to create wiki page %q: %w", args[0], err)
 			}
 
 			if printer.Format() == output.FormatJSON {
-				page, _ := client.Wikis.Get(ctx, projectID, args[0], nil)
 				printer.JSON(page)
 				return nil
 			}

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -81,7 +81,11 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				return nil
 			}
 
-			printer.Success(fmt.Sprintf("Wiki page %q created", args[0]))
+			effective := args[0]
+			if page.Title != "" {
+				effective = page.Title
+			}
+			printer.Success(fmt.Sprintf("Wiki page %q created", effective))
 			return nil
 		},
 	}

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -27,15 +27,21 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		Long:    "Create a new Redmine wiki page (or overwrite an existing one).",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
 			}
 			printer := f.Printer(format)
 
-			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
 			if err != nil {
 				return err
+			}
+
+			if text == "" {
+				return fmt.Errorf("--text must not be empty")
 			}
 
 			create := models.WikiPageCreate{
@@ -48,17 +54,18 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				create.Comments = comments
 			}
 
-			page, err := client.Wikis.Create(context.Background(), projectID, args[0], create)
+			err = client.Wikis.Create(ctx, projectID, args[0], create)
 			if err != nil {
 				return err
 			}
 
 			if printer.Format() == output.FormatJSON {
+				page, _ := client.Wikis.Get(ctx, projectID, args[0], nil)
 				printer.JSON(page)
 				return nil
 			}
 
-			printer.Success(fmt.Sprintf("Wiki page %q created (version %d)", args[0], page.Version))
+			printer.Success(fmt.Sprintf("Wiki page %q created", args[0]))
 			return nil
 		},
 	}

--- a/internal/cmd/wiki/create.go
+++ b/internal/cmd/wiki/create.go
@@ -17,6 +17,7 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		text     string
 		title    string
 		comments string
+		attach   []string
 		format   string
 	)
 
@@ -50,6 +51,14 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				create.Comments = comments
 			}
 
+			if len(attach) > 0 {
+				uploads, err := cmdutil.UploadAttachments(ctx, client, attach)
+				if err != nil {
+					return err
+				}
+				create.Uploads = uploads
+			}
+
 			err = client.Wikis.Create(ctx, projectID, args[0], create)
 			if err != nil {
 				return err
@@ -70,6 +79,7 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&text, "text", "t", "", "Page content in Textile/Markdown (required)")
 	cmd.Flags().StringVar(&title, "title", "", "Display title (defaults to page name)")
 	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")
+	cmd.Flags().StringArrayVar(&attach, "attach", nil, "Path to file to attach (repeatable)")
 	cmdutil.AddOutputFlag(cmd, &format)
 
 	_ = cmd.MarkFlagRequired("text")

--- a/internal/cmd/wiki/delete.go
+++ b/internal/cmd/wiki/delete.go
@@ -22,13 +22,15 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 		Long:    "Delete a Redmine wiki page.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
 			}
 			printer := f.Printer("")
 
-			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
 			if err != nil {
 				return err
 			}
@@ -43,7 +45,7 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			err = client.Wikis.Delete(context.Background(), projectID, pageTitle)
+			err = client.Wikis.Delete(ctx, projectID, pageTitle)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/wiki/delete.go
+++ b/internal/cmd/wiki/delete.go
@@ -1,0 +1,62 @@
+package wiki
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project string
+		force   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "delete <page>",
+		Aliases: []string{"rm"},
+		Short:   "Delete a wiki page",
+		Long:    "Delete a Redmine wiki page.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer("")
+
+			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			pageTitle := args[0]
+
+			if !force {
+				msg := fmt.Sprintf("Are you sure you want to delete wiki page %q?", pageTitle)
+				if !cmdutil.ConfirmAction(f.IOStreams.In, f.IOStreams.ErrOut, msg) {
+					printer.Warning("Deletion cancelled")
+					return nil
+				}
+			}
+
+			err = client.Wikis.Delete(context.Background(), projectID, pageTitle)
+			if err != nil {
+				return err
+			}
+
+			printer.Success(fmt.Sprintf("Wiki page %q deleted", pageTitle))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmdutil.AddForceFlag(cmd, &force)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+
+	return cmd
+}

--- a/internal/cmd/wiki/delete.go
+++ b/internal/cmd/wiki/delete.go
@@ -20,7 +20,12 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a wiki page",
 		Long:    "Delete a Redmine wiki page.\n\nThis also removes all attachments and the page history.\nAny child pages will be re-parented to the wiki root.",
-		Args:    cobra.ExactArgs(1),
+		Example: `  # Delete with confirmation prompt
+  redmine wiki delete MyPage --project myproject
+
+  # Skip confirmation
+  redmine wiki delete MyPage --project myproject --force`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/internal/cmd/wiki/delete.go
+++ b/internal/cmd/wiki/delete.go
@@ -45,9 +45,11 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			stop := printer.Spinner("Deleting wiki page...")
 			err = client.Wikis.Delete(ctx, projectID, pageTitle)
+			stop()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to delete wiki page %q: %w", pageTitle, err)
 			}
 
 			printer.Success(fmt.Sprintf("Wiki page %q deleted", pageTitle))

--- a/internal/cmd/wiki/delete.go
+++ b/internal/cmd/wiki/delete.go
@@ -19,7 +19,7 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 		Use:     "delete <page>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a wiki page",
-		Long:    "Delete a Redmine wiki page.",
+		Long:    "Delete a Redmine wiki page.\n\nThis also removes all attachments and the page history.\nAny child pages will be re-parented to the wiki root.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -38,7 +38,7 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 			pageTitle := args[0]
 
 			if !force {
-				msg := fmt.Sprintf("Are you sure you want to delete wiki page %q?", pageTitle)
+				msg := fmt.Sprintf("Delete wiki page %q?\nThis also removes all attachments and the page history. Any child pages will be re-parented to the wiki root.", pageTitle)
 				if !cmdutil.ConfirmAction(f.IOStreams.In, f.IOStreams.ErrOut, msg) {
 					printer.Warning("Deletion cancelled")
 					return nil

--- a/internal/cmd/wiki/delete.go
+++ b/internal/cmd/wiki/delete.go
@@ -55,7 +55,7 @@ func newCmdDelete(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
 	cmdutil.AddForceFlag(cmd, &force)
 
 	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -27,13 +27,15 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 		Long:    "Display detailed information about a Redmine wiki page.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
 			}
 			printer := f.Printer(format)
 
-			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
 			if err != nil {
 				return err
 			}
@@ -42,9 +44,9 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 
 			var page *models.WikiPage
 			if version > 0 {
-				page, err = client.Wikis.GetVersion(context.Background(), projectID, pageTitle, version)
+				page, err = client.Wikis.GetVersion(ctx, projectID, pageTitle, version)
 			} else {
-				page, err = client.Wikis.Get(context.Background(), projectID, pageTitle, include)
+				page, err = client.Wikis.Get(ctx, projectID, pageTitle, include)
 			}
 			if err != nil {
 				return err
@@ -88,13 +90,11 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			printer.Detail(pairs)
-
-			// Print page text content separately for readability.
 			if page.Text != "" {
-				fmt.Println()
-				fmt.Println(page.Text)
+				pairs = append(pairs, output.KeyValue{Key: "Content", Value: page.Text})
 			}
+
+			printer.Detail(pairs)
 
 			return nil
 		},

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -25,7 +25,15 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"show"},
 		Short:   "Get wiki page details",
 		Long:    "Display detailed information about a Redmine wiki page.",
-		Args:    cobra.ExactArgs(1),
+		Example: `  # View a wiki page
+  redmine wiki get WikiStart --project myproject
+
+  # View a specific version
+  redmine wiki get WikiStart --project myproject --version 3
+
+  # Include attachments
+  redmine wiki get WikiStart --project myproject --include attachments`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -42,14 +42,16 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 
 			pageTitle := args[0]
 
+			stop := printer.Spinner("Fetching wiki page...")
 			var page *models.WikiPage
 			if version > 0 {
 				page, err = client.Wikis.GetVersion(ctx, projectID, pageTitle, version)
 			} else {
 				page, err = client.Wikis.Get(ctx, projectID, pageTitle, include)
 			}
+			stop()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get wiki page %q: %w", pageTitle, err)
 			}
 
 			if printer.Format() == output.FormatJSON {

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -1,0 +1,111 @@
+package wiki
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/models"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+func newCmdGet(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project string
+		version int
+		include []string
+		format  string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "get <page>",
+		Aliases: []string{"show"},
+		Short:   "Get wiki page details",
+		Long:    "Display detailed information about a Redmine wiki page.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			pageTitle := args[0]
+
+			var page *models.WikiPage
+			if version > 0 {
+				page, err = client.Wikis.GetVersion(context.Background(), projectID, pageTitle, version)
+			} else {
+				page, err = client.Wikis.Get(context.Background(), projectID, pageTitle, include)
+			}
+			if err != nil {
+				return err
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(page)
+				return nil
+			}
+
+			pairs := []output.KeyValue{
+				{Key: "Title", Value: output.StyleID.Render(page.Title)},
+				{Key: "Version", Value: strconv.Itoa(page.Version)},
+			}
+
+			if page.Author != nil {
+				pairs = append(pairs, output.KeyValue{Key: "Author", Value: page.Author.Name})
+			}
+			if page.Comments != "" {
+				pairs = append(pairs, output.KeyValue{Key: "Comments", Value: page.Comments})
+			}
+			if page.Parent != nil {
+				pairs = append(pairs, output.KeyValue{Key: "Parent", Value: page.Parent.Title})
+			}
+
+			pairs = append(pairs,
+				output.KeyValue{Key: "Created", Value: page.CreatedOn},
+				output.KeyValue{Key: "Updated", Value: page.UpdatedOn},
+			)
+
+			if len(page.Attachments) > 0 {
+				pairs = append(pairs, output.KeyValue{
+					Key:   "Attachments",
+					Value: fmt.Sprintf("%d file(s)", len(page.Attachments)),
+				})
+				for _, a := range page.Attachments {
+					pairs = append(pairs, output.KeyValue{
+						Key:   fmt.Sprintf("  %s", a.Filename),
+						Value: fmt.Sprintf("%s (%d bytes)", a.Description, a.Filesize),
+					})
+				}
+			}
+
+			printer.Detail(pairs)
+
+			// Print page text content separately for readability.
+			if page.Text != "" {
+				fmt.Println()
+				fmt.Println(page.Text)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().IntVar(&version, "version", 0, "Page version (0 for latest)")
+	cmd.Flags().StringSliceVar(&include, "include", nil, "Include additional data (attachments)")
+	cmdutil.AddOutputFlag(cmd, &format)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+
+	return cmd
+}

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -100,7 +100,7 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
 	cmd.Flags().IntVar(&version, "version", 0, "Page version (0 for latest)")
 	cmd.Flags().StringSliceVar(&include, "include", nil, "Include additional data (attachments)")
 	cmdutil.AddOutputFlag(cmd, &format)

--- a/internal/cmd/wiki/list.go
+++ b/internal/cmd/wiki/list.go
@@ -23,18 +23,20 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 		Short:   "List wiki pages",
 		Long:    "List wiki pages in a Redmine project.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
 			}
 			printer := f.Printer(format)
 
-			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
 			if err != nil {
 				return err
 			}
 
-			pages, total, err := client.Wikis.List(context.Background(), projectID, limit, offset)
+			pages, total, err := client.Wikis.List(ctx, projectID, limit, offset)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/wiki/list.go
+++ b/internal/cmd/wiki/list.go
@@ -75,7 +75,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
 	cmdutil.AddPaginationFlags(cmd, &limit, &offset)
 	cmdutil.AddOutputFlag(cmd, &format)
 

--- a/internal/cmd/wiki/list.go
+++ b/internal/cmd/wiki/list.go
@@ -1,0 +1,83 @@
+package wiki
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/output"
+)
+
+func newCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project string
+		limit   int
+		offset  int
+		format  string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List wiki pages",
+		Long:    "List wiki pages in a Redmine project.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			pages, total, err := client.Wikis.List(context.Background(), projectID, limit, offset)
+			if err != nil {
+				return err
+			}
+
+			if cmdutil.HandleEmpty(printer, pages, "wiki pages") {
+				return nil
+			}
+
+			headers := []string{"Title", "Updated"}
+
+			switch printer.Format() {
+			case output.FormatJSON:
+				printer.JSON(pages)
+			case output.FormatCSV:
+				rows := make([][]string, 0, len(pages))
+				for _, p := range pages {
+					rows = append(rows, []string{p.Title, p.UpdatedOn})
+				}
+				printer.CSV(headers, rows)
+			default:
+				rows := make([][]string, 0, len(pages))
+				for _, p := range pages {
+					rows = append(rows, []string{
+						output.StyleID.Render(p.Title),
+						p.UpdatedOn,
+					})
+				}
+				printer.Table(headers, rows)
+			}
+
+			cmdutil.WarnPagination(printer, cmdutil.PaginationResult{
+				Shown: len(pages), Total: total, Limit: limit, Offset: offset, Noun: "wiki pages",
+			})
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmdutil.AddPaginationFlags(cmd, &limit, &offset)
+	cmdutil.AddOutputFlag(cmd, &format)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+
+	return cmd
+}

--- a/internal/cmd/wiki/list.go
+++ b/internal/cmd/wiki/list.go
@@ -2,6 +2,7 @@ package wiki
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -36,9 +37,11 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
+			stop := printer.Spinner("Fetching wiki pages...")
 			pages, total, err := client.Wikis.List(ctx, projectID, limit, offset)
+			stop()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to list wiki pages: %w", err)
 			}
 
 			if cmdutil.HandleEmpty(printer, pages, "wiki pages") {

--- a/internal/cmd/wiki/list.go
+++ b/internal/cmd/wiki/list.go
@@ -23,6 +23,14 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List wiki pages",
 		Long:    "List wiki pages in a Redmine project.",
+		Example: `  # List wiki pages in a project
+  redmine wiki list --project myproject
+
+  # JSON output
+  redmine wiki list --project myproject --output json
+
+  # Paginate results
+  redmine wiki list --project myproject --limit 10 --offset 20`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -16,6 +16,7 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		text     string
 		title    string
 		comments string
+		attach   []string
 	)
 
 	cmd := &cobra.Command{
@@ -58,6 +59,14 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				update.Comments = &comments
 			}
 
+			if len(attach) > 0 {
+				uploads, err := cmdutil.UploadAttachments(ctx, client, attach)
+				if err != nil {
+					return err
+				}
+				update.Uploads = uploads
+			}
+
 			err = client.Wikis.Update(ctx, projectID, args[0], update)
 			if err != nil {
 				return err
@@ -72,6 +81,7 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&text, "text", "t", "", "Page content in Textile/Markdown")
 	cmd.Flags().StringVar(&title, "title", "", "Display title")
 	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")
+	cmd.Flags().StringArrayVar(&attach, "attach", nil, "Path to file to attach (repeatable)")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
 

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -25,13 +25,15 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		Long:    "Update an existing Redmine wiki page.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
 			client, err := f.ApiClient()
 			if err != nil {
 				return err
 			}
 			printer := f.Printer("")
 
-			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
 			if err != nil {
 				return err
 			}
@@ -48,7 +50,7 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				update.Comments = &comments
 			}
 
-			err = client.Wikis.Update(context.Background(), projectID, args[0], update)
+			err = client.Wikis.Update(ctx, projectID, args[0], update)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -42,6 +42,14 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 			if cmd.Flags().Changed("text") {
 				update.Text = &text
+			} else {
+				// Redmine requires the text field on every PUT.
+				// Fetch the current page and resend its text unchanged.
+				current, err := client.Wikis.Get(ctx, projectID, args[0], nil)
+				if err != nil {
+					return err
+				}
+				update.Text = &current.Text
 			}
 			if cmd.Flags().Changed("title") {
 				update.Title = &title

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -48,7 +48,7 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				// Fetch the current page and resend its text unchanged.
 				current, err := client.Wikis.Get(ctx, projectID, args[0], nil)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to fetch current wiki page %q: %w", args[0], err)
 				}
 				update.Text = &current.Text
 			}
@@ -67,9 +67,11 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				update.Uploads = uploads
 			}
 
+			stop := printer.Spinner("Updating wiki page...")
 			err = client.Wikis.Update(ctx, projectID, args[0], update)
+			stop()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to update wiki page %q: %w", args[0], err)
 			}
 
 			printer.Success(fmt.Sprintf("Wiki page %q updated", args[0]))

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -1,0 +1,69 @@
+package wiki
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/internal/models"
+)
+
+func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project  string
+		text     string
+		title    string
+		comments string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "update <page>",
+		Aliases: []string{"edit"},
+		Short:   "Update a wiki page",
+		Long:    "Update an existing Redmine wiki page.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer("")
+
+			projectID, err := cmdutil.RequireProjectIdentifier(context.Background(), f, project)
+			if err != nil {
+				return err
+			}
+
+			update := models.WikiPageUpdate{}
+
+			if cmd.Flags().Changed("text") {
+				update.Text = &text
+			}
+			if cmd.Flags().Changed("title") {
+				update.Title = &title
+			}
+			if cmd.Flags().Changed("comments") {
+				update.Comments = &comments
+			}
+
+			err = client.Wikis.Update(context.Background(), projectID, args[0], update)
+			if err != nil {
+				return err
+			}
+
+			printer.Success(fmt.Sprintf("Wiki page %q updated", args[0]))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVarP(&text, "text", "t", "", "Page content in Textile/Markdown")
+	cmd.Flags().StringVar(&title, "title", "", "Display title")
+	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+
+	return cmd
+}

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -24,7 +24,18 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"edit"},
 		Short:   "Update a wiki page",
 		Long:    "Update an existing Redmine wiki page.",
-		Args:    cobra.ExactArgs(1),
+		Example: `  # Update page content
+  redmine wiki update MyPage --project myproject --text "Updated content"
+
+  # Update with a change comment (text is preserved when omitted)
+  redmine wiki update MyPage --project myproject --comments "Fixed typo"
+
+  # Rename a page
+  redmine wiki update MyPage --project myproject --title "New Title"
+
+  # Attach a file
+  redmine wiki update MyPage --project myproject --attach ./screenshot.png`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -77,7 +77,7 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&project, "project", "p", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
 	cmd.Flags().StringVarP(&text, "text", "t", "", "Page content in Textile/Markdown")
 	cmd.Flags().StringVar(&title, "title", "", "Display title")
 	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")

--- a/internal/cmd/wiki/wiki.go
+++ b/internal/cmd/wiki/wiki.go
@@ -1,0 +1,25 @@
+package wiki
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/internal/cmdutil"
+)
+
+// NewCmdWiki creates the parent wiki command.
+func NewCmdWiki(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "wiki",
+		Aliases: []string{"w"},
+		Short:   "Manage Redmine wiki pages",
+		Long:    "List, view, create, update, and delete Redmine wiki pages.",
+	}
+
+	cmd.AddCommand(newCmdList(f))
+	cmd.AddCommand(newCmdGet(f))
+	cmd.AddCommand(newCmdCreate(f))
+	cmd.AddCommand(newCmdUpdate(f))
+	cmd.AddCommand(newCmdDelete(f))
+
+	return cmd
+}

--- a/internal/models/wiki.go
+++ b/internal/models/wiki.go
@@ -38,14 +38,16 @@ type WikiPageIndex struct {
 
 // WikiPageCreate defines fields for creating a wiki page.
 type WikiPageCreate struct {
-	Text     string `json:"text"`
-	Comments string `json:"comments,omitempty"`
-	Title    string `json:"title,omitempty"`
+	Text     string   `json:"text"`
+	Comments string   `json:"comments,omitempty"`
+	Title    string   `json:"title,omitempty"`
+	Uploads  []Upload `json:"uploads,omitempty"`
 }
 
 // WikiPageUpdate defines fields for updating a wiki page.
 type WikiPageUpdate struct {
-	Text     *string `json:"text,omitempty"`
-	Comments *string `json:"comments,omitempty"`
-	Title    *string `json:"title,omitempty"`
+	Text     *string  `json:"text,omitempty"`
+	Comments *string  `json:"comments,omitempty"`
+	Title    *string  `json:"title,omitempty"`
+	Uploads  []Upload `json:"uploads,omitempty"`
 }

--- a/internal/models/wiki.go
+++ b/internal/models/wiki.go
@@ -1,0 +1,51 @@
+package models
+
+// WikiPage represents a Redmine wiki page.
+type WikiPage struct {
+	Title       string         `json:"title"`
+	Text        string         `json:"text"`
+	Comments    string         `json:"comments,omitempty"`
+	Version     int            `json:"version"`
+	Author      *IDName        `json:"author,omitempty"`
+	UpdatedOn   string         `json:"updated_on"`
+	CreatedOn   string         `json:"created_on"`
+	Parent      *WikiPageTitle `json:"parent,omitempty"`
+	Attachments []Attachment   `json:"attachments,omitempty"`
+}
+
+// WikiPageTitle is a minimal reference used for parent pages.
+type WikiPageTitle struct {
+	Title string `json:"title"`
+}
+
+// Attachment represents a file attached to a wiki page.
+type Attachment struct {
+	ID          int    `json:"id"`
+	Filename    string `json:"filename"`
+	Filesize    int64  `json:"filesize"`
+	ContentType string `json:"content_type"`
+	Description string `json:"description"`
+	ContentURL  string `json:"content_url"`
+	Author      IDName `json:"author"`
+	CreatedOn   string `json:"created_on"`
+}
+
+// WikiPageIndex represents a wiki page entry in the index listing.
+type WikiPageIndex struct {
+	Title     string `json:"title"`
+	UpdatedOn string `json:"updated_on"`
+}
+
+// WikiPageCreate defines fields for creating a wiki page.
+type WikiPageCreate struct {
+	Text     string `json:"text"`
+	Comments string `json:"comments,omitempty"`
+	Title    string `json:"title,omitempty"`
+}
+
+// WikiPageUpdate defines fields for updating a wiki page.
+type WikiPageUpdate struct {
+	Text     *string `json:"text,omitempty"`
+	Comments *string `json:"comments,omitempty"`
+	Title    *string `json:"title,omitempty"`
+}

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -25,6 +25,7 @@ Only these top-level commands exist. Do NOT invent subcommands that aren't liste
 | `statuses` | List issue statuses |
 | `search` | Search issues, wiki, news, messages, or browse results |
 | `auth` | Login, logout, list, switch, and check status of authentication profiles |
+| `wiki` | List, get, create, update, delete wiki pages |
 | `api` | Make raw authenticated API requests |
 
 ## Setup


### PR DESCRIPTION
 * Introduce `redmine wiki` command to manage Redmine wiki pages
 * Implement subcommands: `list`, `get`, `create`, `update`, and `delete`
 * Add `WikiService` for API interactions with Redmine wiki endpoints
 * Define Go models for wiki page structures (e.g., `WikiPage`, `Attachment`)
 * Include comprehensive documentation for the new command