### PR TITLE
docs: add Google Search Console verification meta tag

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -9,3 +9,4 @@ const xDefault = new URL(enPath, Astro.site).href;
 
 <Default />
 <link rel="alternate" hreflang="x-default" href={xDefault} />
+<meta name="google-site-verification" content="M0pwCLME5lw429GlQb1h_mmr_qon2ASeuZyOmD8c4aQ" />


### PR DESCRIPTION
Adds the Google Search Console verification meta tag to Head.astro so the GitHub Pages site can be verified as a URL-prefix property.