### PR TITLE
test(e2e): add Docker-based end-to-end test harness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,89 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'e2e/**'
+      - 'internal/**'
+      - '!internal/**/*_test.go'
+      - 'main.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/e2e.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'e2e/**'
+      - 'internal/**'
+      - '!internal/**/*_test.go'
+      - 'main.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Redmine version(s) to test
+        type: choice
+        options:
+          - default
+          - '4.2'
+          - '5.1'
+          - '6.1'
+          - all
+        default: default
+
+jobs:
+  prepare:
+    name: Select versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.select.outputs.versions }}
+    steps:
+      - id: select
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          case "${INPUT_VERSION:-default}" in
+            all)
+              echo 'versions=["4.2","5.1","6.1"]' >> "$GITHUB_OUTPUT"
+              ;;
+            4.2|5.1|6.1)
+              echo "versions=[\"${INPUT_VERSION}\"]" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo 'versions=["6.1"]' >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  e2e:
+    name: Redmine ${{ matrix.version }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.prepare.outputs.versions) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      - name: Bring up Redmine ${{ matrix.version }}
+        run: make e2e-up E2E_VERSION=${{ matrix.version }}
+
+      - name: Run e2e suite
+        run: make e2e-test E2E_VERSION=${{ matrix.version }}
+
+      - name: Dump container logs
+        if: failure()
+        run: make e2e-logs E2E_VERSION=${{ matrix.version }}
+
+      - name: Tear down
+        if: always()
+        run: make e2e-down E2E_VERSION=${{ matrix.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/node_modules/
 docs/dist/
 docs/.astro/
 .claude/
+.redmine-cli.e2e.yaml

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ E2E_PROJECT_NAME ?= e2e-$(subst .,-,$(E2E_VERSION))
 E2E_PASSWORD ?= admintest123
 SUPPORTED_E2E_VERSIONS=4.2 5.1 6.1
 
-.PHONY: build test lint clean install e2e-up e2e-down e2e-config e2e-test e2e-matrix
+.PHONY: build test lint clean install e2e-up e2e-down e2e-config e2e-test e2e-logs e2e-matrix
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY_NAME) .
@@ -48,6 +48,9 @@ e2e-test:
 		COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) \
 		REDMINE_E2E_API_KEY="$$(COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) ./e2e/admin-api-key.sh)" \
 		go test -tags=e2e ./e2e -v
+
+e2e-logs:
+	COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) docker compose -f $(E2E_COMPOSE_FILE) logs --no-color
 
 e2e-matrix:
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
 BINARY_NAME=redmine
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+E2E_COMPOSE_FILE=e2e/compose.yaml
+E2E_VERSION ?= 6.1
+E2E_IMAGE ?= redmine:$(E2E_VERSION)
+E2E_PORT ?= 3000
+E2E_BASE_URL ?= http://127.0.0.1:$(E2E_PORT)
+E2E_PROJECT_NAME ?= e2e-$(subst .,-,$(E2E_VERSION))
+# Admin password the e2e bootstrap forces onto the Redmine admin user. Set
+# empty to skip the password reset (in which case basic-auth tests will
+# be skipped as well).
+E2E_PASSWORD ?= admintest123
+SUPPORTED_E2E_VERSIONS=4.2 5.1 6.1
 
-.PHONY: build test lint clean install
+.PHONY: build test lint clean install e2e-up e2e-down e2e-config e2e-test e2e-matrix
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY_NAME) .
@@ -18,3 +29,37 @@ clean:
 
 install:
 	go install $(LDFLAGS) .
+
+e2e-up:
+	COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) REDMINE_IMAGE=$(E2E_IMAGE) REDMINE_E2E_PORT=$(E2E_PORT) docker compose -f $(E2E_COMPOSE_FILE) up -d
+	COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) REDMINE_E2E_BASE_URL=$(E2E_BASE_URL) ./e2e/wait-for-redmine.sh
+	COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) REDMINE_E2E_PASSWORD=$(E2E_PASSWORD) ./e2e/bootstrap-redmine.sh
+
+e2e-down:
+	COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) docker compose -f $(E2E_COMPOSE_FILE) down -v
+
+e2e-config:
+	COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) REDMINE_E2E_BASE_URL=$(E2E_BASE_URL) ./e2e/write-config.sh
+
+e2e-test:
+	REDMINE_E2E=1 REDMINE_NO_UPDATE_CHECK=1 \
+		REDMINE_E2E_BASE_URL=$(E2E_BASE_URL) \
+		REDMINE_E2E_PASSWORD=$(E2E_PASSWORD) \
+		COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) \
+		REDMINE_E2E_API_KEY="$$(COMPOSE_PROJECT_NAME=$(E2E_PROJECT_NAME) ./e2e/admin-api-key.sh)" \
+		go test -tags=e2e ./e2e -v
+
+e2e-matrix:
+	@set -e; \
+	for version in $(SUPPORTED_E2E_VERSIONS); do \
+		case "$$version" in \
+			4.2) port=3402 ;; \
+			5.1) port=3501 ;; \
+			6.1) port=3601 ;; \
+			*) port=3000 ;; \
+		esac; \
+		echo "==> Testing Redmine $$version"; \
+		$(MAKE) e2e-up E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=e2e-$$(echo $$version | tr . -); \
+		$(MAKE) e2e-test E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=e2e-$$(echo $$version | tr . -); \
+		$(MAKE) e2e-down E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=e2e-$$(echo $$version | tr . -); \
+	done

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,15 @@ e2e-matrix:
 			6.1) port=3601 ;; \
 			*) port=3000 ;; \
 		esac; \
+		project_name=e2e-$$(echo $$version | tr . -); \
 		echo "==> Testing Redmine $$version"; \
-		$(MAKE) e2e-up E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=e2e-$$(echo $$version | tr . -); \
-		$(MAKE) e2e-test E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=e2e-$$(echo $$version | tr . -); \
-		$(MAKE) e2e-down E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=e2e-$$(echo $$version | tr . -); \
+		status=0; \
+		$(MAKE) e2e-up E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=$$project_name || status=$$?; \
+		if [ $$status -eq 0 ]; then \
+			$(MAKE) e2e-test E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=$$project_name || status=$$?; \
+		fi; \
+		$(MAKE) e2e-down E2E_VERSION=$$version E2E_IMAGE=redmine:$$version E2E_PORT=$$port E2E_PROJECT_NAME=$$project_name || status=$$?; \
+		if [ $$status -ne 0 ]; then \
+			exit $$status; \
+		fi; \
 	done

--- a/README.md
+++ b/README.md
@@ -123,3 +123,24 @@ If you prefer not to use the skill installer, you can add the skill reference di
 ```
 
 Or copy the contents of [`skills/redmine-cli/SKILL.md`](skills/redmine-cli/SKILL.md) into your project's `CLAUDE.md` or equivalent agent instructions file.
+
+## Local E2E Testing
+
+If you want to exercise the CLI against a real Redmine instance locally, the repo now includes a Docker-based e2e harness under [e2e/README.md](/Users/aarond/Documents/Projects/github/redmine-cli/e2e/README.md:1).
+
+The setup uses Docker Official Images with Postgres and can target the supported Redmine lines `4.2`, `5.1`, and `6.1`. By default it uses `6.1` on `http://127.0.0.1:3000`. If you want a specific supported line, set `E2E_VERSION=...` before the Make target. If you want to point the harness at a custom image later, set `REDMINE_IMAGE=...`.
+
+```bash
+make e2e-up
+make e2e-config
+make e2e-test
+make e2e-down
+```
+
+Or run the full supported-version matrix:
+
+```bash
+make e2e-matrix
+```
+
+The Go e2e suite creates a real project and issue, checks list/get flows, and verifies close/reopen behavior against the local instance.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,118 @@
+# Local Redmine E2E
+
+This directory contains a local end-to-end harness for `redmine-cli`.
+
+It uses:
+
+- Docker Official Image `redmine:6.1` by default
+- `postgres:16-alpine`
+- The default Redmine admin account to derive an API key for CLI tests
+
+The harness is version-aware. The supported matrix in this repo is:
+
+- `4.2`
+- `5.1`
+- `6.1`
+
+If you want to test a custom image, set `REDMINE_IMAGE` when you start the stack.
+
+## Start Redmine
+
+```bash
+make e2e-up
+```
+
+That starts Docker Compose from [compose.yaml](/Users/aarond/Documents/Projects/github/redmine-cli/e2e/compose.yaml:1), waits until Redmine is reachable, and bootstraps the instance for CLI testing by enabling the Redmine REST API.
+
+To choose a supported Redmine line explicitly:
+
+```bash
+make e2e-up E2E_VERSION=4.2
+make e2e-up E2E_VERSION=5.1
+make e2e-up E2E_VERSION=6.1
+```
+
+To override the Redmine image:
+
+```bash
+REDMINE_IMAGE=your-registry/redmine:7.0-rc make e2e-up
+```
+
+## Write a local CLI config
+
+```bash
+make e2e-config
+```
+
+By default this writes `./.redmine-cli.e2e.yaml` in the repo root using basic auth against `http://127.0.0.1:3000`.
+By default this writes `./.redmine-cli.e2e.yaml` in the repo root using the admin user's Redmine API key against `http://127.0.0.1:3000`.
+
+## Run the Go e2e suite
+
+```bash
+make e2e-test
+```
+
+The tests build the CLI once, then each test provisions its own project/issue
+fixtures (cleaned up via `t.Cleanup`) and drives the CLI against the local
+Redmine instance. The suite is split into topical files:
+
+| File                     | Coverage |
+|--------------------------|----------|
+| `projects_test.go`       | project create / get / list / delete |
+| `issues_test.go`         | issue lifecycle (create/list/close/reopen), update, comment, assign, attachment upload |
+| `issues_list_test.go`    | list filter round-trips (`--status`, `--assignee me`, `--tracker`, bogus tracker error) |
+| `time_entries_test.go`   | time log / list / update / delete with activity resolution |
+| `search_test.go`         | `search --issues` and `search --projects` scope |
+| `auth_test.go`           | basic-auth profile against `/users/current.json` (needs `REDMINE_E2E_PASSWORD`) |
+| `api_test.go`            | raw `api` passthrough GET + POST + PUT with `--input` |
+| `errors_test.go`         | error envelope codes: `not_found`, `auth_failed` |
+
+Shared infrastructure lives in `e2e_test.go` (TestMain + `requireE2E`),
+`runner_test.go` (CLI runner + profile constructors), `helpers_test.go`
+(envelope types + env accessors) and `fixtures_test.go` (project / issue
+fixtures, tracker / activity lookups).
+
+### Adding a new test
+
+1. Create `<feature>_test.go` with `//go:build e2e` at the top.
+2. Call `requireE2E(t)` first.
+3. Build a runner with `newCLIRunner` (API key) or `newCLIRunnerBasicAuth`.
+4. Use `createTestProject` / `createTestIssue` for any write fixtures so
+   cleanup is handled automatically.
+5. Decode CLI JSON output with `runner.runJSON(t, &dest, ...)` and assert on
+   the decoded struct rather than the raw bytes.
+6. For commands that must fail, use `runner.runExpectError(t, ...)` and
+   decode into `errorEnvelope`.
+
+To run the full supported-version matrix sequentially:
+
+```bash
+make e2e-matrix
+```
+
+The matrix uses separate ports per Redmine line to avoid collisions:
+
+- `4.2` -> `http://127.0.0.1:3402`
+- `5.1` -> `http://127.0.0.1:3501`
+- `6.1` -> `http://127.0.0.1:3601`
+
+## Tear it down
+
+```bash
+make e2e-down
+```
+
+## Environment overrides
+
+- `REDMINE_E2E_BASE_URL`
+- `REDMINE_E2E_USERNAME`
+- `REDMINE_E2E_API_KEY`
+- `REDMINE_E2E_PASSWORD` - admin password forced by `bootstrap-redmine.sh` and used by basic-auth tests. `make e2e-up` / `make e2e-test` default this to `admintest123`. Tests that need basic auth are skipped when this is empty.
+- `REDMINE_E2E_TIMEOUT_SECONDS`
+- `REDMINE_E2E_CONFIG_PATH`
+- `REDMINE_E2E_PROFILE_NAME`
+- `REDMINE_IMAGE`
+- `E2E_VERSION`
+- `E2E_PORT`
+- `E2E_PASSWORD` - Makefile-level override for the forced admin password (propagates into `REDMINE_E2E_PASSWORD`).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -44,7 +44,6 @@ REDMINE_IMAGE=your-registry/redmine:7.0-rc make e2e-up
 make e2e-config
 ```
 
-By default this writes `./.redmine-cli.e2e.yaml` in the repo root using basic auth against `http://127.0.0.1:3000`.
 By default this writes `./.redmine-cli.e2e.yaml` in the repo root using the admin user's Redmine API key against `http://127.0.0.1:3000`.
 
 ## Run the Go e2e suite

--- a/e2e/admin-api-key.sh
+++ b/e2e/admin-api-key.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+compose_file="${REDMINE_E2E_COMPOSE_FILE:-e2e/compose.yaml}"
+container_service="${REDMINE_E2E_REDMINE_SERVICE:-redmine}"
+login="${REDMINE_E2E_USERNAME:-admin}"
+
+docker compose -f "$compose_file" exec -T "$container_service" \
+  bundle exec rails runner \
+  "u = User.find_by(login: \"$login\"); abort(\"user not found: $login\") unless u; puts u.api_key" \
+  2>/dev/null | tail -n 1

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAPI_Passthrough_GET exercises the GET path with query params.
+func TestAPI_Passthrough_GET(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	var resp struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	r.runJSON(t, &resp, "api", "/users/current.json")
+	if resp.User.Login != e2eUsername() {
+		t.Fatalf("api GET /users/current.json login = %q, want %q", resp.User.Login, e2eUsername())
+	}
+}
+
+// TestAPI_Passthrough_POSTAndPUT creates an issue via raw POST with an input
+// body file, then updates it via raw PUT. This covers the write-side of the
+// passthrough that the GET test cannot.
+func TestAPI_Passthrough_POSTAndPUT(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	// Look up project ID and first tracker so we can build a valid request.
+	var projectInfo struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &projectInfo, "projects", "get", proj.Identifier)
+	var trackers []struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &trackers, "trackers", "list")
+	if len(trackers) == 0 {
+		t.Fatal("no trackers available")
+	}
+
+	// POST a new issue.
+	subject := "Created via raw POST"
+	createBody, _ := json.Marshal(map[string]any{
+		"issue": map[string]any{
+			"project_id": projectInfo.ID,
+			"tracker_id": trackers[0].ID,
+			"subject":    subject,
+		},
+	})
+	createPath := writeBodyFile(t, createBody)
+
+	var created struct {
+		Issue struct {
+			ID      int    `json:"id"`
+			Subject string `json:"subject"`
+		} `json:"issue"`
+	}
+	r.runJSON(t, &created, "api", "/issues.json", "-X", "POST", "--input", createPath)
+	if created.Issue.ID == 0 {
+		t.Fatalf("api POST returned no issue ID; got %+v", created)
+	}
+	if created.Issue.Subject != subject {
+		t.Fatalf("api POST subject = %q, want %q", created.Issue.Subject, subject)
+	}
+
+	// PUT an update. Redmine returns 204 No Content on success, so we don't
+	// parse the body; we just require a clean exit and verify via a GET.
+	updateBody, _ := json.Marshal(map[string]any{
+		"issue": map[string]any{
+			"subject": "Updated via raw PUT",
+		},
+	})
+	updatePath := writeBodyFile(t, updateBody)
+	r.run(t, "api", fmt.Sprintf("/issues/%d.json", created.Issue.ID),
+		"-X", "PUT", "--input", updatePath)
+
+	var got struct {
+		Issue struct {
+			Subject string `json:"subject"`
+		} `json:"issue"`
+	}
+	r.runJSON(t, &got, "api", fmt.Sprintf("/issues/%d.json", created.Issue.ID))
+	if !strings.Contains(got.Issue.Subject, "Updated via raw PUT") {
+		t.Fatalf("subject after PUT = %q, want contains %q", got.Issue.Subject, "Updated via raw PUT")
+	}
+}
+
+func writeBodyFile(t *testing.T, body []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "body.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+	return path
+}

--- a/e2e/auth_test.go
+++ b/e2e/auth_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+// TestAuth_BasicAuth verifies the basic-auth code path: a profile with
+// username + password successfully authenticates against /users/current.json.
+//
+// This test is skipped unless REDMINE_E2E_PASSWORD is set. The Makefile's
+// e2e-test target sources this via e2e/admin-password.sh (which also resets
+// the admin password on the running container).
+func TestAuth_BasicAuth(t *testing.T) {
+	requireE2E(t)
+
+	password := e2ePassword()
+	if password == "" {
+		t.Skip("set REDMINE_E2E_PASSWORD to run basic-auth tests (see e2e/README.md)")
+	}
+
+	r := newCLIRunnerBasicAuth(t, e2eBaseURL(), e2eUsername(), password)
+
+	var me struct {
+		Login string `json:"login"`
+		Admin bool   `json:"admin"`
+	}
+	r.runJSON(t, &me, "users", "me")
+	if me.Login != e2eUsername() {
+		t.Fatalf("basic auth users me login = %q, want %q", me.Login, e2eUsername())
+	}
+	if !me.Admin {
+		t.Fatalf("expected basic auth user %q to be an admin", me.Login)
+	}
+}

--- a/e2e/bootstrap-redmine.sh
+++ b/e2e/bootstrap-redmine.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+set -eu
+
+compose_file="${REDMINE_E2E_COMPOSE_FILE:-e2e/compose.yaml}"
+container_service="${REDMINE_E2E_REDMINE_SERVICE:-redmine}"
+# Optional: when set, the admin password is reset to this value and the
+# must_change_passwd flag is cleared. Used by the basic-auth e2e tests.
+admin_password="${REDMINE_E2E_PASSWORD:-}"
+
+if docker compose -f "$compose_file" exec -T "$container_service" \
+  bundle exec rails runner 'exit((Tracker.count == 0 || IssueStatus.count == 0) ? 0 : 1)' \
+  >/dev/null 2>&1; then
+  printf 'Loading Redmine default data...\n' >&2
+  docker compose -f "$compose_file" exec -T "$container_service" \
+    sh -lc 'REDMINE_LANG=${REDMINE_LANG:-en} bundle exec rake redmine:load_default_data' \
+    >/dev/null
+fi
+
+docker compose -f "$compose_file" exec -T \
+  -e REDMINE_E2E_PASSWORD="$admin_password" \
+  "$container_service" \
+  bundle exec rails runner '
+    Setting.rest_api_enabled = "1"
+    admin = User.find_by(login: "admin")
+    abort("admin user not found") unless admin
+    if ENV["REDMINE_E2E_PASSWORD"].to_s != ""
+      admin.password = admin.password_confirmation = ENV["REDMINE_E2E_PASSWORD"]
+      admin.must_change_passwd = false
+      admin.save!
+    end
+    puts({
+      rest_api_enabled: Setting.rest_api_enabled?,
+      admin_api_key_present: admin.api_key.to_s != "",
+      admin_password_set: ENV["REDMINE_E2E_PASSWORD"].to_s != "",
+      trackers: Tracker.count,
+      statuses: IssueStatus.count
+    }.inspect)
+  ' 2>/dev/null | tail -n 1

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: redmine
+      POSTGRES_USER: redmine
+      POSTGRES_PASSWORD: redmine
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U redmine -d redmine"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redmine:
+    image: ${REDMINE_IMAGE:-redmine:6.1.2}
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${REDMINE_E2E_PORT:-3000}:3000"
+    environment:
+      REDMINE_DB_POSTGRES: postgres
+      REDMINE_DB_DATABASE: redmine
+      REDMINE_DB_USERNAME: redmine
+      REDMINE_DB_PASSWORD: redmine
+      SECRET_KEY_BASE: redmine-cli-local-e2e-secret
+    volumes:
+      - redmine-files:/usr/src/redmine/files
+
+volumes:
+  postgres-data:
+  redmine-files:

--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,0 +1,3 @@
+// Package e2e contains build-tagged end-to-end tests that exercise the CLI
+// against a real Redmine instance started locally via Docker Compose.
+package e2e

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,74 @@
+//go:build e2e
+
+// Package e2e contains end-to-end tests that drive the built `redmine` CLI
+// against a real Redmine instance started via docker-compose (see
+// `make e2e-up`). The package is split into topical test files:
+//
+//   - e2e_test.go       - TestMain (builds the CLI) and the requireE2E gate.
+//   - runner_test.go    - cliRunner and profile-specific constructors.
+//   - helpers_test.go   - envelope types and small utilities shared by tests.
+//   - fixtures_test.go  - reusable test fixtures (project, issue, ...).
+//   - projects_test.go  - project CRUD.
+//   - issues_test.go    - issue lifecycle, mutation, attachment, assign.
+//   - issues_list_test.go - list filter round-trips.
+//   - time_entries_test.go - time entry CRUD.
+//   - search_test.go    - search across resources.
+//   - auth_test.go      - basic-auth profile.
+//   - api_test.go       - raw `api` passthrough (GET/POST).
+//   - errors_test.go    - error envelope and exit code paths.
+//
+// When adding a new feature area, create a new topical file and reuse the
+// helpers here; do not grow a single large test function.
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// builtCLIPath points to the freshly-built CLI binary used by all tests.
+var builtCLIPath string
+
+func TestMain(m *testing.M) {
+	repoRoot := repoRootFromCaller()
+	builtCLIPath = filepath.Join(os.TempDir(), fmt.Sprintf("redmine-e2e-%d", time.Now().UnixNano()))
+
+	buildCmd := exec.Command("go", "build", "-o", builtCLIPath, ".")
+	buildCmd.Dir = repoRoot
+	buildCmd.Env = append(os.Environ(), "REDMINE_NO_UPDATE_CHECK=1")
+	out, err := buildCmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build e2e binary: %v\n%s", err, out)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	_ = os.Remove(builtCLIPath)
+	os.Exit(code)
+}
+
+// requireE2E skips the test unless REDMINE_E2E=1 and REDMINE_E2E_API_KEY are
+// set. Every e2e test must call this first so the suite cleanly no-ops in
+// environments without a running Redmine.
+func requireE2E(t *testing.T) {
+	t.Helper()
+	if os.Getenv("REDMINE_E2E") != "1" {
+		t.Skip("set REDMINE_E2E=1 to run local Redmine end-to-end tests")
+	}
+	if os.Getenv("REDMINE_E2E_API_KEY") == "" {
+		t.Fatal("set REDMINE_E2E_API_KEY to run local Redmine end-to-end tests")
+	}
+}
+
+func repoRootFromCaller() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("failed to resolve e2e test file path")
+	}
+	return filepath.Dir(filepath.Dir(file))
+}

--- a/e2e/errors_test.go
+++ b/e2e/errors_test.go
@@ -1,0 +1,51 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestErrors_NotFound covers 404 handling on both issues and projects: the
+// CLI must exit non-zero and print an error envelope with code=not_found on
+// stdout (since --output json is active).
+func TestErrors_NotFound(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	t.Run("issues get missing", func(t *testing.T) {
+		stdout, _ := r.runExpectError(t, "issues", "get", "2147483600")
+		assertErrorCode(t, stdout, "not_found")
+	})
+
+	t.Run("projects get missing", func(t *testing.T) {
+		stdout, _ := r.runExpectError(t, "projects", "get", "definitely-does-not-exist-12345")
+		assertErrorCode(t, stdout, "not_found")
+	})
+}
+
+// TestErrors_AuthFailed verifies that an invalid API key surfaces as
+// code=auth_failed rather than being swallowed.
+func TestErrors_AuthFailed(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), "invalid-api-key-for-e2e-auth-failure-test")
+
+	stdout, _ := r.runExpectError(t, "users", "me")
+	assertErrorCode(t, stdout, "auth_failed")
+}
+
+func assertErrorCode(t *testing.T, stdout []byte, want string) {
+	t.Helper()
+	var env errorEnvelope
+	if err := json.Unmarshal(stdout, &env); err != nil {
+		t.Fatalf("decode error envelope: %v\nstdout:\n%s", err, stdout)
+	}
+	if env.Error.Code != want {
+		t.Fatalf("error code = %q, want %q\nstdout:\n%s", env.Error.Code, want, stdout)
+	}
+	if strings.TrimSpace(env.Error.Message) == "" {
+		t.Fatalf("error envelope missing message\nstdout:\n%s", stdout)
+	}
+}

--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -67,7 +67,11 @@ func createTestIssue(t *testing.T, r *cliRunner, projectIdentifier string) *issu
 
 func createTestIssueWithSubject(t *testing.T, r *cliRunner, projectIdentifier, subject string) *issueFixture {
 	t.Helper()
-	tracker := firstTrackerName(t, r)
+	return createTestIssueWithTracker(t, r, projectIdentifier, firstTrackerName(t, r), subject)
+}
+
+func createTestIssueWithTracker(t *testing.T, r *cliRunner, projectIdentifier, tracker, subject string) *issueFixture {
+	t.Helper()
 
 	var created struct {
 		ID      int    `json:"id"`
@@ -89,6 +93,11 @@ func createTestIssueWithSubject(t *testing.T, r *cliRunner, projectIdentifier, s
 // than hard-coding a name (which differs across default Redmine data sets).
 func firstTrackerName(t *testing.T, r *cliRunner) string {
 	t.Helper()
+	return trackerNames(t, r)[0]
+}
+
+func trackerNames(t *testing.T, r *cliRunner) []string {
+	t.Helper()
 	var trackers []struct {
 		Name string `json:"name"`
 	}
@@ -96,7 +105,11 @@ func firstTrackerName(t *testing.T, r *cliRunner) string {
 	if len(trackers) == 0 {
 		t.Fatal("trackers list returned no trackers")
 	}
-	return trackers[0].Name
+	names := make([]string, 0, len(trackers))
+	for _, tracker := range trackers {
+		names = append(names, tracker.Name)
+	}
+	return names
 }
 
 // firstActivityName fetches /enumerations/time_entry_activities.json via the

--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -1,0 +1,149 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// projectFixture is an ephemeral test project. The underlying project is
+// deleted by a t.Cleanup registered in createTestProject, so tests never
+// share state.
+type projectFixture struct {
+	ID         int
+	Name       string
+	Identifier string
+}
+
+// createTestProject creates a uniquely-named project for a single test and
+// registers its deletion via t.Cleanup. Use this for any test that needs
+// write access to a project.
+func createTestProject(t *testing.T, r *cliRunner) *projectFixture {
+	t.Helper()
+	identifier := uniqueIdentifier(t)
+	name := "CLI E2E " + identifier
+
+	var created struct {
+		ID         int    `json:"id"`
+		Name       string `json:"name"`
+		Identifier string `json:"identifier"`
+	}
+	r.runJSON(t, &created, "projects", "create",
+		"--name", name,
+		"--identifier", identifier,
+		"--description", "Created by redmine-cli e2e tests")
+	if created.Identifier != identifier {
+		t.Fatalf("created project identifier = %q, want %q", created.Identifier, identifier)
+	}
+
+	t.Cleanup(func() {
+		var deleted actionEnvelope
+		r.runJSON(t, &deleted, "projects", "delete", identifier, "--force")
+		if !deleted.Ok || deleted.Action != "deleted" || deleted.Resource != "project" {
+			t.Errorf("unexpected project delete envelope: %+v", deleted)
+		}
+	})
+
+	return &projectFixture{ID: created.ID, Name: created.Name, Identifier: created.Identifier}
+}
+
+// issueFixture holds the minimal data tests need about a created issue.
+// The parent project's cleanup deletes the issue, so there is no separate
+// issue cleanup.
+type issueFixture struct {
+	ID      int
+	Subject string
+}
+
+// createTestIssue creates an issue in the given project using the first
+// tracker available on the server.
+func createTestIssue(t *testing.T, r *cliRunner, projectIdentifier string) *issueFixture {
+	t.Helper()
+	return createTestIssueWithSubject(t, r, projectIdentifier, "E2E issue "+time.Now().Format("20060102T150405.000"))
+}
+
+func createTestIssueWithSubject(t *testing.T, r *cliRunner, projectIdentifier, subject string) *issueFixture {
+	t.Helper()
+	tracker := firstTrackerName(t, r)
+
+	var created struct {
+		ID      int    `json:"id"`
+		Subject string `json:"subject"`
+	}
+	r.runJSON(t, &created, "issues", "create",
+		"--project", projectIdentifier,
+		"--tracker", tracker,
+		"--subject", subject,
+		"--description", "Created by redmine-cli e2e tests")
+	if created.Subject != subject {
+		t.Fatalf("created issue subject = %q, want %q", created.Subject, subject)
+	}
+	return &issueFixture{ID: created.ID, Subject: created.Subject}
+}
+
+// firstTrackerName returns the name of the first tracker visible on the
+// server. Tests that just need "any valid tracker" should use this rather
+// than hard-coding a name (which differs across default Redmine data sets).
+func firstTrackerName(t *testing.T, r *cliRunner) string {
+	t.Helper()
+	var trackers []struct {
+		Name string `json:"name"`
+	}
+	r.runJSON(t, &trackers, "trackers", "list")
+	if len(trackers) == 0 {
+		t.Fatal("trackers list returned no trackers")
+	}
+	return trackers[0].Name
+}
+
+// firstActivityName fetches /enumerations/time_entry_activities.json via the
+// raw api passthrough and returns the first activity. Tests use this so they
+// work against any default Redmine data set.
+func firstActivityName(t *testing.T, r *cliRunner) string {
+	t.Helper()
+	var resp struct {
+		TimeEntryActivities []struct {
+			Name string `json:"name"`
+		} `json:"time_entry_activities"`
+	}
+	r.runJSON(t, &resp, "api", "/enumerations/time_entry_activities.json")
+	if len(resp.TimeEntryActivities) == 0 {
+		t.Fatal("no time entry activities found on server")
+	}
+	return resp.TimeEntryActivities[0].Name
+}
+
+// issueIDArg renders an issue ID as the string argument expected by the CLI.
+func issueIDArg(id int) string { return strconv.Itoa(id) }
+
+// uniqueIdentifier returns a Redmine-valid project identifier seeded from the
+// test name plus a nanosecond suffix. Redmine requires identifiers to be
+// lowercase letters/digits/dashes and start with a lowercase letter, so we
+// always prefix with "e2e-".
+func uniqueIdentifier(t *testing.T) string {
+	t.Helper()
+	id := fmt.Sprintf("e2e-%s-%d", sanitizeForIdentifier(t.Name()), time.Now().UnixNano())
+	if len(id) > 100 {
+		id = id[:100]
+	}
+	return id
+}
+
+func sanitizeForIdentifier(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+('a'-'A'))
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			out = append(out, c)
+		default:
+			out = append(out, '-')
+		}
+	}
+	return string(out)
+}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -1,0 +1,51 @@
+//go:build e2e
+
+package e2e
+
+import "os"
+
+// actionEnvelope matches the JSON shape emitted by no-body mutators.
+type actionEnvelope struct {
+	Ok       bool   `json:"ok"`
+	Action   string `json:"action"`
+	Resource string `json:"resource"`
+	ID       any    `json:"id"`
+	Message  string `json:"message"`
+}
+
+// errorEnvelope matches the JSON shape written to stdout on failure when
+// --output json is active (see output.ErrorEnvelope).
+type errorEnvelope struct {
+	Error struct {
+		Message string   `json:"message"`
+		Code    string   `json:"code"`
+		Details []string `json:"details"`
+	} `json:"error"`
+}
+
+// envelopeIntID coerces the envelope ID (which JSON decodes as float64) to an
+// int for comparisons.
+func envelopeIntID(v any) int {
+	switch id := v.(type) {
+	case float64:
+		return int(id)
+	case int:
+		return id
+	default:
+		return 0
+	}
+}
+
+func getenvDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// The following accessors centralize env-var lookups so renames stay local to
+// this file. Tests should prefer these over os.Getenv.
+func e2eBaseURL() string  { return getenvDefault("REDMINE_E2E_BASE_URL", "http://127.0.0.1:3000") }
+func e2eUsername() string { return getenvDefault("REDMINE_E2E_USERNAME", "admin") }
+func e2eAPIKey() string   { return os.Getenv("REDMINE_E2E_API_KEY") }
+func e2ePassword() string { return os.Getenv("REDMINE_E2E_PASSWORD") }

--- a/e2e/issues_list_test.go
+++ b/e2e/issues_list_test.go
@@ -1,0 +1,106 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIssues_ListFilters exercises server-side filter round-trips: closed
+// status, tracker filter, and the "me" assignee shortcut. Each filter should
+// narrow the result set to the expected issue.
+func TestIssues_ListFilters(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	open := createTestIssueWithSubject(t, r, proj.Identifier, "Open issue for filter test")
+	closed := createTestIssueWithSubject(t, r, proj.Identifier, "Closed issue for filter test")
+
+	var env actionEnvelope
+	r.runJSON(t, &env, "issues", "close", issueIDArg(closed.ID))
+	if !env.Ok {
+		t.Fatalf("failed to close issue: %+v", env)
+	}
+
+	// Assign the open issue to the current user so --assignee me can match it.
+	r.runJSON(t, &env, "issues", "assign", issueIDArg(open.ID), "me")
+
+	t.Run("status=open excludes closed", func(t *testing.T) {
+		ids := listIssueIDs(t, r, "--project", proj.Identifier, "--status", "open", "--limit", "100")
+		if containsInt(ids, closed.ID) {
+			t.Fatalf("status=open should exclude closed issue %d; got %v", closed.ID, ids)
+		}
+		if !containsInt(ids, open.ID) {
+			t.Fatalf("status=open should include open issue %d; got %v", open.ID, ids)
+		}
+	})
+
+	t.Run("status=closed excludes open", func(t *testing.T) {
+		ids := listIssueIDs(t, r, "--project", proj.Identifier, "--status", "closed", "--limit", "100")
+		if containsInt(ids, open.ID) {
+			t.Fatalf("status=closed should exclude open issue %d; got %v", open.ID, ids)
+		}
+		if !containsInt(ids, closed.ID) {
+			t.Fatalf("status=closed should include closed issue %d; got %v", closed.ID, ids)
+		}
+	})
+
+	t.Run("status=* includes both", func(t *testing.T) {
+		ids := listIssueIDs(t, r, "--project", proj.Identifier, "--status", "*", "--limit", "100")
+		if !containsInt(ids, open.ID) || !containsInt(ids, closed.ID) {
+			t.Fatalf("status=* should include both; got %v", ids)
+		}
+	})
+
+	t.Run("assignee=me matches assigned issue", func(t *testing.T) {
+		ids := listIssueIDs(t, r, "--project", proj.Identifier, "--status", "*",
+			"--assignee", "me", "--limit", "100")
+		if !containsInt(ids, open.ID) {
+			t.Fatalf("assignee=me should include open issue %d; got %v", open.ID, ids)
+		}
+	})
+
+	t.Run("tracker filter round-trips", func(t *testing.T) {
+		tracker := firstTrackerName(t, r)
+		ids := listIssueIDs(t, r, "--project", proj.Identifier, "--status", "*",
+			"--tracker", tracker, "--limit", "100")
+		// Both fixtures used the first tracker.
+		if !containsInt(ids, open.ID) {
+			t.Fatalf("tracker=%s should include open issue %d; got %v", tracker, open.ID, ids)
+		}
+	})
+
+	t.Run("bogus tracker yields a resolver error", func(t *testing.T) {
+		stdout, _ := r.runExpectError(t, "issues", "list", "--project", proj.Identifier,
+			"--tracker", "this-tracker-does-not-exist")
+		if !strings.Contains(string(stdout), "resolving tracker") &&
+			!strings.Contains(string(stdout), "not found") {
+			t.Fatalf("expected resolver error on unknown tracker; stdout:\n%s", stdout)
+		}
+	})
+}
+
+func listIssueIDs(t *testing.T, r *cliRunner, args ...string) []int {
+	t.Helper()
+	var listed []struct {
+		ID int `json:"id"`
+	}
+	full := append([]string{"issues", "list"}, args...)
+	r.runJSON(t, &listed, full...)
+	out := make([]int, len(listed))
+	for i, it := range listed {
+		out[i] = it.ID
+	}
+	return out
+}
+
+func containsInt(xs []int, target int) bool {
+	for _, x := range xs {
+		if x == target {
+			return true
+		}
+	}
+	return false
+}

--- a/e2e/issues_list_test.go
+++ b/e2e/issues_list_test.go
@@ -14,9 +14,14 @@ func TestIssues_ListFilters(t *testing.T) {
 	requireE2E(t)
 	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
 	proj := createTestProject(t, r)
+	trackers := trackerNames(t, r)
+	if len(trackers) < 2 {
+		t.Skip("need at least two trackers to validate tracker filtering")
+	}
 
-	open := createTestIssueWithSubject(t, r, proj.Identifier, "Open issue for filter test")
-	closed := createTestIssueWithSubject(t, r, proj.Identifier, "Closed issue for filter test")
+	open := createTestIssueWithTracker(t, r, proj.Identifier, trackers[0], "Open issue for filter test")
+	closed := createTestIssueWithTracker(t, r, proj.Identifier, trackers[0], "Closed issue for filter test")
+	differentTracker := createTestIssueWithTracker(t, r, proj.Identifier, trackers[1], "Different tracker issue for filter test")
 
 	var env actionEnvelope
 	r.runJSON(t, &env, "issues", "close", issueIDArg(closed.ID))
@@ -60,15 +65,24 @@ func TestIssues_ListFilters(t *testing.T) {
 		if !containsInt(ids, open.ID) {
 			t.Fatalf("assignee=me should include open issue %d; got %v", open.ID, ids)
 		}
+		if containsInt(ids, closed.ID) || containsInt(ids, differentTracker.ID) {
+			t.Fatalf("assignee=me should exclude unassigned issues; got %v", ids)
+		}
 	})
 
 	t.Run("tracker filter round-trips", func(t *testing.T) {
-		tracker := firstTrackerName(t, r)
+		tracker := trackers[0]
 		ids := listIssueIDs(t, r, "--project", proj.Identifier, "--status", "*",
 			"--tracker", tracker, "--limit", "100")
-		// Both fixtures used the first tracker.
 		if !containsInt(ids, open.ID) {
 			t.Fatalf("tracker=%s should include open issue %d; got %v", tracker, open.ID, ids)
+		}
+		if !containsInt(ids, closed.ID) {
+			t.Fatalf("tracker=%s should include closed issue %d; got %v", tracker, closed.ID, ids)
+		}
+		if containsInt(ids, differentTracker.ID) {
+			t.Fatalf("tracker=%s should exclude issue %d from tracker %s; got %v",
+				tracker, differentTracker.ID, trackers[1], ids)
 		}
 	})
 

--- a/e2e/issues_test.go
+++ b/e2e/issues_test.go
@@ -116,6 +116,25 @@ func TestIssues_Assign(t *testing.T) {
 	proj := createTestProject(t, r)
 	issue := createTestIssue(t, r, proj.Identifier)
 
+	var before struct {
+		AssignedTo struct {
+			Login string `json:"login"`
+			Name  string `json:"name"`
+		} `json:"assigned_to"`
+	}
+	r.runJSON(t, &before, "issues", "get", issueIDArg(issue.ID))
+	if before.AssignedTo.Name != "" || before.AssignedTo.Login != "" {
+		t.Fatalf("expected new issue to start unassigned, got %+v", before.AssignedTo)
+	}
+
+	var me struct {
+		Login     string `json:"login"`
+		FirstName string `json:"firstname"`
+		LastName  string `json:"lastname"`
+	}
+	r.runJSON(t, &me, "users", "me")
+	wantName := strings.TrimSpace(me.FirstName + " " + me.LastName)
+
 	var assigned actionEnvelope
 	r.runJSON(t, &assigned, "issues", "assign", issueIDArg(issue.ID), "me")
 	if !assigned.Ok || assigned.Action != "assigned" || assigned.Resource != "issue" {
@@ -131,6 +150,12 @@ func TestIssues_Assign(t *testing.T) {
 	r.runJSON(t, &after, "issues", "get", issueIDArg(issue.ID))
 	if after.AssignedTo.Name == "" {
 		t.Fatalf("expected issue to be assigned after `issues assign`, got %+v", after)
+	}
+	if wantName == "" {
+		t.Fatalf("users me returned empty name components: %+v", me)
+	}
+	if after.AssignedTo.Name != wantName {
+		t.Fatalf("assigned_to.name = %q, want %q (user %q)", after.AssignedTo.Name, wantName, me.Login)
 	}
 }
 

--- a/e2e/issues_test.go
+++ b/e2e/issues_test.go
@@ -1,0 +1,207 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestIssues_Lifecycle covers create → list → close → reopen.
+func TestIssues_Lifecycle(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+	issue := createTestIssue(t, r, proj.Identifier)
+
+	var listed []struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &listed, "issues", "list", "--project", proj.Identifier, "--limit", "100")
+	if !containsIssueID(listed, issue.ID) {
+		t.Fatalf("issues list did not include issue %d", issue.ID)
+	}
+
+	var closed actionEnvelope
+	r.runJSON(t, &closed, "issues", "close", issueIDArg(issue.ID), "--note", "Closed by e2e")
+	if !closed.Ok || closed.Action != "closed" || closed.Resource != "issue" || envelopeIntID(closed.ID) != issue.ID {
+		t.Fatalf("unexpected close envelope: %+v", closed)
+	}
+
+	after := getIssueStatus(t, r, issue.ID)
+	if !strings.Contains(strings.ToLower(after), "closed") {
+		t.Fatalf("expected closed status after close, got %q", after)
+	}
+
+	var reopened actionEnvelope
+	r.runJSON(t, &reopened, "issues", "reopen", issueIDArg(issue.ID), "--note", "Reopened by e2e")
+	if !reopened.Ok || reopened.Action != "reopened" || reopened.Resource != "issue" || envelopeIntID(reopened.ID) != issue.ID {
+		t.Fatalf("unexpected reopen envelope: %+v", reopened)
+	}
+
+	after = getIssueStatus(t, r, issue.ID)
+	if strings.Contains(strings.ToLower(after), "closed") {
+		t.Fatalf("expected reopened issue to have non-closed status, got %q", after)
+	}
+}
+
+// TestIssues_UpdateAndComment verifies that `issues update` maps flag values
+// onto the right Redmine fields, and that `issues comment` appends a journal
+// note visible via `issues get --journals`.
+func TestIssues_UpdateAndComment(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+	issue := createTestIssue(t, r, proj.Identifier)
+
+	newSubject := "Updated subject " + strconv.Itoa(issue.ID)
+	var updated actionEnvelope
+	r.runJSON(t, &updated, "issues", "update", issueIDArg(issue.ID),
+		"--subject", newSubject,
+		"--done-ratio", "50",
+		"--description", "rewritten description")
+	if !updated.Ok || updated.Action != "updated" || updated.Resource != "issue" {
+		t.Fatalf("unexpected update envelope: %+v", updated)
+	}
+
+	var after struct {
+		Subject     string `json:"subject"`
+		Description string `json:"description"`
+		DoneRatio   int    `json:"done_ratio"`
+	}
+	r.runJSON(t, &after, "issues", "get", issueIDArg(issue.ID))
+	if after.Subject != newSubject {
+		t.Fatalf("issue subject = %q, want %q", after.Subject, newSubject)
+	}
+	if after.DoneRatio != 50 {
+		t.Fatalf("issue done_ratio = %d, want 50", after.DoneRatio)
+	}
+	if !strings.Contains(after.Description, "rewritten") {
+		t.Fatalf("issue description not updated: %q", after.Description)
+	}
+
+	commentBody := "Comment added by e2e " + strconv.Itoa(issue.ID)
+	var commented actionEnvelope
+	r.runJSON(t, &commented, "issues", "comment", issueIDArg(issue.ID), "-m", commentBody)
+	if !commented.Ok || commented.Action != "commented" || commented.Resource != "issue" {
+		t.Fatalf("unexpected comment envelope: %+v", commented)
+	}
+
+	var withJournals struct {
+		Journals []struct {
+			Notes string `json:"notes"`
+		} `json:"journals"`
+	}
+	r.runJSON(t, &withJournals, "issues", "get", issueIDArg(issue.ID), "--journals")
+	found := false
+	for _, j := range withJournals.Journals {
+		if strings.Contains(j.Notes, commentBody) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("journal did not contain comment %q; got %+v", commentBody, withJournals.Journals)
+	}
+}
+
+// TestIssues_Assign verifies `issues assign` resolves a user by login and
+// sets assigned_to on the issue.
+func TestIssues_Assign(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+	issue := createTestIssue(t, r, proj.Identifier)
+
+	var assigned actionEnvelope
+	r.runJSON(t, &assigned, "issues", "assign", issueIDArg(issue.ID), "me")
+	if !assigned.Ok || assigned.Action != "assigned" || assigned.Resource != "issue" {
+		t.Fatalf("unexpected assign envelope: %+v", assigned)
+	}
+
+	var after struct {
+		AssignedTo struct {
+			Login string `json:"login"`
+			Name  string `json:"name"`
+		} `json:"assigned_to"`
+	}
+	r.runJSON(t, &after, "issues", "get", issueIDArg(issue.ID))
+	if after.AssignedTo.Name == "" {
+		t.Fatalf("expected issue to be assigned after `issues assign`, got %+v", after)
+	}
+}
+
+// TestIssues_Attachment verifies the multipart upload path: create an issue
+// with --attach, then fetch via the raw api with ?include=attachments (the
+// typed Issue model doesn't surface attachments) and assert the file is
+// present.
+func TestIssues_Attachment(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	attachPath := filepath.Join(t.TempDir(), "hello.txt")
+	payload := []byte("hello from redmine-cli e2e\n")
+	if err := os.WriteFile(attachPath, payload, 0o600); err != nil {
+		t.Fatalf("write attach file: %v", err)
+	}
+
+	tracker := firstTrackerName(t, r)
+	var created struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &created, "issues", "create",
+		"--project", proj.Identifier,
+		"--tracker", tracker,
+		"--subject", "E2E issue with attachment",
+		"--attach", attachPath)
+	if created.ID == 0 {
+		t.Fatal("issues create returned no ID")
+	}
+
+	var resp struct {
+		Issue struct {
+			Attachments []struct {
+				Filename    string `json:"filename"`
+				Filesize    int    `json:"filesize"`
+				ContentType string `json:"content_type"`
+			} `json:"attachments"`
+		} `json:"issue"`
+	}
+	r.runJSON(t, &resp, "api", "/issues/"+issueIDArg(created.ID)+".json", "-f", "include=attachments")
+	found := false
+	for _, att := range resp.Issue.Attachments {
+		if att.Filename == "hello.txt" && att.Filesize == len(payload) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("attachment not found on issue; got %+v", resp.Issue.Attachments)
+	}
+}
+
+func containsIssueID(issues []struct {
+	ID int `json:"id"`
+}, id int) bool {
+	for _, i := range issues {
+		if i.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func getIssueStatus(t *testing.T, r *cliRunner, id int) string {
+	t.Helper()
+	var got struct {
+		Status struct {
+			Name string `json:"name"`
+		} `json:"status"`
+	}
+	r.runJSON(t, &got, "issues", "get", issueIDArg(id))
+	return got.Status.Name
+}

--- a/e2e/projects_test.go
+++ b/e2e/projects_test.go
@@ -1,0 +1,38 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+// TestProjects_CRUD covers project create/get/list/delete (delete runs via
+// the fixture's t.Cleanup).
+func TestProjects_CRUD(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	proj := createTestProject(t, r)
+
+	var fetched struct {
+		ID         int    `json:"id"`
+		Identifier string `json:"identifier"`
+	}
+	r.runJSON(t, &fetched, "projects", "get", proj.Identifier)
+	if fetched.ID != proj.ID {
+		t.Fatalf("projects get ID = %d, want %d", fetched.ID, proj.ID)
+	}
+
+	var listed []struct {
+		Identifier string `json:"identifier"`
+	}
+	r.runJSON(t, &listed, "projects", "list")
+	found := false
+	for _, p := range listed {
+		if p.Identifier == proj.Identifier {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("projects list did not include %q", proj.Identifier)
+	}
+}

--- a/e2e/runner_test.go
+++ b/e2e/runner_test.go
@@ -1,0 +1,109 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cliRunner executes the redmine CLI against a specific temporary config
+// file. Each test gets its own runner so config state never leaks between
+// tests. Prefer the factory constructors below over building a runner by hand;
+// add a new constructor when introducing a new profile shape (OAuth, proxy
+// auth, ...).
+type cliRunner struct {
+	configPath string
+	repoRoot   string
+}
+
+// newCLIRunner returns a runner with a single API-key profile. This is the
+// default factory used by most tests.
+func newCLIRunner(t *testing.T, baseURL, apiKey string) *cliRunner {
+	t.Helper()
+	return newRunnerWithConfig(t, fmt.Sprintf(`active_profile: local-e2e
+profiles:
+  local-e2e:
+    server: %s
+    api_key: %s
+    auth_method: apikey
+    output_format: json
+`, baseURL, apiKey))
+}
+
+// newCLIRunnerBasicAuth returns a runner configured for HTTP basic auth.
+// Tests that want to verify the basic-auth code path use this.
+func newCLIRunnerBasicAuth(t *testing.T, baseURL, username, password string) *cliRunner {
+	t.Helper()
+	return newRunnerWithConfig(t, fmt.Sprintf(`active_profile: local-e2e-basic
+profiles:
+  local-e2e-basic:
+    server: %s
+    username: %s
+    password: %s
+    auth_method: basic
+    output_format: json
+`, baseURL, username, password))
+}
+
+func newRunnerWithConfig(t *testing.T, config string) *cliRunner {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "redmine-cli-e2e.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return &cliRunner{configPath: configPath, repoRoot: repoRootFromCaller()}
+}
+
+// run executes the CLI, fails the test on non-zero exit, and returns stdout.
+func (r *cliRunner) run(t *testing.T, args ...string) []byte {
+	t.Helper()
+	stdout, _, err := r.runRaw(args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stdout
+}
+
+// runJSON runs the CLI and decodes stdout into dest.
+func (r *cliRunner) runJSON(t *testing.T, dest any, args ...string) {
+	t.Helper()
+	stdout := r.run(t, args...)
+	if err := json.Unmarshal(stdout, dest); err != nil {
+		t.Fatalf("decode JSON for %q: %v\nstdout:\n%s", strings.Join(args, " "), err, stdout)
+	}
+}
+
+// runExpectError runs the CLI and requires a non-zero exit. It returns
+// stdout and stderr so tests can inspect the error envelope.
+func (r *cliRunner) runExpectError(t *testing.T, args ...string) (stdout, stderr []byte) {
+	t.Helper()
+	stdout, stderr, err := r.runRaw(args...)
+	if err == nil {
+		t.Fatalf("expected non-zero exit for %q\nstdout:\n%s", strings.Join(args, " "), stdout)
+	}
+	return stdout, stderr
+}
+
+func (r *cliRunner) runRaw(args ...string) (stdout, stderr []byte, err error) {
+	cmdArgs := append([]string{"--config", r.configPath, "--output", "json"}, args...)
+	cmd := exec.Command(builtCLIPath, cmdArgs...)
+	cmd.Dir = r.repoRoot
+	cmd.Env = append(os.Environ(), "REDMINE_NO_UPDATE_CHECK=1")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	runErr := cmd.Run()
+	if runErr != nil {
+		runErr = fmt.Errorf("run %q: %w\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(cmdArgs, " "), runErr, outBuf.String(), errBuf.String())
+	}
+	return outBuf.Bytes(), errBuf.Bytes(), runErr
+}

--- a/e2e/search_test.go
+++ b/e2e/search_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSearch_Issues creates an issue with a unique token in its subject, then
+// verifies the search command finds it.
+func TestSearch_Issues(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	token := fmt.Sprintf("etoken%d", time.Now().UnixNano())
+	subject := "Find me via search " + token
+	issue := createTestIssueWithSubject(t, r, proj.Identifier, subject)
+
+	var results []struct {
+		ID    int    `json:"id"`
+		Type  string `json:"type"`
+		Title string `json:"title"`
+	}
+	r.runJSON(t, &results, "search", token, "--issues", "--limit", "25")
+
+	found := false
+	for _, res := range results {
+		if strings.Contains(res.Type, "issue") && res.ID == issue.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("search %q did not find issue %d; got %+v", token, issue.ID, results)
+	}
+}
+
+// TestSearch_Projects verifies the --projects scope hits the project index.
+func TestSearch_Projects(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	// Query by the project identifier's trailing nanosecond suffix, which is
+	// unique per run and unlikely to match any other project.
+	parts := strings.Split(proj.Identifier, "-")
+	token := parts[len(parts)-1]
+
+	var results []struct {
+		Type  string `json:"type"`
+		Title string `json:"title"`
+	}
+	r.runJSON(t, &results, "search", token, "--projects", "--limit", "25")
+
+	found := false
+	for _, res := range results {
+		if res.Type == "project" && strings.Contains(res.Title, token) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("search %q --projects did not return %q; got %+v", token, proj.Identifier, results)
+	}
+}

--- a/e2e/time_entries_test.go
+++ b/e2e/time_entries_test.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestTimeEntries_CRUD covers log → list → update → delete. It validates
+// hours parsing, activity name resolution, spent_on date handling, and that
+// the list filter scoped to the issue returns just the logged entry.
+func TestTimeEntries_CRUD(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+	issue := createTestIssue(t, r, proj.Identifier)
+	activity := firstActivityName(t, r)
+
+	var created struct {
+		ID       int     `json:"id"`
+		Hours    float64 `json:"hours"`
+		SpentOn  string  `json:"spent_on"`
+		Comments string  `json:"comments"`
+		Activity struct {
+			Name string `json:"name"`
+		} `json:"activity"`
+	}
+	r.runJSON(t, &created, "time", "log",
+		"--issue", strconv.Itoa(issue.ID),
+		"--hours", "1.25",
+		"--activity", activity,
+		"--date", "2026-04-17",
+		"--comment", "logged by e2e")
+	if created.Hours != 1.25 {
+		t.Fatalf("time log hours = %v, want 1.25", created.Hours)
+	}
+	if created.SpentOn != "2026-04-17" {
+		t.Fatalf("time log spent_on = %q, want 2026-04-17", created.SpentOn)
+	}
+	if created.Activity.Name == "" {
+		t.Fatalf("time log activity not resolved: %+v", created)
+	}
+
+	var entries []struct {
+		ID       int     `json:"id"`
+		Hours    float64 `json:"hours"`
+		Comments string  `json:"comments"`
+	}
+	r.runJSON(t, &entries, "time", "list", "--issue", strconv.Itoa(issue.ID))
+	if len(entries) != 1 || entries[0].ID != created.ID {
+		t.Fatalf("time list for issue %d = %+v, want single entry %d", issue.ID, entries, created.ID)
+	}
+
+	var updated actionEnvelope
+	r.runJSON(t, &updated, "time", "update", strconv.Itoa(created.ID),
+		"--hours", "2",
+		"--comment", "edited by e2e")
+	if !updated.Ok || updated.Action != "updated" || updated.Resource != "time_entry" {
+		t.Fatalf("unexpected update envelope: %+v", updated)
+	}
+
+	var got struct {
+		Hours    float64 `json:"hours"`
+		Comments string  `json:"comments"`
+	}
+	r.runJSON(t, &got, "time", "get", strconv.Itoa(created.ID))
+	if got.Hours != 2 {
+		t.Fatalf("time get hours = %v after update, want 2", got.Hours)
+	}
+	if got.Comments != "edited by e2e" {
+		t.Fatalf("time get comments = %q after update, want %q", got.Comments, "edited by e2e")
+	}
+
+	var deleted actionEnvelope
+	r.runJSON(t, &deleted, "time", "delete", strconv.Itoa(created.ID), "--force")
+	if !deleted.Ok || deleted.Action != "deleted" || deleted.Resource != "time_entry" {
+		t.Fatalf("unexpected delete envelope: %+v", deleted)
+	}
+
+	r.runJSON(t, &entries, "time", "list", "--issue", strconv.Itoa(issue.ID))
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries after delete; got %+v", entries)
+	}
+}

--- a/e2e/wait-for-redmine.sh
+++ b/e2e/wait-for-redmine.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+base_url="${REDMINE_E2E_BASE_URL:-http://127.0.0.1:3000}"
+timeout_seconds="${REDMINE_E2E_TIMEOUT_SECONDS:-300}"
+
+printf 'Waiting for Redmine at %s\n' "$base_url" >&2
+
+start_time="$(date +%s)"
+
+while :; do
+  if curl --silent --show-error --fail "$base_url/" >/dev/null 2>&1; then
+    printf 'Redmine is ready.\n' >&2
+    exit 0
+  fi
+
+  now="$(date +%s)"
+  if [ $((now - start_time)) -ge "$timeout_seconds" ]; then
+    printf 'Timed out waiting for Redmine after %s seconds.\n' "$timeout_seconds" >&2
+    exit 1
+  fi
+
+  sleep 5
+done

--- a/e2e/write-config.sh
+++ b/e2e/write-config.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -eu
+
+config_path="${1:-${REDMINE_E2E_CONFIG_PATH:-$(pwd)/.redmine-cli.e2e.yaml}}"
+base_url="${REDMINE_E2E_BASE_URL:-http://127.0.0.1:3000}"
+api_key="${REDMINE_E2E_API_KEY:-}"
+profile_name="${REDMINE_E2E_PROFILE_NAME:-local-e2e}"
+
+if [ -z "$api_key" ]; then
+  api_key="$(./e2e/admin-api-key.sh)"
+fi
+
+cat >"$config_path" <<EOF
+active_profile: $profile_name
+profiles:
+  $profile_name:
+    server: $base_url
+    api_key: $api_key
+    auth_method: apikey
+    output_format: json
+EOF
+
+printf 'Wrote e2e config to %s\n' "$config_path" >&2


### PR DESCRIPTION
## Summary

- Docker Compose harness for Redmine 4.2 / 5.1 / 6.1 + Postgres, wired into `make e2e-up | e2e-config | e2e-test | e2e-down | e2e-matrix`
- Go e2e suite split into topical files (projects, issues, list filters, time entries, search, basic-auth, raw `api` passthrough, error envelopes) sharing a small set of runner + fixture helpers so new areas can be added without growing a monolithic test function
- Bootstrap script now optionally resets the admin password (`REDMINE_E2E_PASSWORD`, defaulted by the Makefile) so the basic-auth profile can be exercised alongside the default api-key flow
- `.redmine-cli.e2e.yaml` added to `.gitignore` (local artifact produced by `make e2e-config`, contains a live api key)

Matrix verification (all three Redmine lines):

| Redmine | Result | Duration |
|---------|--------|----------|
| 4.2     | PASS   | 5.53s    |
| 5.1     | PASS   | 4.99s    |
| 6.1     | PASS   | 5.00s    |

14 tests per version, 42 total, 0 failures.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` and `go vet -tags=e2e ./e2e/...` clean
- [x] `go test ./...` (unit) passes
- [x] `golangci-lint run` 0 issues
- [x] `make e2e-matrix` passes end-to-end against Redmine 4.2, 5.1, 6.1