### PR TITLE
feat: add `view` alias to all get subcommands

### DIFF
--- a/docs/src/content/docs/commands/groups.mdx
+++ b/docs/src/content/docs/commands/groups.mdx
@@ -35,7 +35,7 @@ redmine groups list [flags]
 redmine groups get <id-or-name> [flags]
 ```
 
-Accepts a numeric ID or group name.
+Aliases: `show`, `view`. Accepts a numeric ID or group name.
 
 ## create
 

--- a/docs/src/content/docs/commands/issues.mdx
+++ b/docs/src/content/docs/commands/issues.mdx
@@ -66,6 +66,8 @@ redmine issues list [flags]
 redmine issues get <id> [flags]
 ```
 
+Aliases: `show`, `view`.
+
 | Flag | Description |
 |------|-------------|
 | `--include`    | Include related data: `journals`, `children`, `relations` |

--- a/docs/src/content/docs/commands/memberships.mdx
+++ b/docs/src/content/docs/commands/memberships.mdx
@@ -34,6 +34,8 @@ redmine memberships list --project <identifier> [flags]
 redmine memberships get <id> [flags]
 ```
 
+Aliases: `show`, `view`.
+
 | Flag | Description |
 |------|-------------|
 | `-o, --output` | Output format |

--- a/docs/src/content/docs/commands/projects.mdx
+++ b/docs/src/content/docs/commands/projects.mdx
@@ -34,6 +34,8 @@ redmine projects list [flags]
 redmine projects get <identifier> [flags]
 ```
 
+Aliases: `show`, `view`.
+
 | Flag | Description |
 |------|-------------|
 | `--include`    | Extra data: `trackers`, `issue_categories`, `enabled_modules`, `time_entry_activities` |

--- a/docs/src/content/docs/commands/time.mdx
+++ b/docs/src/content/docs/commands/time.mdx
@@ -83,6 +83,8 @@ redmine time list [flags]
 redmine time get <id> [flags]
 ```
 
+Aliases: `show`, `view`.
+
 ## update
 
 ```bash

--- a/docs/src/content/docs/commands/users.mdx
+++ b/docs/src/content/docs/commands/users.mdx
@@ -37,7 +37,7 @@ redmine users list [flags]
 redmine users get <id-or-name> [flags]
 ```
 
-Accepts a numeric ID, login, full name, or `me`.
+Aliases: `show`, `view`. Accepts a numeric ID, login, full name, or `me`.
 
 ## me
 

--- a/docs/src/content/docs/commands/versions.mdx
+++ b/docs/src/content/docs/commands/versions.mdx
@@ -36,7 +36,7 @@ redmine versions list --project myproject --status open
 redmine versions get <id-or-name> [flags]
 ```
 
-Accepts a numeric ID or a version name.
+Aliases: `show`, `view`. Accepts a numeric ID or a version name.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/src/content/docs/commands/wiki.mdx
+++ b/docs/src/content/docs/commands/wiki.mdx
@@ -56,7 +56,7 @@ Aliases: `ls`. Lists each page's title and last-modified timestamp. Results are 
 redmine wiki get <page> [flags]
 ```
 
-Aliases: `show`. Prints the page metadata and full Textile/Markdown source. Pass `--version` to fetch a historical revision instead of the current one.
+Aliases: `show`, `view`. Prints the page metadata and full Textile/Markdown source. Pass `--version` to fetch a historical revision instead of the current one.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/src/content/docs/zh-cn/commands/groups.mdx
+++ b/docs/src/content/docs/zh-cn/commands/groups.mdx
@@ -35,7 +35,7 @@ redmine groups list [flags]
 redmine groups get <id-or-name> [flags]
 ```
 
-接受数字 ID 或用户组名称。
+别名：`show`、`view`。接受数字 ID 或用户组名称。
 
 ## create
 

--- a/docs/src/content/docs/zh-cn/commands/issues.mdx
+++ b/docs/src/content/docs/zh-cn/commands/issues.mdx
@@ -66,6 +66,8 @@ redmine issues list [flags]
 redmine issues get <id> [flags]
 ```
 
+别名：`show`、`view`。
+
 | 标志 | 描述 |
 |------|------|
 | `--include`    | 包含关联数据：`journals`、`children`、`relations` |

--- a/docs/src/content/docs/zh-cn/commands/memberships.mdx
+++ b/docs/src/content/docs/zh-cn/commands/memberships.mdx
@@ -34,6 +34,8 @@ redmine memberships list --project <identifier> [flags]
 redmine memberships get <id> [flags]
 ```
 
+别名：`show`、`view`。
+
 | 标志 | 描述 |
 |------|------|
 | `-o, --output` | 输出格式 |

--- a/docs/src/content/docs/zh-cn/commands/projects.mdx
+++ b/docs/src/content/docs/zh-cn/commands/projects.mdx
@@ -34,6 +34,8 @@ redmine projects list [flags]
 redmine projects get <identifier> [flags]
 ```
 
+别名：`show`、`view`。
+
 | 标志 | 描述 |
 |------|------|
 | `--include`    | 附加数据：`trackers`、`issue_categories`、`enabled_modules`、`time_entry_activities` |

--- a/docs/src/content/docs/zh-cn/commands/time.mdx
+++ b/docs/src/content/docs/zh-cn/commands/time.mdx
@@ -83,6 +83,8 @@ redmine time list [flags]
 redmine time get <id> [flags]
 ```
 
+别名：`show`、`view`。
+
 ## update
 
 ```bash

--- a/docs/src/content/docs/zh-cn/commands/users.mdx
+++ b/docs/src/content/docs/zh-cn/commands/users.mdx
@@ -37,7 +37,7 @@ redmine users list [flags]
 redmine users get <id-or-name> [flags]
 ```
 
-接受数字 ID、登录名、全名或 `me`。
+别名：`show`、`view`。接受数字 ID、登录名、全名或 `me`。
 
 ## me
 

--- a/docs/src/content/docs/zh-cn/commands/versions.mdx
+++ b/docs/src/content/docs/zh-cn/commands/versions.mdx
@@ -36,7 +36,7 @@ redmine versions list --project myproject --status open
 redmine versions get <id-or-name> [flags]
 ```
 
-接受数字 ID 或版本名称。
+别名：`show`、`view`。接受数字 ID 或版本名称。
 
 | 标志 | 描述 |
 |------|------|

--- a/docs/src/content/docs/zh-cn/commands/wiki.mdx
+++ b/docs/src/content/docs/zh-cn/commands/wiki.mdx
@@ -56,7 +56,7 @@ redmine wiki list [flags]
 redmine wiki get <page> [flags]
 ```
 
-别名：`show`。打印页面的元数据以及完整的 Textile/Markdown 源文本。传入 `--version` 可获取历史版本而非当前版本。
+别名：`show`、`view`。打印页面的元数据以及完整的 Textile/Markdown 源文本。传入 `--version` 可获取历史版本而非当前版本。
 
 | 标志 | 描述 |
 |------|------|

--- a/internal/cmd/group/get.go
+++ b/internal/cmd/group/get.go
@@ -22,7 +22,7 @@ func newCmdGroupGet(f *cmdutil.Factory) *cobra.Command {
 		Use:     "get <id-or-name>",
 		Short:   "Show group details",
 		Long:    "Show group details. Accepts a numeric ID or group name.",
-		Aliases: []string{"show"},
+		Aliases: []string{"show", "view"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := f.ApiClient()

--- a/internal/cmd/project/get.go
+++ b/internal/cmd/project/get.go
@@ -16,7 +16,7 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "get <identifier>",
-		Aliases: []string{"show"},
+		Aliases: []string{"show", "view"},
 		Short:   "Get project details",
 		Long:    "Display detailed information about a Redmine project.",
 		Args:    cobra.ExactArgs(1),

--- a/internal/cmd/time/get.go
+++ b/internal/cmd/time/get.go
@@ -14,7 +14,7 @@ import (
 func newCmdTimeGet(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get <id>",
-		Aliases: []string{"show"},
+		Aliases: []string{"show", "view"},
 		Short:   "Show a time entry",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/user/get.go
+++ b/internal/cmd/user/get.go
@@ -17,7 +17,7 @@ func newCmdUserGet(f *cmdutil.Factory) *cobra.Command {
 		Use:     "get <id-or-name>",
 		Short:   "Show user details",
 		Long:    "Show user details. Accepts a numeric ID, login, full name, or 'me'.",
-		Aliases: []string{"show"},
+		Aliases: []string{"show", "view"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := f.ApiClient()

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -22,7 +22,7 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "get <page>",
-		Aliases: []string{"show"},
+		Aliases: []string{"show", "view"},
 		Short:   "Get wiki page details",
 		Long:    "Display detailed information about a Redmine wiki page.",
 		Example: `  # View a wiki page


### PR DESCRIPTION
## Summary

- Adds `view` as an alias on every `get` subcommand (projects, users, wiki, time, groups). Previously only issues, memberships, and versions accepted `view`, so agents frequently failed when reaching for the alias on other entities.
- Every entity with a `get` command now accepts `get`, `show`, and `view` uniformly.
- Updates English and Simplified Chinese docs so each `## get` section lists the `show`/`view` aliases.

## Test plan

- [x] `go fmt ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] `go test ./...`
- [x] Manually verified `redmine {projects,groups,users,wiki,time} view --help` now resolves to the corresponding `get` command.