### PR TITLE
fix(update): treat brew outdated exit 1 with stdout as outdated

### DIFF
--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -106,14 +106,29 @@ func defaultCheckHomebrew() bool {
 }
 
 func defaultCheckHomebrewOutdated() (bool, error) {
+	// `brew outdated --cask <name>` exits 0 with empty stdout when the cask
+	// is up to date, exits 1 with the cask name on stdout when outdated, and
+	// exits non-zero with stderr output on actual errors (e.g. unknown cask).
+	// Treating any non-zero exit as an error would misclassify the common
+	// "outdated" case, blocking self-update right when it should run.
 	cmd := exec.Command("brew", "outdated", "--cask", "redmine")
-	var out bytes.Buffer
+	var out, errBuf bytes.Buffer
 	cmd.Stdout = &out
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil {
-		return false, fmt.Errorf("brew outdated failed: %w", err)
+	cmd.Stderr = &errBuf
+	runErr := cmd.Run()
+	stdout := strings.TrimSpace(out.String())
+
+	if stdout != "" {
+		return true, nil
 	}
-	return strings.TrimSpace(out.String()) != "", nil
+	if runErr != nil {
+		stderr := strings.TrimSpace(errBuf.String())
+		if stderr != "" {
+			return false, fmt.Errorf("brew outdated failed: %w: %s", runErr, stderr)
+		}
+		return false, fmt.Errorf("brew outdated failed: %w", runErr)
+	}
+	return false, nil
 }
 
 func defaultUpgradeHomebrew(stdout, stderr io.Writer) error {

--- a/internal/cmd/update/update_test.go
+++ b/internal/cmd/update/update_test.go
@@ -14,6 +14,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -72,6 +74,62 @@ func TestDefaultCheckHomebrew_BrewNotInstalled(t *testing.T) {
 	stubBrewEnv(t, "/opt/homebrew/Caskroom/redmine/2.1.1/redmine", "", errors.New("brew not found"))
 	if defaultCheckHomebrew() {
 		t.Error("expected false when brew is unavailable")
+	}
+}
+
+// withBrewShim prepends a temp dir containing a fake `brew` shell script to
+// PATH. The script's body is the argument verbatim. Returns nothing; the
+// original PATH is restored via t.Cleanup.
+func withBrewShim(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" + body + "\n"
+	shimPath := filepath.Join(dir, "brew")
+	if err := os.WriteFile(shimPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write brew shim: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+}
+
+func TestDefaultCheckHomebrewOutdated_Outdated(t *testing.T) {
+	// brew outdated --cask <name> exits 1 and prints the cask name when
+	// the cask is outdated. Must be read as outdated=true, not as an error.
+	withBrewShim(t, `echo redmine; exit 1`)
+
+	outdated, err := defaultCheckHomebrewOutdated()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !outdated {
+		t.Error("expected outdated=true when brew prints cask name and exits 1")
+	}
+}
+
+func TestDefaultCheckHomebrewOutdated_UpToDate(t *testing.T) {
+	withBrewShim(t, `exit 0`)
+
+	outdated, err := defaultCheckHomebrewOutdated()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outdated {
+		t.Error("expected outdated=false for exit 0 with empty stdout")
+	}
+}
+
+func TestDefaultCheckHomebrewOutdated_ActualError(t *testing.T) {
+	withBrewShim(t, `echo "Error: Cask unavailable" >&2; exit 1`)
+
+	outdated, err := defaultCheckHomebrewOutdated()
+	if err == nil {
+		t.Fatal("expected error when stdout is empty and stderr has a message")
+	}
+	if outdated {
+		t.Error("expected outdated=false on error path")
+	}
+	if !strings.Contains(err.Error(), "Cask unavailable") {
+		t.Errorf("expected error to surface stderr, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Self-update via Homebrew currently fails with:

```
Error: brew outdated failed: exit status 1
```

whenever a newer cask version is actually available. `brew outdated --cask <name>` exits **1** (not 0) when the cask is outdated and prints the cask name to stdout. Our previous implementation classified any non-zero exit as a hard error, so the exact case self-update exists for fails.

The fix distinguishes the three real outcomes:

| brew behavior                  | stdout | exit | old result   | new result     |
|--------------------------------|--------|------|--------------|----------------|
| cask is outdated               | name   | 1    | hard error   | outdated=true  |
| cask is up to date             | empty  | 0    | up to date   | up to date     |
| actual error (e.g. bad name)   | empty  | non-0 | hard error   | hard error     |

Unit tests exercise the real `defaultCheckHomebrewOutdated` against a fake `brew` shim on `PATH` covering all three cases, so this cannot silently regress again. The bug has shipped in every prior release and only manifested after v2.2.0 made v2.1.1 outdated upstream.

## Test plan

- [x] `go fmt`, `go vet`, `go test ./...`, `golangci-lint run` all clean.
- [x] New brew-shim tests pass: outdated (exit 1 with stdout), up to date (exit 0), real error (exit 1 with stderr).
- [x] Reproduced the original failure locally (`redmine update` with v2.1.1 installed while v2.2.0 is published in the tap).
- [ ] After merge and v2.2.1 tag, confirm `redmine update` on a v2.2.0 brew install successfully upgrades to v2.2.1 without the "brew outdated failed" error.

## Release note

This is a hotfix for all prior Homebrew installs. Users currently on v2.1.1 or v2.2.0 need to run `brew upgrade redmine` manually once to get past the buggy binary; from v2.2.1 onwards `redmine update` will work correctly.