### PR TITLE
docs: add robots.txt with sitemap reference

### DIFF
--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://aarondpn.github.io/redmine-cli/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Adds `docs/public/robots.txt` so the deployed Pages site serves a real `robots.txt` at `https://aarondpn.github.io/redmine-cli/robots.txt` (currently 404).
- File advertises the existing `sitemap-index.xml` and allows all crawlers.

## Why
Google Search Console refuses to read the sitemap (`Sitemap konnte nicht gelesen werden`, 0 pages, live test also fails). Bing accepts the same sitemap instantly. Community-reported workaround for `*.github.io` Project Pages: publish a `robots.txt` from the project path with a `Sitemap:` directive — GSC starts processing within ~12-24h after.

Astro copies `public/` verbatim into `dist/`, so no config change required.

## Test plan
- [x] `npm run build` in `docs/` — `dist/robots.txt` is emitted with the expected content
- [ ] After deploy, verify `https://aarondpn.github.io/redmine-cli/robots.txt` returns 200
- [ ] Re-submit sitemap in GSC; expect status to clear within ~24h