### PR TITLE
ci(e2e): run full version matrix on push and PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ jobs:
               echo "versions=[\"${INPUT_VERSION}\"]" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo 'versions=["6.1"]' >> "$GITHUB_OUTPUT"
+              echo 'versions=["4.2","5.1","6.1"]' >> "$GITHUB_OUTPUT"
               ;;
           esac
 


### PR DESCRIPTION
## Summary
- Run e2e suite against Redmine 4.2, 5.1, and 6.1 on every push and PR
- Previously only 6.1 ran automatically; full matrix was gated behind manual workflow_dispatch
- All three versions are supported, so regressions in older versions should be caught before merge

## Test plan
- [ ] CI runs three parallel e2e jobs (4.2, 5.1, 6.1) on this PR
- [ ] All three jobs pass independently (`fail-fast: false` already set)
- [ ] Manual workflow_dispatch with explicit version still selects single version