### PR TITLE
feat(mcp): configurable tool group exposure

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -119,12 +119,42 @@ skill の完全な内容については [`skills/redmine-cli/SKILL.md`](skills/r
 
 ### MCP Server
 
-[Model Context Protocol](https://modelcontextprotocol.io) に対応したホスト向けに、`redmine mcp serve` は CLI を stdio 経由で MCP サーバーとして公開します。認証は他のすべての `redmine` コマンドと同じ profile ベースの仕組みを再利用します。
+[Model Context Protocol](https://modelcontextprotocol.io) に対応したホスト向けに、`redmine mcp serve` はデフォルトで stdio 経由、`--http` を渡した場合は streamable HTTP 経由で CLI を MCP サーバーとして公開します。認証は他のすべての `redmine` コマンドと同じ profile ベースの仕組みを再利用します。
 
 - **デフォルトは読み取り専用。** 変更系ツールは `--enable-writes` を指定したときのみ登録されます。このフラグがなければ `tools/list` に表示されることはありません。
 - **認証はアクティブな profile を再利用します**（または `--profile`、`--server/--api-key`、`REDMINE_*` 環境変数）。
+- **公開するツールの範囲を設定できます。** `--enable-groups` / `--disable-groups` でカテゴリ単位（`issues`、`wiki`、`time` など）に公開対象を制御し、`--enable-tools` / `--disable-tools` で個別のツールを上書きできます。`redmine mcp tools` を実行するとカタログを表示できます。
 
 書き込みツールは破壊的です。ホスト側に信頼できる呼び出しごとの承認 UI がない限り、無効のままにしておくことをおすすめします。
+
+#### 公開するツールを絞り込む
+
+issue 関連だけを扱う MCP サーバーを起動するには、グループの allow-list を設定します。
+
+```bash
+redmine mcp serve --enable-groups issues
+```
+
+破壊的な delete 系を除いたうえで書き込みを有効にするには、deny-list と組み合わせます。
+
+```bash
+redmine mcp serve --enable-writes --disable-tools delete_issue,delete_project,delete_wiki_page
+```
+
+同じデフォルト値は profile ごとの `~/.redmine-cli.yaml` にも記述できます。これにより、MCP ホストは常に意図した公開範囲で起動されます。
+
+```yaml
+profiles:
+  internal:
+    server: https://redmine.internal
+    api_key: ...
+    mcp:
+      enable_writes: true
+      enable_groups: [issues, wiki]
+      disable_tools: [delete_issue]
+```
+
+CLI フラグは設定ファイルより優先され、`REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` 環境変数は設定ファイルを上書きします。
 
 ## ローカル E2E テスト
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,38 @@ For hosts that speak the [Model Context Protocol](https://modelcontextprotocol.i
 
 - **Read-only by default.** Mutating tools are only registered when `--enable-writes` is passed; without the flag they never appear in `tools/list`.
 - **Authentication reuses the active profile** (or `--profile`, `--server/--api-key`, `REDMINE_*` env vars).
+- **Configurable tool surface.** Use `--enable-groups` / `--disable-groups` to expose only some categories (`issues`, `wiki`, `time`, ...), or `--enable-tools` / `--disable-tools` for per-tool overrides. Run `redmine mcp tools` to print the catalog.
 
 Write tools are destructive; prefer leaving them disabled unless the host surfaces a per-call approval UI you trust.
+
+#### Narrowing the exposed tools
+
+To run an MCP server that only knows about issues, set the group allow-list:
+
+```bash
+redmine mcp serve --enable-groups issues
+```
+
+To expose everything except destructive deletes, combine writes with a deny-list:
+
+```bash
+redmine mcp serve --enable-writes --disable-tools delete_issue,delete_project,delete_wiki_page
+```
+
+The same defaults can live in `~/.redmine-cli.yaml` per profile so an MCP host always launches with the surface you want:
+
+```yaml
+profiles:
+  internal:
+    server: https://redmine.internal
+    api_key: ...
+    mcp:
+      enable_writes: true
+      enable_groups: [issues, wiki]
+      disable_tools: [delete_issue]
+```
+
+CLI flags override config, and `REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` env vars override the config file.
 
 ## Local E2E Testing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,12 +119,42 @@ redmine install-skill
 
 ### MCP Server
 
-对于支持 [Model Context Protocol](https://modelcontextprotocol.io) 的宿主，`redmine mcp serve` 通过 stdio 将 CLI 暴露为一个 MCP 服务器，并复用与其他所有 `redmine` 命令相同的基于 profile 的认证。
+对于支持 [Model Context Protocol](https://modelcontextprotocol.io) 的宿主，`redmine mcp serve` 默认通过 stdio 将 CLI 暴露为一个 MCP 服务器；传入 `--http` 时，也可以通过 streamable HTTP 暴露同一个服务，并复用与其他所有 `redmine` 命令相同的基于 profile 的认证。
 
 - **默认只读。** 仅在传入 `--enable-writes` 时才会注册修改类工具；未传入该参数时，这些工具不会出现在 `tools/list` 中。
 - **认证复用当前激活的 profile**（或 `--profile`、`--server/--api-key`、`REDMINE_*` 环境变量）。
+- **可配置工具暴露范围。** 使用 `--enable-groups` / `--disable-groups` 可按类别（`issues`、`wiki`、`time` 等）控制暴露的工具，使用 `--enable-tools` / `--disable-tools` 可进一步按单个工具覆盖。运行 `redmine mcp tools` 可查看完整目录。
 
 写入工具具有破坏性；除非宿主提供你信任的按调用审批 UI，否则建议保持禁用。
+
+#### 收窄暴露的工具范围
+
+如果要运行一个只了解 issue 的 MCP 服务器，可以设置 group allow-list：
+
+```bash
+redmine mcp serve --enable-groups issues
+```
+
+如果要启用写入，但排除破坏性的删除工具，可结合 deny-list：
+
+```bash
+redmine mcp serve --enable-writes --disable-tools delete_issue,delete_project,delete_wiki_page
+```
+
+同样的默认值也可以写入每个 profile 的 `~/.redmine-cli.yaml`，这样 MCP 宿主总会以你期望的暴露范围启动：
+
+```yaml
+profiles:
+  internal:
+    server: https://redmine.internal
+    api_key: ...
+    mcp:
+      enable_writes: true
+      enable_groups: [issues, wiki]
+      disable_tools: [delete_issue]
+```
+
+CLI 标志会覆盖配置文件，`REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` 环境变量也会覆盖该配置块。
 
 ## 本地端到端测试
 

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -54,10 +54,40 @@ The same file is the source of truth for what the agent learns -- read it direct
 - **Transport:** stdio by default. The host can spawn `redmine mcp serve` and talk JSON-RPC over its standard streams, or you can pass `--http :8080` to expose the same server over streamable HTTP.
 - **Authentication:** the active profile is used by default. Override with `--profile <name>`, `--server` / `--api-key`, or the `REDMINE_*` environment variables -- exactly like every other subcommand.
 - **Read-only by default.** Mutating tools (create / update / delete, comment, close, reopen, and similar write operations) are registered only when `--enable-writes` is passed. Without the flag they never appear in `tools/list`.
+- **Configurable surface.** `--enable-groups` / `--disable-groups` constrain the registered tools to specific categories (`issues`, `wiki`, `time`, ...). For sharper control, `--enable-tools` / `--disable-tools` allow- or deny-list individual tool names. Run `redmine mcp tools` to print the full catalog.
 
 <Aside type="caution">
   Write tools are destructive. Prefer leaving them disabled unless the host surfaces a per-call approval UI you trust.
 </Aside>
+
+### Narrowing the exposed tools
+
+For an issue-only assistant, drop everything but the issues group:
+
+```bash
+redmine mcp serve --enable-groups issues
+```
+
+To enable writes everywhere except destructive deletes, combine the flags:
+
+```bash
+redmine mcp serve --enable-writes --disable-tools delete_issue,delete_project,delete_wiki_page
+```
+
+The same defaults can live in `~/.redmine-cli.yaml` per profile, and CLI flags override them:
+
+```yaml
+profiles:
+  internal:
+    server: https://redmine.internal
+    api_key: ...
+    mcp:
+      enable_writes: true
+      enable_groups: [issues, wiki]
+      disable_tools: [delete_issue]
+```
+
+Environment variables (`REDMINE_MCP_ENABLE_GROUPS`, `REDMINE_MCP_DISABLE_GROUPS`, `REDMINE_MCP_ENABLE_TOOLS`, `REDMINE_MCP_DISABLE_TOOLS`, `REDMINE_MCP_ENABLE_WRITES`) override the config block.
 
 ### Prerequisite
 
@@ -154,7 +184,7 @@ The same file is the source of truth for what the agent learns -- read it direct
 
 1. **Host reports "command not found".** The spawned process inherits the host's `PATH`, which often differs from your shell. Use an absolute path (`which redmine`) in the `command` field.
 
-2. **Tools list is empty or missing mutations.** `--enable-writes` was not passed, or the host cached an older `tools/list`. Restart the host after changing args.
+2. **Tools list is empty or missing mutations.** `--enable-writes` was not passed, the surface was narrowed via `--enable-groups` / `--enable-tools`, or the host cached an older `tools/list`. Run `redmine mcp tools` to see the full catalog and restart the host after changing args.
 
 3. **401 / "no profile" errors.** No profile is logged in, or `--profile <name>` points at one that does not exist. Run `redmine auth list` to confirm.
 

--- a/docs/src/content/docs/zh-cn/guides/ai-agents.mdx
+++ b/docs/src/content/docs/zh-cn/guides/ai-agents.mdx
@@ -54,10 +54,40 @@ redmine-cli 针对 AI 代理提供两种集成方式，具体取决于你的工�
 - **传输方式：** 默认使用 stdio。宿主可以生成 `redmine mcp serve` 进程，并通过其标准流使用 JSON-RPC 通信；也可以传入 `--http :8080` 通过 streamable HTTP 暴露同一个服务。
 - **身份验证：** 默认使用当前活跃的配置文件。可通过 `--profile <name>`、`--server` / `--api-key` 或 `REDMINE_*` 环境变量覆盖，与其他子命令完全一致。
 - **默认只读。** 修改类工具（创建 / 更新 / 删除、评论、关闭、重新打开及其他写操作）仅在传入 `--enable-writes` 时才会注册。未传入该标志时，这些工具不会出现在 `tools/list` 中。
+- **可配置暴露范围。** `--enable-groups` / `--disable-groups` 可将注册的工具限制到特定类别（`issues`、`wiki`、`time` 等）。若需更细粒度的控制，可使用 `--enable-tools` / `--disable-tools` 对单个工具做 allow-list 或 deny-list。运行 `redmine mcp tools` 可打印完整工具目录。
 
 <Aside type="caution">
   写入工具具有破坏性。除非宿主提供了你信任的逐次审批界面（per-call approval UI），否则建议保持禁用。
 </Aside>
+
+### 收窄暴露的工具范围
+
+对于只处理 issue 的助手，可仅保留 issues 组：
+
+```bash
+redmine mcp serve --enable-groups issues
+```
+
+若要全局启用写入，但排除破坏性的删除工具，可组合这些标志：
+
+```bash
+redmine mcp serve --enable-writes --disable-tools delete_issue,delete_project,delete_wiki_page
+```
+
+同样的默认值也可以按 profile 写入 `~/.redmine-cli.yaml`，CLI 标志会覆盖这些值：
+
+```yaml
+profiles:
+  internal:
+    server: https://redmine.internal
+    api_key: ...
+    mcp:
+      enable_writes: true
+      enable_groups: [issues, wiki]
+      disable_tools: [delete_issue]
+```
+
+环境变量（`REDMINE_MCP_ENABLE_GROUPS`、`REDMINE_MCP_DISABLE_GROUPS`、`REDMINE_MCP_ENABLE_TOOLS`、`REDMINE_MCP_DISABLE_TOOLS`、`REDMINE_MCP_ENABLE_WRITES`）会覆盖该配置块。
 
 ### 前置条件
 
@@ -154,7 +184,7 @@ redmine-cli 针对 AI 代理提供两种集成方式，具体取决于你的工�
 
 1. **宿主报告 “command not found”。** 生成的进程继承宿主的 `PATH`，这通常与你的 shell 不同。请在 `command` 字段中使用绝对路径（`which redmine`）。
 
-2. **工具列表为空或缺少修改类工具。** 未传入 `--enable-writes`，或宿主缓存了旧的 `tools/list`。修改参数后请重启宿主。
+2. **工具列表为空或缺少修改类工具。** 未传入 `--enable-writes`，暴露范围被 `--enable-groups` / `--enable-tools` 收窄了，或者宿主缓存了旧的 `tools/list`。运行 `redmine mcp tools` 查看完整目录，并在修改参数后重启宿主。
 
 3. **401 / “no profile” 错误。** 当前没有登录的配置文件，或 `--profile <name>` 指向的配置文件不存在。运行 `redmine auth list` 进行确认。
 

--- a/internal/cmd/mcp/mcp.go
+++ b/internal/cmd/mcp/mcp.go
@@ -18,5 +18,6 @@ func NewCmdMCP(f *cmdutil.Factory) *cobra.Command {
 			"can drive Redmine through the same profile-backed authentication.",
 	}
 	cmd.AddCommand(newCmdServe(f))
+	cmd.AddCommand(newCmdTools(f))
 	return cmd
 }

--- a/internal/cmd/mcp/serve.go
+++ b/internal/cmd/mcp/serve.go
@@ -5,20 +5,26 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 
 	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/config"
 	"github.com/aarondpn/redmine-cli/v2/internal/mcpserver"
 )
 
 func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 	var (
-		enableWrites bool
-		name         string
-		httpAddr     string
+		enableWrites  bool
+		name          string
+		httpAddr      string
+		enableGroups  []string
+		disableGroups []string
+		enableTools   []string
+		disableTools  []string
 	)
 
 	cmd := &cobra.Command{
@@ -30,7 +36,11 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 			"flags) selects the Redmine instance.\n\n" +
 			"By default only read tools are registered. Pass --enable-writes to " +
 			"also register create/update/delete tools. Use --http to listen on " +
-			"an HTTP address such as :8080 instead of stdio.",
+			"an HTTP address such as :8080 instead of stdio.\n\n" +
+			"To narrow the set of tools exposed to MCP clients, use " +
+			"--enable-groups / --disable-groups (allow- and deny-list of tool " +
+			"groups) and --enable-tools / --disable-tools (per-tool overrides). " +
+			"Run `redmine mcp tools` to see the available groups and tools.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := f.ApiClient()
@@ -43,11 +53,18 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 				version = "dev"
 			}
 
+			cfg, _ := f.Config()
+			spec, err := buildFilterSpec(cfg, cmd, enableGroups, disableGroups, enableTools, disableTools)
+			if err != nil {
+				return err
+			}
+
 			opts := mcpserver.Options{
-				EnableWrites: enableWrites,
+				EnableWrites: resolveEnableWrites(cmd, enableWrites, cfg),
 				Name:         name,
 				Version:      version,
 			}
+			opts = mcpserver.ResolveOptions(opts, spec)
 
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
@@ -77,6 +94,75 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&enableWrites, "enable-writes", false, "Register tools that create, update, or delete Redmine data")
 	cmd.Flags().StringVar(&httpAddr, "http", "", "Serve MCP over streamable HTTP on the given address instead of stdio (for example :8080)")
 	cmd.Flags().StringVar(&name, "name", "redmine-cli", "Server name advertised to MCP clients")
+	cmd.Flags().StringSliceVar(&enableGroups, "enable-groups", nil, "Comma-separated tool groups to expose (default: all). See `redmine mcp tools`.")
+	cmd.Flags().StringSliceVar(&disableGroups, "disable-groups", nil, "Comma-separated tool groups to hide. Applied after --enable-groups.")
+	cmd.Flags().StringSliceVar(&enableTools, "enable-tools", nil, "Allow-list of tool names. Tools outside the list are hidden.")
+	cmd.Flags().StringSliceVar(&disableTools, "disable-tools", nil, "Deny-list of tool names. Applied after --enable-tools.")
 
 	return cmd
+}
+
+// buildFilterSpec merges config-file values with the CLI flag values. CLI
+// flags take precedence: when a flag is explicitly set, the corresponding
+// config value is ignored entirely (rather than appended).
+func buildFilterSpec(cfg *config.Config, cmd *cobra.Command, enableGroupsFlag, disableGroupsFlag, enableToolsFlag, disableToolsFlag []string) (mcpserver.FilterSpec, error) {
+	pick := func(flagName string, fromFlag, fromCfg []string) []string {
+		if cmd.Flags().Changed(flagName) {
+			return fromFlag
+		}
+		return fromCfg
+	}
+
+	var cfgEG, cfgDG, cfgET, cfgDT []string
+	if cfg != nil {
+		cfgEG = cfg.MCP.EnableGroups
+		cfgDG = cfg.MCP.DisableGroups
+		cfgET = cfg.MCP.EnableTools
+		cfgDT = cfg.MCP.DisableTools
+	}
+
+	eg := pick("enable-groups", enableGroupsFlag, cfgEG)
+	dg := pick("disable-groups", disableGroupsFlag, cfgDG)
+	et := pick("enable-tools", enableToolsFlag, cfgET)
+	dt := pick("disable-tools", disableToolsFlag, cfgDT)
+
+	parsedEnable, err := mcpserver.ParseGroups(eg)
+	if err != nil {
+		return mcpserver.FilterSpec{}, err
+	}
+	parsedDisable, err := mcpserver.ParseGroups(dg)
+	if err != nil {
+		return mcpserver.FilterSpec{}, err
+	}
+
+	return mcpserver.FilterSpec{
+		EnableGroups:  parsedEnable,
+		DisableGroups: parsedDisable,
+		EnableTools:   trimSlice(et),
+		DisableTools:  trimSlice(dt),
+	}, nil
+}
+
+// resolveEnableWrites returns the effective --enable-writes setting. Flag
+// takes precedence; otherwise the config-file MCP block wins; otherwise the
+// flag default.
+func resolveEnableWrites(cmd *cobra.Command, flagVal bool, cfg *config.Config) bool {
+	if cmd.Flags().Changed("enable-writes") {
+		return flagVal
+	}
+	if cfg != nil && cfg.MCP.EnableWrites != nil {
+		return *cfg.MCP.EnableWrites
+	}
+	return flagVal
+}
+
+// trimSlice drops empty entries and trims whitespace.
+func trimSlice(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if t := strings.TrimSpace(v); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/internal/cmd/mcp/serve.go
+++ b/internal/cmd/mcp/serve.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -94,7 +93,7 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&enableWrites, "enable-writes", false, "Register tools that create, update, or delete Redmine data")
 	cmd.Flags().StringVar(&httpAddr, "http", "", "Serve MCP over streamable HTTP on the given address instead of stdio (for example :8080)")
 	cmd.Flags().StringVar(&name, "name", "redmine-cli", "Server name advertised to MCP clients")
-	cmd.Flags().StringSliceVar(&enableGroups, "enable-groups", nil, "Comma-separated tool groups to expose (default: all). See `redmine mcp tools`.")
+	cmd.Flags().StringSliceVar(&enableGroups, "enable-groups", nil, "Comma-separated tool groups to expose (default: all). See redmine mcp tools.")
 	cmd.Flags().StringSliceVar(&disableGroups, "disable-groups", nil, "Comma-separated tool groups to hide. Applied after --enable-groups.")
 	cmd.Flags().StringSliceVar(&enableTools, "enable-tools", nil, "Allow-list of tool names. Tools outside the list are hidden.")
 	cmd.Flags().StringSliceVar(&disableTools, "disable-tools", nil, "Deny-list of tool names. Applied after --enable-tools.")
@@ -134,12 +133,20 @@ func buildFilterSpec(cfg *config.Config, cmd *cobra.Command, enableGroupsFlag, d
 	if err != nil {
 		return mcpserver.FilterSpec{}, err
 	}
+	parsedEnableTools, err := mcpserver.ParseTools(et)
+	if err != nil {
+		return mcpserver.FilterSpec{}, err
+	}
+	parsedDisableTools, err := mcpserver.ParseTools(dt)
+	if err != nil {
+		return mcpserver.FilterSpec{}, err
+	}
 
 	return mcpserver.FilterSpec{
 		EnableGroups:  parsedEnable,
 		DisableGroups: parsedDisable,
-		EnableTools:   trimSlice(et),
-		DisableTools:  trimSlice(dt),
+		EnableTools:   parsedEnableTools,
+		DisableTools:  parsedDisableTools,
 	}, nil
 }
 
@@ -154,15 +161,4 @@ func resolveEnableWrites(cmd *cobra.Command, flagVal bool, cfg *config.Config) b
 		return *cfg.MCP.EnableWrites
 	}
 	return flagVal
-}
-
-// trimSlice drops empty entries and trims whitespace.
-func trimSlice(in []string) []string {
-	out := make([]string, 0, len(in))
-	for _, v := range in {
-		if t := strings.TrimSpace(v); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
 }

--- a/internal/cmd/mcp/serve_test.go
+++ b/internal/cmd/mcp/serve_test.go
@@ -1,8 +1,10 @@
 package mcp
 
 import (
+	"bytes"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -142,5 +144,49 @@ func TestResolveEnableWrites(t *testing.T) {
 	}
 	if resolveEnableWrites(cmd, false, cfg) {
 		t.Error("explicit flag should override config")
+	}
+}
+
+func TestBuildFilterSpec_RejectsUnknownTool(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("enable-groups", nil, "")
+	cmd.Flags().StringSlice("disable-groups", nil, "")
+	cmd.Flags().StringSlice("enable-tools", nil, "")
+	cmd.Flags().StringSlice("disable-tools", nil, "")
+
+	if err := cmd.Flags().Set("enable-tools", "list_issues,not_a_real_tool"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	enableGroups, _ := cmd.Flags().GetStringSlice("enable-groups")
+	disableGroups, _ := cmd.Flags().GetStringSlice("disable-groups")
+	enableTools, _ := cmd.Flags().GetStringSlice("enable-tools")
+	disableTools, _ := cmd.Flags().GetStringSlice("disable-tools")
+
+	_, err := buildFilterSpec(nil, cmd, enableGroups, disableGroups, enableTools, disableTools)
+	if err == nil {
+		t.Fatal("buildFilterSpec should reject unknown tool names")
+	}
+	if !strings.Contains(err.Error(), `unknown tool "not_a_real_tool"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServeHelp_EnableGroupsUsageRendersNormally(t *testing.T) {
+	cmd := newCmdServe(cmdutil.NewFactory())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help: %v", err)
+	}
+
+	help := out.String()
+	if strings.Contains(help, "--enable-groups redmine mcp tools") {
+		t.Fatalf("help output used command text as value placeholder:\n%s", help)
+	}
+	if !strings.Contains(help, "--enable-groups strings") {
+		t.Fatalf("help output missing normal StringSlice placeholder:\n%s", help)
 	}
 }

--- a/internal/cmd/mcp/serve_test.go
+++ b/internal/cmd/mcp/serve_test.go
@@ -1,9 +1,15 @@
 package mcp
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/config"
+	"github.com/aarondpn/redmine-cli/v2/internal/mcpserver"
 )
 
 func TestNewCmdMCP_HasServe(t *testing.T) {
@@ -11,14 +17,14 @@ func TestNewCmdMCP_HasServe(t *testing.T) {
 	if cmd.Use != "mcp" {
 		t.Errorf("Use = %q, want mcp", cmd.Use)
 	}
-	found := false
+	subcommands := map[string]bool{}
 	for _, sub := range cmd.Commands() {
-		if sub.Use == "serve" {
-			found = true
-		}
+		subcommands[sub.Use] = true
 	}
-	if !found {
-		t.Fatal("mcp serve subcommand not registered")
+	for _, want := range []string{"serve", "tools"} {
+		if !subcommands[want] {
+			t.Errorf("mcp %s subcommand not registered", want)
+		}
 	}
 }
 
@@ -47,5 +53,94 @@ func TestServeFlags_DefaultsToReadOnly(t *testing.T) {
 	}
 	if httpAddr != "" {
 		t.Errorf("--http default = %q, want empty string", httpAddr)
+	}
+}
+
+func TestBuildFilterSpec_FlagsBeatConfig(t *testing.T) {
+	cfg := &config.Config{MCP: config.MCPConfig{
+		EnableGroups: []string{"issues"},
+		DisableTools: []string{"delete_issue"},
+	}}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("enable-groups", nil, "")
+	cmd.Flags().StringSlice("disable-groups", nil, "")
+	cmd.Flags().StringSlice("enable-tools", nil, "")
+	cmd.Flags().StringSlice("disable-tools", nil, "")
+
+	if err := cmd.Flags().Set("enable-groups", "wiki,projects"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	enableGroups, _ := cmd.Flags().GetStringSlice("enable-groups")
+	disableGroups, _ := cmd.Flags().GetStringSlice("disable-groups")
+	enableTools, _ := cmd.Flags().GetStringSlice("enable-tools")
+	disableTools, _ := cmd.Flags().GetStringSlice("disable-tools")
+
+	spec, err := buildFilterSpec(cfg, cmd, enableGroups, disableGroups, enableTools, disableTools)
+	if err != nil {
+		t.Fatalf("buildFilterSpec: %v", err)
+	}
+
+	gotGroups := make([]string, 0, len(spec.EnableGroups))
+	for _, g := range spec.EnableGroups {
+		gotGroups = append(gotGroups, string(g))
+	}
+	sort.Strings(gotGroups)
+	wantGroups := []string{"projects", "wiki"}
+	if !reflect.DeepEqual(gotGroups, wantGroups) {
+		t.Errorf("EnableGroups from flag = %v, want %v (config should be ignored)", gotGroups, wantGroups)
+	}
+
+	if !reflect.DeepEqual(spec.DisableTools, []string{"delete_issue"}) {
+		t.Errorf("DisableTools should fall back to config when flag unset, got %v", spec.DisableTools)
+	}
+}
+
+func TestBuildFilterSpec_ConfigUsedWhenFlagsAbsent(t *testing.T) {
+	cfg := &config.Config{MCP: config.MCPConfig{
+		EnableGroups: []string{"issues", "wiki"},
+		EnableTools:  []string{"list_issues"},
+	}}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("enable-groups", nil, "")
+	cmd.Flags().StringSlice("disable-groups", nil, "")
+	cmd.Flags().StringSlice("enable-tools", nil, "")
+	cmd.Flags().StringSlice("disable-tools", nil, "")
+
+	spec, err := buildFilterSpec(cfg, cmd, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildFilterSpec: %v", err)
+	}
+
+	got := make([]mcpserver.Group, 0, len(spec.EnableGroups))
+	got = append(got, spec.EnableGroups...)
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	want := []mcpserver.Group{mcpserver.GroupIssues, mcpserver.GroupWiki}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("EnableGroups = %v, want %v", got, want)
+	}
+	if !reflect.DeepEqual(spec.EnableTools, []string{"list_issues"}) {
+		t.Errorf("EnableTools = %v, want [list_issues]", spec.EnableTools)
+	}
+}
+
+func TestResolveEnableWrites(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("enable-writes", false, "")
+
+	tr := true
+	cfg := &config.Config{MCP: config.MCPConfig{EnableWrites: &tr}}
+
+	if !resolveEnableWrites(cmd, false, cfg) {
+		t.Error("config should win when flag is unset")
+	}
+
+	if err := cmd.Flags().Set("enable-writes", "false"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if resolveEnableWrites(cmd, false, cfg) {
+		t.Error("explicit flag should override config")
 	}
 }

--- a/internal/cmd/mcp/tools.go
+++ b/internal/cmd/mcp/tools.go
@@ -1,0 +1,48 @@
+package mcp
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/mcpserver"
+)
+
+func newCmdTools(_ *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "List the MCP tool groups and the tools they contain",
+		Long: "Print the catalog of tools the MCP server can expose, grouped by " +
+			"the value used with --enable-groups / --disable-groups. Read tools " +
+			"are always available; tools marked (write) only register when " +
+			"--enable-writes is passed to `mcp serve`.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return printToolCatalog(cmd.OutOrStdout())
+		},
+	}
+	return cmd
+}
+
+func printToolCatalog(out io.Writer) error {
+	byGroup := mcpserver.ToolsByGroup()
+	for _, g := range mcpserver.AllGroups() {
+		fmt.Fprintf(out, "%s\n", g)
+		tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+		for _, d := range byGroup[g] {
+			kind := "read"
+			if d.Writes {
+				kind = "write"
+			}
+			fmt.Fprintf(tw, "  %s\t(%s)\t%s\n", d.Name, kind, d.Description)
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+		fmt.Fprintln(out)
+	}
+	return nil
+}

--- a/internal/cmd/output_contract_test.go
+++ b/internal/cmd/output_contract_test.go
@@ -57,6 +57,7 @@ var commandOutputContracts = map[string]commandContract{
 	"redmine issues reopen":      {Mode: outputContractStructured},
 	"redmine issues update":      {Mode: outputContractStructured},
 	"redmine mcp serve":          {Mode: outputContractRawPassthrough, Reason: "runs the MCP JSON-RPC protocol over stdio"},
+	"redmine mcp tools":          {Mode: outputContractRawPassthrough, Reason: "prints a human-formatted catalog of MCP tools and groups"},
 	"redmine memberships create": {Mode: outputContractStructured},
 	"redmine memberships delete": {Mode: outputContractStructured},
 	"redmine memberships get":    {Mode: outputContractStructured},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -339,4 +339,45 @@ func applyEnvOverrides(cfg *Config, log *debug.Logger) {
 	if os.Getenv("REDMINE_NO_COLOR") != "" {
 		cfg.NoColor = true
 	}
+
+	mcpListEnv := map[string]*[]string{
+		"REDMINE_MCP_ENABLE_GROUPS":  &cfg.MCP.EnableGroups,
+		"REDMINE_MCP_DISABLE_GROUPS": &cfg.MCP.DisableGroups,
+		"REDMINE_MCP_ENABLE_TOOLS":   &cfg.MCP.EnableTools,
+		"REDMINE_MCP_DISABLE_TOOLS":  &cfg.MCP.DisableTools,
+	}
+	for envVar, field := range mcpListEnv {
+		if val := os.Getenv(envVar); val != "" {
+			*field = splitCSV(val)
+			log.Printf("Config: env override %s is set", envVar)
+		}
+	}
+
+	if val := os.Getenv("REDMINE_MCP_ENABLE_WRITES"); val != "" {
+		enable := parseBoolEnv(val)
+		cfg.MCP.EnableWrites = &enable
+		log.Printf("Config: env override REDMINE_MCP_ENABLE_WRITES is set")
+	}
+}
+
+// splitCSV trims, splits on commas, and drops empty entries.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// parseBoolEnv treats common falsy values as false; everything else is true.
+func parseBoolEnv(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "0", "false", "no", "off", "":
+		return false
+	default:
+		return true
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -500,3 +500,30 @@ profiles:
 		t.Fatalf("ActiveProfile = %q, want %q", pc.ActiveProfile, "a")
 	}
 }
+
+func TestApplyEnvOverrides_MCPListsAndBool(t *testing.T) {
+	t.Setenv("REDMINE_MCP_ENABLE_GROUPS", "issues, wiki ,projects")
+	t.Setenv("REDMINE_MCP_DISABLE_TOOLS", "delete_issue,delete_project")
+	t.Setenv("REDMINE_MCP_ENABLE_WRITES", "true")
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server: https://example.com\napi_key: k\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	want := []string{"issues", "wiki", "projects"}
+	if got := cfg.MCP.EnableGroups; len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Errorf("EnableGroups = %v, want %v", got, want)
+	}
+	if got := cfg.MCP.DisableTools; len(got) != 2 || got[0] != "delete_issue" || got[1] != "delete_project" {
+		t.Errorf("DisableTools = %v", got)
+	}
+	if cfg.MCP.EnableWrites == nil || !*cfg.MCP.EnableWrites {
+		t.Errorf("EnableWrites should be true (got %v)", cfg.MCP.EnableWrites)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,14 +2,32 @@ package config
 
 // Config holds the CLI configuration for a single profile.
 type Config struct {
-	Server         string `mapstructure:"server" yaml:"server,omitempty"`
-	APIKey         string `mapstructure:"api_key" yaml:"api_key,omitempty"`
-	Username       string `mapstructure:"username" yaml:"username,omitempty"`
-	Password       string `mapstructure:"password" yaml:"password,omitempty"`
-	AuthMethod     string `mapstructure:"auth_method" yaml:"auth_method,omitempty"` // "apikey" or "basic"
-	DefaultProject string `mapstructure:"default_project" yaml:"default_project,omitempty"`
-	OutputFormat   string `mapstructure:"output_format" yaml:"output_format,omitempty"` // "table", "json", "csv"
-	NoColor        bool   `mapstructure:"no_color" yaml:"no_color,omitempty"`
+	Server         string    `mapstructure:"server" yaml:"server,omitempty"`
+	APIKey         string    `mapstructure:"api_key" yaml:"api_key,omitempty"`
+	Username       string    `mapstructure:"username" yaml:"username,omitempty"`
+	Password       string    `mapstructure:"password" yaml:"password,omitempty"`
+	AuthMethod     string    `mapstructure:"auth_method" yaml:"auth_method,omitempty"` // "apikey" or "basic"
+	DefaultProject string    `mapstructure:"default_project" yaml:"default_project,omitempty"`
+	OutputFormat   string    `mapstructure:"output_format" yaml:"output_format,omitempty"` // "table", "json", "csv"
+	NoColor        bool      `mapstructure:"no_color" yaml:"no_color,omitempty"`
+	MCP            MCPConfig `mapstructure:"mcp" yaml:"mcp,omitempty"`
+}
+
+// MCPConfig holds per-profile defaults for the `redmine mcp serve` command.
+// Empty slices and a nil EnableWrites mean "no preference"; the CLI flags and
+// environment variables take precedence over these values.
+type MCPConfig struct {
+	// EnableWrites, when set, becomes the default for `--enable-writes` on
+	// the MCP server. A nil pointer means "fall back to the flag default".
+	EnableWrites *bool `mapstructure:"enable_writes" yaml:"enable_writes,omitempty"`
+	// EnableGroups restricts the server to the listed tool groups.
+	EnableGroups []string `mapstructure:"enable_groups" yaml:"enable_groups,omitempty"`
+	// DisableGroups removes groups from the active set.
+	DisableGroups []string `mapstructure:"disable_groups" yaml:"disable_groups,omitempty"`
+	// EnableTools is an explicit allow-list of tool names.
+	EnableTools []string `mapstructure:"enable_tools" yaml:"enable_tools,omitempty"`
+	// DisableTools is a deny-list of tool names applied last.
+	DisableTools []string `mapstructure:"disable_tools" yaml:"disable_tools,omitempty"`
 }
 
 // ProfileConfig holds the top-level configuration with multiple profiles.

--- a/internal/mcpgen/mcpgen.go
+++ b/internal/mcpgen/mcpgen.go
@@ -215,12 +215,30 @@ func renderTools(specs []ToolSpec) ([]byte, error) {
 		fmt.Fprintf(&buf, "\tregisterToolSpec(s, client, opts, toolSpec[%s, %s]{\n", spec.InputType, spec.OutputType)
 		fmt.Fprintf(&buf, "\t\tName:        %q,\n", spec.Name)
 		fmt.Fprintf(&buf, "\t\tDescription: %q,\n", spec.Description)
+		fmt.Fprintf(&buf, "\t\tCategory:    %q,\n", spec.Category)
 		if spec.Writes {
 			buf.WriteString("\t\tWrites:      true,\n")
 		}
 		fmt.Fprintf(&buf, "\t\tCall:        ops.%s,\n", spec.FuncName)
 		buf.WriteString("\t})\n")
 	}
+	buf.WriteString("}\n\n")
+
+	// Tool descriptor table for discovery commands (mcp list-groups). Built
+	// from the same specs to stay in lock-step with registerGeneratedTools.
+	buf.WriteString("// generatedToolDescriptors lists every tool registered by registerGeneratedTools\n")
+	buf.WriteString("// so the `mcp list-groups` command can render the catalog without spinning up\n")
+	buf.WriteString("// an MCP server.\n")
+	buf.WriteString("func generatedToolDescriptors() []ToolDescriptor {\n")
+	buf.WriteString("\treturn []ToolDescriptor{\n")
+	for _, spec := range specs {
+		if spec.Handler != "" {
+			continue
+		}
+		fmt.Fprintf(&buf, "\t\t{Name: %q, Description: %q, Group: %q, Writes: %v},\n",
+			spec.Name, spec.Description, spec.Category, spec.Writes)
+	}
+	buf.WriteString("\t}\n")
 	buf.WriteString("}\n")
 
 	return format.Source(buf.Bytes())

--- a/internal/mcpserver/filter_test.go
+++ b/internal/mcpserver/filter_test.go
@@ -1,0 +1,241 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestResolveOptions_NoSpecKeepsDefaults(t *testing.T) {
+	got := ResolveOptions(Options{}, FilterSpec{})
+	if got.EnabledGroups != nil {
+		t.Errorf("expected nil EnabledGroups, got %v", got.EnabledGroups)
+	}
+	if got.EnabledTools != nil || got.DisabledTools != nil {
+		t.Errorf("expected nil tool maps, got allow=%v deny=%v", got.EnabledTools, got.DisabledTools)
+	}
+}
+
+func TestResolveOptions_EnableGroupsNarrowsSet(t *testing.T) {
+	got := ResolveOptions(Options{}, FilterSpec{EnableGroups: []Group{GroupIssues, GroupWiki}})
+	want := map[Group]bool{GroupIssues: true, GroupWiki: true}
+	if len(got.EnabledGroups) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got.EnabledGroups), len(want))
+	}
+	for g := range want {
+		if !got.EnabledGroups[g] {
+			t.Errorf("group %q expected enabled", g)
+		}
+	}
+}
+
+func TestResolveOptions_DisableGroupsSubtractsFromAll(t *testing.T) {
+	got := ResolveOptions(Options{}, FilterSpec{DisableGroups: []Group{GroupTime}})
+	if got.EnabledGroups[GroupTime] {
+		t.Error("time group should be disabled")
+	}
+	if !got.EnabledGroups[GroupIssues] {
+		t.Error("issues should remain enabled when only time is disabled")
+	}
+}
+
+func TestResolveOptions_DisableSubtractsFromEnable(t *testing.T) {
+	got := ResolveOptions(Options{}, FilterSpec{
+		EnableGroups:  []Group{GroupIssues, GroupWiki},
+		DisableGroups: []Group{GroupWiki},
+	})
+	if !got.EnabledGroups[GroupIssues] {
+		t.Error("issues should remain enabled")
+	}
+	if got.EnabledGroups[GroupWiki] {
+		t.Error("wiki should be subtracted by disable list")
+	}
+}
+
+func TestParseGroup_RejectsUnknown(t *testing.T) {
+	if _, err := ParseGroup("nonsense"); err == nil {
+		t.Fatal("expected error for unknown group")
+	}
+}
+
+func TestParseGroup_AcceptsCanonical(t *testing.T) {
+	for _, g := range AllGroups() {
+		got, err := ParseGroup(string(g))
+		if err != nil {
+			t.Errorf("ParseGroup(%q): %v", g, err)
+		}
+		if got != g {
+			t.Errorf("ParseGroup(%q) = %q, want %q", g, got, g)
+		}
+	}
+}
+
+func TestGroupFilter_HidesDisabledGroup(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer closeTS()
+
+	opts := ResolveOptions(Options{Version: "v0", EnableWrites: true}, FilterSpec{
+		EnableGroups: []Group{GroupIssues},
+	})
+	cs, cleanup := newConnectedSession(t, apiClient, opts)
+	defer cleanup()
+
+	names := listToolNames(t, cs)
+	mustHave := []string{"list_issues", "get_issue", "create_issue"}
+	mustMiss := []string{"list_projects", "list_users", "search", "list_wiki_pages", "list_versions", "list_groups"}
+
+	for _, n := range mustHave {
+		if !contains(names, n) {
+			t.Errorf("issues tool %q missing when only issues group enabled", n)
+		}
+	}
+	for _, n := range mustMiss {
+		if contains(names, n) {
+			t.Errorf("non-issue tool %q registered when only issues group enabled", n)
+		}
+	}
+}
+
+func TestToolDenyList_HidesIndividualTool(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer closeTS()
+
+	opts := ResolveOptions(Options{Version: "v0", EnableWrites: true}, FilterSpec{
+		DisableTools: []string{"delete_issue", "delete_project"},
+	})
+	cs, cleanup := newConnectedSession(t, apiClient, opts)
+	defer cleanup()
+
+	names := listToolNames(t, cs)
+	if contains(names, "delete_issue") {
+		t.Error("delete_issue should be hidden by deny-list")
+	}
+	if contains(names, "delete_project") {
+		t.Error("delete_project should be hidden by deny-list")
+	}
+	if !contains(names, "create_issue") {
+		t.Error("create_issue should still be present (not in deny list)")
+	}
+	if !contains(names, "delete_user") {
+		t.Error("delete_user should still be present (not in deny list)")
+	}
+}
+
+func TestToolAllowList_OnlyListedToolsRegistered(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer closeTS()
+
+	opts := ResolveOptions(Options{Version: "v0"}, FilterSpec{
+		EnableTools: []string{"list_issues", "get_issue"},
+	})
+	cs, cleanup := newConnectedSession(t, apiClient, opts)
+	defer cleanup()
+
+	names := listToolNames(t, cs)
+	for _, n := range []string{"list_issues", "get_issue"} {
+		if !contains(names, n) {
+			t.Errorf("allow-listed tool %q missing", n)
+		}
+	}
+	for _, n := range []string{"list_projects", "list_versions", "search", "me"} {
+		if contains(names, n) {
+			t.Errorf("tool %q outside allow-list was registered", n)
+		}
+	}
+}
+
+func TestResourceTemplatesGatedByGroup(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer closeTS()
+
+	opts := ResolveOptions(Options{Version: "v0"}, FilterSpec{
+		EnableGroups: []Group{GroupIssues},
+	})
+	cs, cleanup := newConnectedSession(t, apiClient, opts)
+	defer cleanup()
+
+	res, err := cs.ListResourceTemplates(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+
+	templates := make(map[string]bool, len(res.ResourceTemplates))
+	for _, rt := range res.ResourceTemplates {
+		templates[rt.URITemplate] = true
+	}
+
+	if !templates[tmplIssue] {
+		t.Error("issue resource template should remain when issues group is enabled")
+	}
+	for _, t2 := range []string{tmplProject, tmplUser, tmplTimeEntry, tmplWiki, tmplVersion} {
+		if templates[t2] {
+			t.Errorf("resource template %q should be gated off when its group is disabled", t2)
+		}
+	}
+}
+
+func TestAllToolsCatalogCoversEveryGroup(t *testing.T) {
+	byGroup := ToolsByGroup()
+	if len(byGroup) != len(AllGroups()) {
+		t.Fatalf("ToolsByGroup len=%d, want %d", len(byGroup), len(AllGroups()))
+	}
+	for _, g := range AllGroups() {
+		if _, ok := byGroup[g]; !ok {
+			t.Errorf("group %q missing from catalog", g)
+		}
+	}
+
+	// Spot-check that at least one well-known tool ended up in each expected group.
+	wantOne := map[Group]string{
+		GroupIssues:      "list_issues",
+		GroupProjects:    "list_projects",
+		GroupTime:        "list_time_entries",
+		GroupUsers:       "list_users",
+		GroupGroups:      "list_groups",
+		GroupSearch:      "search",
+		GroupMeta:        "list_versions",
+		GroupWiki:        "list_wiki_pages",
+		GroupMemberships: "list_memberships",
+	}
+	for g, name := range wantOne {
+		found := false
+		for _, d := range byGroup[g] {
+			if d.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in group %q catalog", name, g)
+		}
+	}
+}
+
+func TestOptionsToolEnabled(t *testing.T) {
+	opts := Options{
+		EnabledTools:  map[string]bool{"list_issues": true},
+		DisabledTools: map[string]bool{"get_issue": true},
+	}
+	if !opts.toolEnabled("list_issues") {
+		t.Error("list_issues should be enabled by allow-list")
+	}
+	if opts.toolEnabled("create_issue") {
+		t.Error("create_issue not in allow-list should be hidden")
+	}
+	if opts.toolEnabled("get_issue") {
+		t.Error("get_issue should be hidden by deny-list (overrides allow)")
+	}
+
+	noFilter := Options{}
+	if !noFilter.toolEnabled("anything") {
+		t.Error("nil filters should pass through")
+	}
+}

--- a/internal/mcpserver/groups.go
+++ b/internal/mcpserver/groups.go
@@ -1,0 +1,130 @@
+package mcpserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Group is the public identifier of a tool group exposed by the MCP server.
+// Group names are part of the configuration surface (CLI flags, env vars,
+// config file). Renaming a value is a breaking change.
+//
+// Values mirror the //mcpgen:category directives in internal/ops so the
+// generator can stamp each tool with its group at code-generation time.
+type Group string
+
+const (
+	GroupIssues      Group = "issues"
+	GroupProjects    Group = "projects"
+	GroupTime        Group = "time"
+	GroupUsers       Group = "users"
+	GroupGroups      Group = "groups"
+	GroupSearch      Group = "search"
+	GroupMeta        Group = "meta"
+	GroupWiki        Group = "wiki"
+	GroupMemberships Group = "memberships"
+)
+
+// AllGroups returns the canonical list of groups in the order used by
+// `redmine mcp list-groups` and the documentation.
+func AllGroups() []Group {
+	return []Group{
+		GroupIssues,
+		GroupProjects,
+		GroupTime,
+		GroupUsers,
+		GroupGroups,
+		GroupSearch,
+		GroupMeta,
+		GroupWiki,
+		GroupMemberships,
+	}
+}
+
+// IsKnownGroup reports whether name matches one of the canonical groups.
+func IsKnownGroup(name string) bool {
+	for _, g := range AllGroups() {
+		if string(g) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseGroup validates a textual group name and returns the matching Group.
+// Names are matched case-insensitively to be friendly to CLI input.
+func ParseGroup(name string) (Group, error) {
+	want := strings.ToLower(strings.TrimSpace(name))
+	for _, g := range AllGroups() {
+		if string(g) == want {
+			return g, nil
+		}
+	}
+	return "", fmt.Errorf("unknown tool group %q (valid: %s)", name, strings.Join(groupNames(), ", "))
+}
+
+// ParseGroups parses a list of group names. Empty entries are skipped so
+// callers can pass values like "issues,,wiki" without failing.
+func ParseGroups(names []string) ([]Group, error) {
+	out := make([]Group, 0, len(names))
+	for _, n := range names {
+		if strings.TrimSpace(n) == "" {
+			continue
+		}
+		g, err := ParseGroup(n)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
+func groupNames() []string {
+	gs := AllGroups()
+	out := make([]string, len(gs))
+	for i, g := range gs {
+		out[i] = string(g)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ToolDescriptor is a static description of an MCP tool. It is emitted by
+// the code generator (zz_generated_tools.go) and consumed by the
+// `mcp list-groups` discovery command.
+type ToolDescriptor struct {
+	Name        string
+	Description string
+	Group       Group
+	Writes      bool
+}
+
+// AllTools returns the static catalog of every tool registered by the code
+// generator, sorted by group and then name. The result reflects the contents
+// of internal/ops/, not the current Options filter.
+func AllTools() []ToolDescriptor {
+	descriptors := generatedToolDescriptors()
+	sort.SliceStable(descriptors, func(i, j int) bool {
+		if descriptors[i].Group != descriptors[j].Group {
+			return descriptors[i].Group < descriptors[j].Group
+		}
+		return descriptors[i].Name < descriptors[j].Name
+	})
+	return descriptors
+}
+
+// ToolsByGroup buckets AllTools by group. Groups that are valid but have no
+// tools are still included with an empty slice so callers can render every
+// group.
+func ToolsByGroup() map[Group][]ToolDescriptor {
+	out := make(map[Group][]ToolDescriptor, len(AllGroups()))
+	for _, g := range AllGroups() {
+		out[g] = nil
+	}
+	for _, d := range AllTools() {
+		out[d.Group] = append(out[d.Group], d)
+	}
+	return out
+}

--- a/internal/mcpserver/groups.go
+++ b/internal/mcpserver/groups.go
@@ -128,3 +128,32 @@ func ToolsByGroup() map[Group][]ToolDescriptor {
 	}
 	return out
 }
+
+// IsKnownTool reports whether name matches a generated MCP tool name.
+func IsKnownTool(name string) bool {
+	want := strings.TrimSpace(name)
+	for _, d := range AllTools() {
+		if d.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseTools validates a list of tool names and returns the trimmed values.
+// Empty entries are skipped so callers can pass values like
+// "list_issues,,get_issue" without failing.
+func ParseTools(names []string) ([]string, error) {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		if !IsKnownTool(trimmed) {
+			return nil, fmt.Errorf("unknown tool %q", name)
+		}
+		out = append(out, trimmed)
+	}
+	return out, nil
+}

--- a/internal/mcpserver/options.go
+++ b/internal/mcpserver/options.go
@@ -15,4 +15,94 @@ type Options struct {
 
 	// Version is the server version advertised in the MCP initialize response.
 	Version string
+
+	// EnabledGroups, if non-nil, restricts tool and resource registration to
+	// the listed groups. A nil map means "all groups enabled" (the default).
+	// An empty non-nil map means "no groups enabled".
+	EnabledGroups map[Group]bool
+
+	// EnabledTools, if non-nil, restricts tool registration to the listed
+	// tool names within the enabled groups. A nil map means "no allow-list".
+	EnabledTools map[string]bool
+
+	// DisabledTools is a deny-list applied after the group and allow-list
+	// filters. Names listed here are never registered.
+	DisabledTools map[string]bool
+}
+
+// groupEnabled reports whether tools or resources belonging to g should be
+// registered. A nil EnabledGroups map means all groups are enabled.
+func (o Options) groupEnabled(g Group) bool {
+	if o.EnabledGroups == nil {
+		return true
+	}
+	return o.EnabledGroups[g]
+}
+
+// toolEnabled reports whether a tool with the given name should be registered,
+// applying both the optional allow-list and the deny-list. The group filter
+// is checked separately by registerToolSpec.
+func (o Options) toolEnabled(name string) bool {
+	if o.DisabledTools[name] {
+		return false
+	}
+	if o.EnabledTools != nil && !o.EnabledTools[name] {
+		return false
+	}
+	return true
+}
+
+// FilterSpec is the user-facing filter input collected from flags, env, and
+// config. ResolveOptions merges it into the runtime maps used by Options.
+type FilterSpec struct {
+	EnableGroups  []Group
+	DisableGroups []Group
+	EnableTools   []string
+	DisableTools  []string
+}
+
+// ResolveOptions builds the runtime Options filter maps from a FilterSpec.
+//
+// Precedence rules:
+//   - EnableGroups, when non-empty, narrows the set to only those groups;
+//     when empty, all groups start enabled.
+//   - DisableGroups subtracts from whatever EnableGroups produced.
+//   - EnableTools, when non-empty, becomes the tool allow-list.
+//   - DisableTools is the tool deny-list, applied last.
+//
+// Passing an empty FilterSpec is a no-op, preserving the default behavior of
+// "all groups enabled, no per-tool filter".
+func ResolveOptions(opts Options, spec FilterSpec) Options {
+	if len(spec.EnableGroups) > 0 || len(spec.DisableGroups) > 0 {
+		enabled := make(map[Group]bool, len(AllGroups()))
+		if len(spec.EnableGroups) == 0 {
+			for _, g := range AllGroups() {
+				enabled[g] = true
+			}
+		} else {
+			for _, g := range spec.EnableGroups {
+				enabled[g] = true
+			}
+		}
+		for _, g := range spec.DisableGroups {
+			delete(enabled, g)
+		}
+		opts.EnabledGroups = enabled
+	}
+
+	if len(spec.EnableTools) > 0 {
+		allow := make(map[string]bool, len(spec.EnableTools))
+		for _, n := range spec.EnableTools {
+			allow[n] = true
+		}
+		opts.EnabledTools = allow
+	}
+	if len(spec.DisableTools) > 0 {
+		deny := make(map[string]bool, len(spec.DisableTools))
+		for _, n := range spec.DisableTools {
+			deny[n] = true
+		}
+		opts.DisabledTools = deny
+	}
+	return opts
 }

--- a/internal/mcpserver/resources.go
+++ b/internal/mcpserver/resources.go
@@ -23,14 +23,23 @@ const (
 
 type resourceTemplateDefinition struct {
 	Template *mcp.ResourceTemplate
-	Read     func(context.Context, *api.Client, string) (*mcp.ReadResourceResult, error)
+	// Group ties the resource to a tool group. When the group is filtered out
+	// of Options, the resource template is skipped so a wiki-disabled server
+	// does not advertise redmine://wiki URIs.
+	Group Group
+	Read  func(context.Context, *api.Client, string) (*mcp.ReadResourceResult, error)
 }
 
 // registerResources wires the read-only URI templates. Resources are exposed
-// regardless of EnableWrites because they do not mutate state.
-func registerResources(s *mcp.Server, client *api.Client) {
+// regardless of EnableWrites because they do not mutate state, but they are
+// still gated by the same group filter as tools so a server configured to
+// only expose `issues` does not advertise wiki resources.
+func registerResources(s *mcp.Server, client *api.Client, opts Options) {
 	for _, def := range resourceTemplateDefinitions() {
 		definition := def
+		if definition.Group != "" && !opts.groupEnabled(definition.Group) {
+			continue
+		}
 		s.AddResourceTemplate(definition.Template, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 			return definition.Read(ctx, client, req.Params.URI)
 		})
@@ -46,7 +55,8 @@ func resourceTemplateDefinitions() []resourceTemplateDefinition {
 				Description: "A Redmine issue including journals, attachments, relations, children, and watchers.",
 				MIMEType:    mimeJSON,
 			},
-			Read: readIssueResource,
+			Group: GroupIssues,
+			Read:  readIssueResource,
 		},
 		{
 			Template: &mcp.ResourceTemplate{
@@ -55,7 +65,8 @@ func resourceTemplateDefinitions() []resourceTemplateDefinition {
 				Description: "A Redmine project including trackers, categories, and enabled modules.",
 				MIMEType:    mimeJSON,
 			},
-			Read: readProjectResource,
+			Group: GroupProjects,
+			Read:  readProjectResource,
 		},
 		{
 			Template: &mcp.ResourceTemplate{
@@ -64,7 +75,8 @@ func resourceTemplateDefinitions() []resourceTemplateDefinition {
 				Description: "A Redmine user. Use 'me' as the id to fetch the authenticated user.",
 				MIMEType:    mimeJSON,
 			},
-			Read: readUserResource,
+			Group: GroupUsers,
+			Read:  readUserResource,
 		},
 		{
 			Template: &mcp.ResourceTemplate{
@@ -73,7 +85,8 @@ func resourceTemplateDefinitions() []resourceTemplateDefinition {
 				Description: "A single Redmine time entry.",
 				MIMEType:    mimeJSON,
 			},
-			Read: readTimeEntryResource,
+			Group: GroupTime,
+			Read:  readTimeEntryResource,
 		},
 		{
 			Template: &mcp.ResourceTemplate{
@@ -82,7 +95,8 @@ func resourceTemplateDefinitions() []resourceTemplateDefinition {
 				Description: "A Redmine wiki page body. Markup is whatever the Redmine instance is configured to use (Textile by default, CommonMark optional).",
 				MIMEType:    mimeWikiText,
 			},
-			Read: readWikiResource,
+			Group: GroupWiki,
+			Read:  readWikiResource,
 		},
 		{
 			Template: &mcp.ResourceTemplate{
@@ -91,7 +105,8 @@ func resourceTemplateDefinitions() []resourceTemplateDefinition {
 				Description: "A Redmine version (milestone).",
 				MIMEType:    mimeJSON,
 			},
-			Read: readVersionResource,
+			Group: GroupMeta,
+			Read:  readVersionResource,
 		},
 	}
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -22,7 +22,7 @@ func BuildServer(client *api.Client, opts Options) *mcp.Server {
 	}, nil)
 
 	registerTools(srv, client, opts)
-	registerResources(srv, client)
+	registerResources(srv, client, opts)
 	registerPrompts(srv)
 
 	return srv

--- a/internal/mcpserver/tool_registry.go
+++ b/internal/mcpserver/tool_registry.go
@@ -16,12 +16,19 @@ type messageResult interface {
 type toolSpec[In, Out any] struct {
 	Name        string
 	Description string
+	Category    Group
 	Writes      bool
 	Call        func(context.Context, *api.Client, In) (Out, error)
 }
 
 func registerToolSpec[In, Out any](srv *mcp.Server, client *api.Client, opts Options, spec toolSpec[In, Out]) {
 	if spec.Writes && !opts.EnableWrites {
+		return
+	}
+	if spec.Category != "" && !opts.groupEnabled(spec.Category) {
+		return
+	}
+	if !opts.toolEnabled(spec.Name) {
 		return
 	}
 

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -13,290 +13,402 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 	registerToolSpec(s, client, opts, toolSpec[ops.GroupUserInput, ops.MessageResult]{
 		Name:        "add_group_user",
 		Description: "Add a user to a Redmine group. Requires --enable-writes.",
+		Category:    "groups",
 		Writes:      true,
 		Call:        ops.AddGroupUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateGroupInput, *models.Group]{
 		Name:        "create_group",
 		Description: "Create a new Redmine group. Requires --enable-writes.",
+		Category:    "groups",
 		Writes:      true,
 		Call:        ops.CreateGroup,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteGroupInput, ops.MessageResult]{
 		Name:        "delete_group",
 		Description: "Delete a Redmine group. Destructive. Requires --enable-writes.",
+		Category:    "groups",
 		Writes:      true,
 		Call:        ops.DeleteGroup,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetGroupInput, *models.Group]{
 		Name:        "get_group",
 		Description: "Fetch a single Redmine group by ID.",
+		Category:    "groups",
 		Call:        ops.GetGroup,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListGroupsInput, ops.GroupsListResult]{
 		Name:        "list_groups",
 		Description: "List Redmine groups.",
+		Category:    "groups",
 		Call:        ops.ListGroups,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GroupUserInput, ops.MessageResult]{
 		Name:        "remove_group_user",
 		Description: "Remove a user from a Redmine group. Requires --enable-writes.",
+		Category:    "groups",
 		Writes:      true,
 		Call:        ops.RemoveGroupUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateGroupInput, ops.MessageResult]{
 		Name:        "update_group",
 		Description: "Update an existing Redmine group. Requires --enable-writes.",
+		Category:    "groups",
 		Writes:      true,
 		Call:        ops.UpdateGroup,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.AddIssueCommentInput, ops.MessageResult]{
 		Name:        "add_issue_comment",
 		Description: "Add a journal comment to an existing issue. Requires --enable-writes.",
+		Category:    "issues",
 		Writes:      true,
 		Call:        ops.AddIssueComment,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CloseIssueInput, ops.MessageResult]{
 		Name:        "close_issue",
 		Description: "Close an issue by setting its status to the first closed status. Requires --enable-writes.",
+		Category:    "issues",
 		Writes:      true,
 		Call:        ops.CloseIssue,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateIssueInput, *models.Issue]{
 		Name:        "create_issue",
 		Description: "Create a new Redmine issue. Requires --enable-writes.",
+		Category:    "issues",
 		Writes:      true,
 		Call:        ops.CreateIssue,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteIssueInput, ops.MessageResult]{
 		Name:        "delete_issue",
 		Description: "Delete a Redmine issue. Destructive. Requires --enable-writes.",
+		Category:    "issues",
 		Writes:      true,
 		Call:        ops.DeleteIssue,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetIssueInput, *models.Issue]{
 		Name:        "get_issue",
 		Description: "Fetch a single Redmine issue by ID.",
+		Category:    "issues",
 		Call:        ops.GetIssue,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListIssuesInput, ops.IssuesListResult]{
 		Name:        "list_issues",
 		Description: "List Redmine issues matching the given filters.",
+		Category:    "issues",
 		Call:        ops.ListIssues,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ReopenIssueInput, ops.MessageResult]{
 		Name:        "reopen_issue",
 		Description: "Reopen a closed issue by setting its status to the first open status. Requires --enable-writes.",
+		Category:    "issues",
 		Writes:      true,
 		Call:        ops.ReopenIssue,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateIssueInput, ops.MessageResult]{
 		Name:        "update_issue",
 		Description: "Update fields on an existing Redmine issue. Requires --enable-writes.",
+		Category:    "issues",
 		Writes:      true,
 		Call:        ops.UpdateIssue,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateMembershipInput, *models.Membership]{
 		Name:        "create_membership",
 		Description: "Add a user to a project with the given roles. Requires --enable-writes.",
+		Category:    "memberships",
 		Writes:      true,
 		Call:        ops.CreateMembership,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteMembershipInput, ops.MessageResult]{
 		Name:        "delete_membership",
 		Description: "Remove a project membership. Destructive. Requires --enable-writes.",
+		Category:    "memberships",
 		Writes:      true,
 		Call:        ops.DeleteMembership,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetMembershipInput, *models.Membership]{
 		Name:        "get_membership",
 		Description: "Fetch a single project membership by ID.",
+		Category:    "memberships",
 		Call:        ops.GetMembership,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListMembershipsInput, ops.MembershipsListResult]{
 		Name:        "list_memberships",
 		Description: "List memberships for a project.",
+		Category:    "memberships",
 		Call:        ops.ListMemberships,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateMembershipInput, ops.MessageResult]{
 		Name:        "update_membership",
 		Description: "Replace the roles on a project membership. Requires --enable-writes.",
+		Category:    "memberships",
 		Writes:      true,
 		Call:        ops.UpdateMembership,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateVersionInput, *models.Version]{
 		Name:        "create_version",
 		Description: "Create a project version (milestone). Requires --enable-writes.",
+		Category:    "meta",
 		Writes:      true,
 		Call:        ops.CreateVersion,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteVersionInput, ops.MessageResult]{
 		Name:        "delete_version",
 		Description: "Delete a version (milestone). Destructive. Requires --enable-writes.",
+		Category:    "meta",
 		Writes:      true,
 		Call:        ops.DeleteVersion,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetVersionInput, *models.Version]{
 		Name:        "get_version",
 		Description: "Fetch a single version (milestone) by ID.",
+		Category:    "meta",
 		Call:        ops.GetVersion,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListCategoriesInput, ops.CategoriesListResult]{
 		Name:        "list_categories",
 		Description: "List issue categories for a project.",
+		Category:    "meta",
 		Call:        ops.ListCategories,
 	})
 	registerToolSpec(s, client, opts, toolSpec[struct{}, ops.StatusesListResult]{
 		Name:        "list_statuses",
 		Description: "List all issue statuses configured in this Redmine instance.",
+		Category:    "meta",
 		Call:        ops.ListStatuses,
 	})
 	registerToolSpec(s, client, opts, toolSpec[struct{}, ops.TrackersListResult]{
 		Name:        "list_trackers",
 		Description: "List all trackers (Bug, Feature, ...) configured in this Redmine instance.",
+		Category:    "meta",
 		Call:        ops.ListTrackers,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListVersionsInput, ops.VersionsListResult]{
 		Name:        "list_versions",
 		Description: "List versions (milestones) for a project.",
+		Category:    "meta",
 		Call:        ops.ListVersions,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateVersionInput, ops.MessageResult]{
 		Name:        "update_version",
 		Description: "Update an existing version (milestone). Requires --enable-writes.",
+		Category:    "meta",
 		Writes:      true,
 		Call:        ops.UpdateVersion,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateProjectInput, *models.Project]{
 		Name:        "create_project",
 		Description: "Create a new Redmine project. Requires --enable-writes.",
+		Category:    "projects",
 		Writes:      true,
 		Call:        ops.CreateProject,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteProjectInput, ops.MessageResult]{
 		Name:        "delete_project",
 		Description: "Delete a Redmine project. Destructive. Requires --enable-writes.",
+		Category:    "projects",
 		Writes:      true,
 		Call:        ops.DeleteProject,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetProjectInput, *models.Project]{
 		Name:        "get_project",
 		Description: "Fetch a single Redmine project by identifier or ID.",
+		Category:    "projects",
 		Call:        ops.GetProject,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListProjectMembersInput, ops.ProjectMembersListResult]{
 		Name:        "list_project_members",
 		Description: "List members for a Redmine project.",
+		Category:    "projects",
 		Call:        ops.ListProjectMembers,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListProjectsInput, ops.ProjectsListResult]{
 		Name:        "list_projects",
 		Description: "List Redmine projects.",
+		Category:    "projects",
 		Call:        ops.ListProjects,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateProjectInput, ops.MessageResult]{
 		Name:        "update_project",
 		Description: "Update an existing Redmine project. Requires --enable-writes.",
+		Category:    "projects",
 		Writes:      true,
 		Call:        ops.UpdateProject,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.SearchInput, ops.SearchResultsListResult]{
 		Name:        "search",
 		Description: "Search across Redmine issues, wiki pages, news, and more. If no type flag is set, issues and wiki pages are included by default.",
+		Category:    "search",
 		Call:        ops.Search,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateTimeEntryInput, *models.TimeEntry]{
 		Name:        "create_time_entry",
 		Description: "Log a new time entry. Requires --enable-writes.",
+		Category:    "time",
 		Writes:      true,
 		Call:        ops.CreateTimeEntry,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteTimeEntryInput, ops.MessageResult]{
 		Name:        "delete_time_entry",
 		Description: "Delete a time entry. Destructive. Requires --enable-writes.",
+		Category:    "time",
 		Writes:      true,
 		Call:        ops.DeleteTimeEntry,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetTimeEntryInput, *models.TimeEntry]{
 		Name:        "get_time_entry",
 		Description: "Fetch a single time entry by ID.",
+		Category:    "time",
 		Call:        ops.GetTimeEntry,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListTimeEntriesInput, ops.TimeEntriesListResult]{
 		Name:        "list_time_entries",
 		Description: "List Redmine time entries matching the given filters.",
+		Category:    "time",
 		Call:        ops.ListTimeEntries,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.SummaryTimeEntriesInput, ops.TimeSummaryResult]{
 		Name:        "summary_time_entries",
 		Description: "Summarize time entries grouped by day, project, or activity.",
+		Category:    "time",
 		Call:        ops.SummaryTimeEntries,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateTimeEntryInput, ops.MessageResult]{
 		Name:        "update_time_entry",
 		Description: "Update an existing time entry. Requires --enable-writes.",
+		Category:    "time",
 		Writes:      true,
 		Call:        ops.UpdateTimeEntry,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateUserInput, *models.User]{
 		Name:        "create_user",
 		Description: "Create a new Redmine user. Requires --enable-writes and admin privileges.",
+		Category:    "users",
 		Writes:      true,
 		Call:        ops.CreateUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteUserInput, ops.MessageResult]{
 		Name:        "delete_user",
 		Description: "Delete a Redmine user. Destructive. Requires --enable-writes.",
+		Category:    "users",
 		Writes:      true,
 		Call:        ops.DeleteUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetUserInput, *models.User]{
 		Name:        "get_user",
 		Description: "Fetch a single Redmine user by numeric ID.",
+		Category:    "users",
 		Call:        ops.GetUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListUsersInput, ops.UsersListResult]{
 		Name:        "list_users",
 		Description: "List Redmine users matching the given filter.",
+		Category:    "users",
 		Call:        ops.ListUsers,
 	})
 	registerToolSpec(s, client, opts, toolSpec[struct{}, *models.User]{
 		Name:        "me",
 		Description: "Return the currently authenticated Redmine user.",
+		Category:    "users",
 		Call:        ops.GetCurrentUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateUserInput, ops.MessageResult]{
 		Name:        "update_user",
 		Description: "Update an existing Redmine user. Requires --enable-writes.",
+		Category:    "users",
 		Writes:      true,
 		Call:        ops.UpdateUser,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.CreateWikiPageInput, *models.WikiPage]{
 		Name:        "create_wiki_page",
 		Description: "Create (or overwrite) a wiki page. Requires --enable-writes.",
+		Category:    "wiki",
 		Writes:      true,
 		Call:        ops.CreateWikiPage,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.DeleteWikiPageInput, ops.MessageResult]{
 		Name:        "delete_wiki_page",
 		Description: "Delete a wiki page. Destructive. Requires --enable-writes.",
+		Category:    "wiki",
 		Writes:      true,
 		Call:        ops.DeleteWikiPage,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetWikiPageInput, *models.WikiPage]{
 		Name:        "get_wiki_page",
 		Description: "Fetch a single wiki page.",
+		Category:    "wiki",
 		Call:        ops.GetWikiPage,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListWikiPagesInput, ops.WikiPagesListResult]{
 		Name:        "list_wiki_pages",
 		Description: "List wiki pages for a project.",
+		Category:    "wiki",
 		Call:        ops.ListWikiPages,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.UpdateWikiPageInput, ops.MessageResult]{
 		Name:        "update_wiki_page",
 		Description: "Update an existing wiki page. Requires --enable-writes.",
+		Category:    "wiki",
 		Writes:      true,
 		Call:        ops.UpdateWikiPage,
 	})
+}
+
+// generatedToolDescriptors lists every tool registered by registerGeneratedTools
+// so the `mcp list-groups` command can render the catalog without spinning up
+// an MCP server.
+func generatedToolDescriptors() []ToolDescriptor {
+	return []ToolDescriptor{
+		{Name: "add_group_user", Description: "Add a user to a Redmine group. Requires --enable-writes.", Group: "groups", Writes: true},
+		{Name: "create_group", Description: "Create a new Redmine group. Requires --enable-writes.", Group: "groups", Writes: true},
+		{Name: "delete_group", Description: "Delete a Redmine group. Destructive. Requires --enable-writes.", Group: "groups", Writes: true},
+		{Name: "get_group", Description: "Fetch a single Redmine group by ID.", Group: "groups", Writes: false},
+		{Name: "list_groups", Description: "List Redmine groups.", Group: "groups", Writes: false},
+		{Name: "remove_group_user", Description: "Remove a user from a Redmine group. Requires --enable-writes.", Group: "groups", Writes: true},
+		{Name: "update_group", Description: "Update an existing Redmine group. Requires --enable-writes.", Group: "groups", Writes: true},
+		{Name: "add_issue_comment", Description: "Add a journal comment to an existing issue. Requires --enable-writes.", Group: "issues", Writes: true},
+		{Name: "close_issue", Description: "Close an issue by setting its status to the first closed status. Requires --enable-writes.", Group: "issues", Writes: true},
+		{Name: "create_issue", Description: "Create a new Redmine issue. Requires --enable-writes.", Group: "issues", Writes: true},
+		{Name: "delete_issue", Description: "Delete a Redmine issue. Destructive. Requires --enable-writes.", Group: "issues", Writes: true},
+		{Name: "get_issue", Description: "Fetch a single Redmine issue by ID.", Group: "issues", Writes: false},
+		{Name: "list_issues", Description: "List Redmine issues matching the given filters.", Group: "issues", Writes: false},
+		{Name: "reopen_issue", Description: "Reopen a closed issue by setting its status to the first open status. Requires --enable-writes.", Group: "issues", Writes: true},
+		{Name: "update_issue", Description: "Update fields on an existing Redmine issue. Requires --enable-writes.", Group: "issues", Writes: true},
+		{Name: "create_membership", Description: "Add a user to a project with the given roles. Requires --enable-writes.", Group: "memberships", Writes: true},
+		{Name: "delete_membership", Description: "Remove a project membership. Destructive. Requires --enable-writes.", Group: "memberships", Writes: true},
+		{Name: "get_membership", Description: "Fetch a single project membership by ID.", Group: "memberships", Writes: false},
+		{Name: "list_memberships", Description: "List memberships for a project.", Group: "memberships", Writes: false},
+		{Name: "update_membership", Description: "Replace the roles on a project membership. Requires --enable-writes.", Group: "memberships", Writes: true},
+		{Name: "create_version", Description: "Create a project version (milestone). Requires --enable-writes.", Group: "meta", Writes: true},
+		{Name: "delete_version", Description: "Delete a version (milestone). Destructive. Requires --enable-writes.", Group: "meta", Writes: true},
+		{Name: "get_version", Description: "Fetch a single version (milestone) by ID.", Group: "meta", Writes: false},
+		{Name: "list_categories", Description: "List issue categories for a project.", Group: "meta", Writes: false},
+		{Name: "list_statuses", Description: "List all issue statuses configured in this Redmine instance.", Group: "meta", Writes: false},
+		{Name: "list_trackers", Description: "List all trackers (Bug, Feature, ...) configured in this Redmine instance.", Group: "meta", Writes: false},
+		{Name: "list_versions", Description: "List versions (milestones) for a project.", Group: "meta", Writes: false},
+		{Name: "update_version", Description: "Update an existing version (milestone). Requires --enable-writes.", Group: "meta", Writes: true},
+		{Name: "create_project", Description: "Create a new Redmine project. Requires --enable-writes.", Group: "projects", Writes: true},
+		{Name: "delete_project", Description: "Delete a Redmine project. Destructive. Requires --enable-writes.", Group: "projects", Writes: true},
+		{Name: "get_project", Description: "Fetch a single Redmine project by identifier or ID.", Group: "projects", Writes: false},
+		{Name: "list_project_members", Description: "List members for a Redmine project.", Group: "projects", Writes: false},
+		{Name: "list_projects", Description: "List Redmine projects.", Group: "projects", Writes: false},
+		{Name: "update_project", Description: "Update an existing Redmine project. Requires --enable-writes.", Group: "projects", Writes: true},
+		{Name: "search", Description: "Search across Redmine issues, wiki pages, news, and more. If no type flag is set, issues and wiki pages are included by default.", Group: "search", Writes: false},
+		{Name: "create_time_entry", Description: "Log a new time entry. Requires --enable-writes.", Group: "time", Writes: true},
+		{Name: "delete_time_entry", Description: "Delete a time entry. Destructive. Requires --enable-writes.", Group: "time", Writes: true},
+		{Name: "get_time_entry", Description: "Fetch a single time entry by ID.", Group: "time", Writes: false},
+		{Name: "list_time_entries", Description: "List Redmine time entries matching the given filters.", Group: "time", Writes: false},
+		{Name: "summary_time_entries", Description: "Summarize time entries grouped by day, project, or activity.", Group: "time", Writes: false},
+		{Name: "update_time_entry", Description: "Update an existing time entry. Requires --enable-writes.", Group: "time", Writes: true},
+		{Name: "create_user", Description: "Create a new Redmine user. Requires --enable-writes and admin privileges.", Group: "users", Writes: true},
+		{Name: "delete_user", Description: "Delete a Redmine user. Destructive. Requires --enable-writes.", Group: "users", Writes: true},
+		{Name: "get_user", Description: "Fetch a single Redmine user by numeric ID.", Group: "users", Writes: false},
+		{Name: "list_users", Description: "List Redmine users matching the given filter.", Group: "users", Writes: false},
+		{Name: "me", Description: "Return the currently authenticated Redmine user.", Group: "users", Writes: false},
+		{Name: "update_user", Description: "Update an existing Redmine user. Requires --enable-writes.", Group: "users", Writes: true},
+		{Name: "create_wiki_page", Description: "Create (or overwrite) a wiki page. Requires --enable-writes.", Group: "wiki", Writes: true},
+		{Name: "delete_wiki_page", Description: "Delete a wiki page. Destructive. Requires --enable-writes.", Group: "wiki", Writes: true},
+		{Name: "get_wiki_page", Description: "Fetch a single wiki page.", Group: "wiki", Writes: false},
+		{Name: "list_wiki_pages", Description: "List wiki pages for a project.", Group: "wiki", Writes: false},
+		{Name: "update_wiki_page", Description: "Update an existing wiki page. Requires --enable-writes.", Group: "wiki", Writes: true},
+	}
 }


### PR DESCRIPTION
## Summary

- Adds per-group and per-tool allow/deny filters to the MCP server so a host can be limited to a narrow surface (e.g. only `issues`, or everything except destructive deletes). Defaults are unchanged.
- Filters can be set via CLI flags, environment variables, or a profile-scoped `mcp:` block in `~/.redmine-cli.yaml`.
- New `redmine mcp tools` command prints the static catalog of tool groups and tools so users can see what's available before configuring filters.

## Configuration surfaces

| Layer | Knobs |
| --- | --- |
| CLI flags | `--enable-groups`, `--disable-groups`, `--enable-tools`, `--disable-tools` (plus existing `--enable-writes`) |
| Env vars | `REDMINE_MCP_ENABLE_GROUPS`, `REDMINE_MCP_DISABLE_GROUPS`, `REDMINE_MCP_ENABLE_TOOLS`, `REDMINE_MCP_DISABLE_TOOLS`, `REDMINE_MCP_ENABLE_WRITES` |
| Config file | `profiles.<name>.mcp.{enable_writes, enable_groups, disable_groups, enable_tools, disable_tools}` |

Precedence: CLI flag > env var > config file > default. Resource templates are gated by the same group filter, so disabling `wiki` also drops `redmine://wiki/...` from `ListResourceTemplates`.

## Implementation notes

- Tool groups are first-class via the existing `//mcpgen:category` directives, surfaced as `mcpserver.Group` constants. The mcpgen output now stamps each tool with `Category` and emits a `generatedToolDescriptors()` table that powers `mcp tools` without spinning up an MCP server.
- Filtering lives in one place: `registerToolSpec` checks group, allow-list, and deny-list before adding the tool. No per-tool boilerplate to maintain.
- Defaults preserved: nil `EnabledGroups` map = all groups enabled. Existing `TestWriteGate_*` tests continue to pass without changes.

## Test plan

- [x] `go test ./...` (full suite, 26 packages green)
- [x] `golangci-lint run` (0 issues)
- [x] New tests: `filter_test.go` covers group narrowing, deny-list, allow-list, resource gating, catalog completeness, and option resolution precedence
- [x] New tests: `serve_test.go` covers the flag-vs-config merge precedence and the boolean enable-writes resolution
- [x] New test: `config_test.go` covers `REDMINE_MCP_*` env overrides
- [x] Smoke-tested `redmine mcp tools` output (renders all 9 groups grouped with read/write markers)