### PR TITLE
feat(mcp): harden HTTP transport and add e2e coverage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -154,7 +154,11 @@ profiles:
       disable_tools: [delete_issue]
 ```
 
-CLI フラグは設定ファイルより優先され、`REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` 環境変数は設定ファイルを上書きします。
+CLI フラグは設定ファイルより優先され、`REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` / `REDMINE_MCP_AUTH_TOKEN` 環境変数は設定ファイルを上書きします。
+
+#### HTTP トランスポート
+
+`--http :8080` は `127.0.0.1:8080` にバインドするように書き換えられます -- サーバがすべてのインターフェースに既定で公開されることはありません。外部に公開するには明示的にホストを指定し（`0.0.0.0:8080`）、`--auth-token`（または `REDMINE_MCP_AUTH_TOKEN` / 設定の `mcp.auth_token`）でベアラートークンを設定してください。ループバック以外にバインドしているのにトークンが無い場合、CLI は stderr に警告を出しつつ起動します。クライアントは毎リクエストに `Authorization: Bearer <token>` を付与する必要があります。
 
 ## ローカル E2E テスト
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ profiles:
       disable_tools: [delete_issue]
 ```
 
-CLI flags override config, and `REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` env vars override the config file.
+CLI flags override config, and `REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` / `REDMINE_MCP_AUTH_TOKEN` env vars override the config file.
+
+#### HTTP transport
+
+`--http :8080` is rewritten to bind on `127.0.0.1:8080` -- the server is never exposed on every interface by default. To listen externally, pass an explicit host (`0.0.0.0:8080`) and set a bearer token with `--auth-token` (or `REDMINE_MCP_AUTH_TOKEN` / `mcp.auth_token` in the config). Without a token on a non-loopback bind the CLI prints a warning and starts anyway. Clients must send `Authorization: Bearer <token>` on every request.
 
 ## Local E2E Testing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,11 @@ profiles:
       disable_tools: [delete_issue]
 ```
 
-CLI 标志会覆盖配置文件，`REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` 环境变量也会覆盖该配置块。
+CLI 标志会覆盖配置文件，`REDMINE_MCP_ENABLE_GROUPS` / `REDMINE_MCP_DISABLE_GROUPS` / `REDMINE_MCP_ENABLE_TOOLS` / `REDMINE_MCP_DISABLE_TOOLS` / `REDMINE_MCP_ENABLE_WRITES` / `REDMINE_MCP_AUTH_TOKEN` 环境变量也会覆盖该配置块。
+
+#### HTTP 传输
+
+`--http :8080` 会被改写为绑定在 `127.0.0.1:8080` 上 -- 服务器永远不会默认在所有网卡上暴露。如要对外监听，请显式指定主机（`0.0.0.0:8080`），并通过 `--auth-token`（或 `REDMINE_MCP_AUTH_TOKEN` / 配置中的 `mcp.auth_token`）设置一个 Bearer 令牌。如果在非回环地址上绑定时未设置令牌，CLI 会向 stderr 输出警告但仍会启动。客户端必须在每个请求上发送 `Authorization: Bearer <token>`。
 
 ## 本地端到端测试
 

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -60,6 +60,37 @@ The same file is the source of truth for what the agent learns -- read it direct
   Write tools are destructive. Prefer leaving them disabled unless the host surfaces a per-call approval UI you trust.
 </Aside>
 
+### HTTP transport
+
+Pass `--http <addr>` to expose the server over streamable HTTP instead of stdio. The address shorthand `:8080` (no host) is rewritten to `127.0.0.1:8080` so the server is never accidentally reachable from other machines. Pass an explicit host to listen elsewhere:
+
+```bash
+# Loopback only -- safe default
+redmine mcp serve --http :8080
+
+# Explicit loopback (equivalent)
+redmine mcp serve --http 127.0.0.1:8080
+
+# Listen on every interface -- always pair with --auth-token
+redmine mcp serve --http 0.0.0.0:8080 --auth-token "$(openssl rand -hex 32)"
+```
+
+When a non-loopback bind is detected without `--auth-token`, the CLI prints a warning to stderr but still starts. The server applies `ReadHeaderTimeout=10s`, `ReadTimeout=30s`, and `IdleTimeout=120s`; `WriteTimeout` is left unbounded so slow Redmine instances don't terminate in-flight tool calls.
+
+Clients must send the bearer token on every request:
+
+```http
+POST / HTTP/1.1
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+The token can also live in the config block (`mcp.auth_token`) or `REDMINE_MCP_AUTH_TOKEN`. Flags override both.
+
+<Aside type="danger">
+  The bearer token is the only thing standing between any HTTP-reachable client and your Redmine instance through this server. Generate it with a CSPRNG, never reuse it across deployments, and prefer terminating TLS in front of the server (reverse proxy) when binding outside loopback.
+</Aside>
+
 ### Narrowing the exposed tools
 
 For an issue-only assistant, drop everything but the issues group:
@@ -87,7 +118,7 @@ profiles:
       disable_tools: [delete_issue]
 ```
 
-Environment variables (`REDMINE_MCP_ENABLE_GROUPS`, `REDMINE_MCP_DISABLE_GROUPS`, `REDMINE_MCP_ENABLE_TOOLS`, `REDMINE_MCP_DISABLE_TOOLS`, `REDMINE_MCP_ENABLE_WRITES`) override the config block.
+Environment variables (`REDMINE_MCP_ENABLE_GROUPS`, `REDMINE_MCP_DISABLE_GROUPS`, `REDMINE_MCP_ENABLE_TOOLS`, `REDMINE_MCP_DISABLE_TOOLS`, `REDMINE_MCP_ENABLE_WRITES`, `REDMINE_MCP_AUTH_TOKEN`) override the config block.
 
 ### Prerequisite
 

--- a/docs/src/content/docs/zh-cn/guides/ai-agents.mdx
+++ b/docs/src/content/docs/zh-cn/guides/ai-agents.mdx
@@ -60,6 +60,37 @@ redmine-cli 针对 AI 代理提供两种集成方式，具体取决于你的工�
   写入工具具有破坏性。除非宿主提供了你信任的逐次审批界面（per-call approval UI），否则建议保持禁用。
 </Aside>
 
+### HTTP 传输
+
+传入 `--http <addr>` 可以让服务器通过 streamable HTTP 而不是 stdio 暴露。地址简写 `:8080`（不带主机）会被改写为 `127.0.0.1:8080`，因此服务器永远不会被意外地暴露到其他机器。要在其他地址监听，请显式指定主机：
+
+```bash
+# 仅回环 -- 安全的默认值
+redmine mcp serve --http :8080
+
+# 显式回环（等价）
+redmine mcp serve --http 127.0.0.1:8080
+
+# 在所有网卡上监听 -- 务必同时设置 --auth-token
+redmine mcp serve --http 0.0.0.0:8080 --auth-token "$(openssl rand -hex 32)"
+```
+
+当检测到非回环绑定但未设置 `--auth-token` 时，CLI 会向 stderr 输出警告，但仍然启动。服务器会应用 `ReadHeaderTimeout=10s`、`ReadTimeout=30s`、`IdleTimeout=120s`；为避免缓慢的 Redmine 实例中断进行中的工具调用，`WriteTimeout` 保持不限。
+
+客户端必须在每个请求上发送 Bearer 令牌：
+
+```http
+POST / HTTP/1.1
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+令牌也可以放在配置块（`mcp.auth_token`）或 `REDMINE_MCP_AUTH_TOKEN` 中。命令行标志会覆盖二者。
+
+<Aside type="danger">
+  Bearer 令牌是任何可达 HTTP 客户端与你的 Redmine 实例之间唯一的屏障。请使用 CSPRNG 生成令牌，不要在不同部署间复用，并尽量在服务器之前用反向代理终止 TLS（特别是当绑定到回环以外时）。
+</Aside>
+
 ### 收窄暴露的工具范围
 
 对于只处理 issue 的助手，可仅保留 issues 组：
@@ -87,7 +118,7 @@ profiles:
       disable_tools: [delete_issue]
 ```
 
-环境变量（`REDMINE_MCP_ENABLE_GROUPS`、`REDMINE_MCP_DISABLE_GROUPS`、`REDMINE_MCP_ENABLE_TOOLS`、`REDMINE_MCP_DISABLE_TOOLS`、`REDMINE_MCP_ENABLE_WRITES`）会覆盖该配置块。
+环境变量（`REDMINE_MCP_ENABLE_GROUPS`、`REDMINE_MCP_DISABLE_GROUPS`、`REDMINE_MCP_ENABLE_TOOLS`、`REDMINE_MCP_DISABLE_TOOLS`、`REDMINE_MCP_ENABLE_WRITES`、`REDMINE_MCP_AUTH_TOKEN`）会覆盖该配置块。
 
 ### 前置条件
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -66,6 +66,7 @@ Redmine instance. The suite is split into topical files:
 | `auth_test.go`           | basic-auth profile against `/users/current.json` (needs `REDMINE_E2E_PASSWORD`) |
 | `api_test.go`            | raw `api` passthrough GET + POST + PUT with `--input` |
 | `errors_test.go`         | error envelope codes: `not_found`, `auth_failed` |
+| `mcp_test.go`            | MCP `serve` over stdio + HTTP, group filter, write gating, `--auth-token` 401 |
 
 Shared infrastructure lives in `e2e_test.go` (TestMain + `requireE2E`),
 `runner_test.go` (CLI runner + profile constructors), `helpers_test.go`

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -1,0 +1,335 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mcpServerArgs returns the standard `mcp serve` argv with the active
+// runner's config wired in. Extra args are appended verbatim.
+func (r *cliRunner) mcpServerArgs(extra ...string) []string {
+	args := []string{"--config", r.configPath, "mcp", "serve"}
+	return append(args, extra...)
+}
+
+// startMCPStdio spawns the CLI as a subprocess on the stdio transport and
+// returns a connected MCP client session. Cleanup terminates the subprocess
+// and surfaces its stderr on test failure.
+func (r *cliRunner) startMCPStdio(t *testing.T, ctx context.Context, extraArgs ...string) *mcp.ClientSession {
+	t.Helper()
+
+	cmd := exec.Command(builtCLIPath, r.mcpServerArgs(extraArgs...)...)
+	cmd.Dir = r.repoRoot
+	cmd.Env = append(os.Environ(), "REDMINE_NO_UPDATE_CHECK=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	transport := &mcp.CommandTransport{Command: cmd}
+	client := mcp.NewClient(&mcp.Implementation{Name: "redmine-cli-e2e", Version: "v0"}, nil)
+
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP stdio: %v\nserver stderr:\n%s", err, stderr.String())
+	}
+	t.Cleanup(func() {
+		_ = session.Close()
+		if t.Failed() && stderr.Len() > 0 {
+			t.Logf("MCP server stderr:\n%s", stderr.String())
+		}
+	})
+	return session
+}
+
+// startMCPHTTP spawns the CLI on a free localhost port over HTTP and returns a
+// connected MCP client session plus the chosen base URL. authToken, when
+// non-empty, is passed via --auth-token and the client is configured to send
+// it on every request.
+func (r *cliRunner) startMCPHTTP(t *testing.T, ctx context.Context, authToken string, extraArgs ...string) (*mcp.ClientSession, string) {
+	t.Helper()
+
+	port := freeLoopbackPort(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	args := []string{"--http", addr}
+	if authToken != "" {
+		args = append(args, "--auth-token", authToken)
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.Command(builtCLIPath, r.mcpServerArgs(args...)...)
+	cmd.Dir = r.repoRoot
+	cmd.Env = append(os.Environ(), "REDMINE_NO_UPDATE_CHECK=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start MCP HTTP: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		if t.Failed() && stderr.Len() > 0 {
+			t.Logf("MCP server stderr:\n%s", stderr.String())
+		}
+	})
+
+	endpoint := "http://" + addr
+	if err := waitForHTTP(ctx, endpoint, 10*time.Second); err != nil {
+		t.Fatalf("MCP HTTP server never became ready at %s: %v\nstderr:\n%s", addr, err, stderr.String())
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	if authToken != "" {
+		httpClient.Transport = &authedTransport{base: http.DefaultTransport, token: authToken}
+	}
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:             endpoint,
+		HTTPClient:           httpClient,
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "redmine-cli-e2e", Version: "v0"}, nil)
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP HTTP: %v\nstderr:\n%s", err, stderr.String())
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	return session, endpoint
+}
+
+// authedTransport adds an Authorization: Bearer header to every request.
+type authedTransport struct {
+	base  http.RoundTripper
+	token string
+}
+
+func (a *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+a.token)
+	return a.base.RoundTrip(clone)
+}
+
+// freeLoopbackPort reserves an OS-assigned port on 127.0.0.1, releases it,
+// and returns the port number. There is a small race between release and the
+// child process binding it; in practice this is fine for sequential e2e runs.
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		t.Fatalf("release port: %v", err)
+	}
+	return port
+}
+
+// waitForHTTP polls endpoint until a TCP connection succeeds or the timeout
+// elapses. The MCP server returns 4xx for unrelated requests, which still
+// proves the listener is up; we just need the connect to succeed.
+func waitForHTTP(ctx context.Context, endpoint string, timeout time.Duration) error {
+	host := strings.TrimPrefix(endpoint, "http://")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		conn, err := net.DialTimeout("tcp", host, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("listener at %s did not come up within %s", endpoint, timeout)
+}
+
+// toolNames extracts the tool names from a tools/list response, sorted by
+// the order returned. Tests should compare via maps for stable assertions.
+func toolNames(tools []*mcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func TestMCPStdio_HandshakeAndReadTool(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session := r.startMCPStdio(t, ctx)
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	names := toolNames(tools.Tools)
+	if len(names) == 0 {
+		t.Fatal("ListTools returned no tools")
+	}
+	mustContain(t, names, "list_projects", "get_issue", "list_issues")
+
+	// list_projects against the live Redmine proves the tool actually
+	// reaches the API, not just that it was registered.
+	out, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_projects"})
+	if err != nil {
+		t.Fatalf("CallTool list_projects: %v", err)
+	}
+	if out.IsError {
+		t.Fatalf("list_projects returned IsError: %s", structuredJSON(out))
+	}
+	if len(out.Content) == 0 {
+		t.Fatal("list_projects returned empty content")
+	}
+}
+
+func TestMCPStdio_WritesGatedByFlag(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session := r.startMCPStdio(t, ctx)
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	for _, name := range toolNames(tools.Tools) {
+		switch name {
+		case "create_issue", "update_issue", "delete_issue", "create_project", "delete_project":
+			t.Errorf("write tool %q exposed without --enable-writes", name)
+		}
+	}
+}
+
+func TestMCPStdio_GroupFilter(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session := r.startMCPStdio(t, ctx, "--enable-groups", "issues")
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	names := toolNames(tools.Tools)
+	if len(names) == 0 {
+		t.Fatal("issues group should expose at least one tool")
+	}
+	mustContain(t, names, "list_issues", "get_issue")
+	for _, name := range names {
+		// list_projects belongs to the projects group; should be hidden.
+		if name == "list_projects" || name == "get_project" || name == "list_users" {
+			t.Errorf("--enable-groups issues leaked non-issues tool %q", name)
+		}
+	}
+}
+
+func TestMCPHTTP_HandshakeAndReadTool(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session, _ := r.startMCPHTTP(t, ctx, "")
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools over HTTP: %v", err)
+	}
+	if len(tools.Tools) == 0 {
+		t.Fatal("ListTools over HTTP returned no tools")
+	}
+
+	out, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_projects"})
+	if err != nil {
+		t.Fatalf("CallTool list_projects over HTTP: %v", err)
+	}
+	if out.IsError {
+		t.Fatalf("list_projects returned IsError over HTTP: %s", structuredJSON(out))
+	}
+}
+
+func TestMCPHTTP_AuthTokenGate(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const token = "e2e-secret-token-do-not-reuse"
+	session, endpoint := r.startMCPHTTP(t, ctx, token)
+
+	if _, err := session.ListTools(ctx, nil); err != nil {
+		t.Fatalf("ListTools with valid token: %v", err)
+	}
+
+	// Probe the same endpoint with no token: must be 401.
+	rejectClient := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	if err != nil {
+		t.Fatalf("build probe request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := rejectClient.Do(req)
+	if err != nil {
+		t.Fatalf("probe without token: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status without token = %d, want 401", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got == "" {
+		t.Error("expected WWW-Authenticate header on 401 from auth-gated server")
+	}
+}
+
+func mustContain(t *testing.T, haystack []string, needles ...string) {
+	t.Helper()
+	set := make(map[string]bool, len(haystack))
+	for _, h := range haystack {
+		set[h] = true
+	}
+	for _, n := range needles {
+		if !set[n] {
+			t.Errorf("expected %q in tool list, got %v", n, haystack)
+		}
+	}
+}
+
+func structuredJSON(out *mcp.CallToolResult) string {
+	b, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Sprintf("<unmarshalable: %v>", err)
+	}
+	return string(b)
+}

--- a/internal/cmd/mcp/serve.go
+++ b/internal/cmd/mcp/serve.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -20,6 +21,7 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 		enableWrites  bool
 		name          string
 		httpAddr      string
+		authToken     string
 		enableGroups  []string
 		disableGroups []string
 		enableTools   []string
@@ -35,7 +37,10 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 			"flags) selects the Redmine instance.\n\n" +
 			"By default only read tools are registered. Pass --enable-writes to " +
 			"also register create/update/delete tools. Use --http to listen on " +
-			"an HTTP address such as :8080 instead of stdio.\n\n" +
+			"an HTTP address such as :8080 instead of stdio. The HTTP transport " +
+			"defaults to a loopback bind (127.0.0.1); pass an explicit host to " +
+			"listen elsewhere, and use --auth-token (or REDMINE_MCP_AUTH_TOKEN) " +
+			"to require a bearer token on every request.\n\n" +
 			"To narrow the set of tools exposed to MCP clients, use " +
 			"--enable-groups / --disable-groups (allow- and deny-list of tool " +
 			"groups) and --enable-tools / --disable-tools (per-tool overrides). " +
@@ -69,11 +74,18 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 			defer stop()
 
 			if httpAddr != "" {
-				handler := mcpserver.BuildHTTPHandler(client, opts)
-				server := &http.Server{
-					Addr:    httpAddr,
-					Handler: handler,
+				normalized, isLoopback := mcpserver.NormalizeBindAddr(httpAddr)
+				token := resolveAuthToken(cmd, authToken, cfg)
+				if !isLoopback && token == "" {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: serving MCP on %s without --auth-token; anyone reachable on that interface can drive Redmine through this server\n",
+						normalized)
 				}
+
+				server := mcpserver.BuildHTTPServer(client, opts, mcpserver.HTTPOptions{
+					Addr:      normalized,
+					AuthToken: token,
+				})
 				go func() {
 					<-ctx.Done()
 					_ = server.Close()
@@ -91,7 +103,8 @@ func newCmdServe(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&enableWrites, "enable-writes", false, "Register tools that create, update, or delete Redmine data")
-	cmd.Flags().StringVar(&httpAddr, "http", "", "Serve MCP over streamable HTTP on the given address instead of stdio (for example :8080)")
+	cmd.Flags().StringVar(&httpAddr, "http", "", "Serve MCP over streamable HTTP on the given address instead of stdio (e.g. :8080 binds 127.0.0.1; pass 0.0.0.0:8080 to expose externally)")
+	cmd.Flags().StringVar(&authToken, "auth-token", "", "Require this bearer token in the Authorization header for every HTTP request. Strongly recommended whenever --http binds outside of loopback.")
 	cmd.Flags().StringVar(&name, "name", "redmine-cli", "Server name advertised to MCP clients")
 	cmd.Flags().StringSliceVar(&enableGroups, "enable-groups", nil, "Comma-separated tool groups to expose (default: all). See redmine mcp tools.")
 	cmd.Flags().StringSliceVar(&disableGroups, "disable-groups", nil, "Comma-separated tool groups to hide. Applied after --enable-groups.")
@@ -159,6 +172,19 @@ func resolveEnableWrites(cmd *cobra.Command, flagVal bool, cfg *config.Config) b
 	}
 	if cfg != nil && cfg.MCP.EnableWrites != nil {
 		return *cfg.MCP.EnableWrites
+	}
+	return flagVal
+}
+
+// resolveAuthToken returns the effective HTTP bearer token. Precedence: CLI
+// flag > config block. The env-var override (REDMINE_MCP_AUTH_TOKEN) is
+// applied to the config block in applyEnvOverrides.
+func resolveAuthToken(cmd *cobra.Command, flagVal string, cfg *config.Config) string {
+	if cmd.Flags().Changed("auth-token") {
+		return flagVal
+	}
+	if cfg != nil && cfg.MCP.AuthToken != "" {
+		return cfg.MCP.AuthToken
 	}
 	return flagVal
 }

--- a/internal/cmd/mcp/serve_test.go
+++ b/internal/cmd/mcp/serve_test.go
@@ -147,6 +147,33 @@ func TestResolveEnableWrites(t *testing.T) {
 	}
 }
 
+func TestResolveAuthToken(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("auth-token", "", "")
+
+	cfg := &config.Config{MCP: config.MCPConfig{AuthToken: "from-config"}}
+
+	if got := resolveAuthToken(cmd, "", cfg); got != "from-config" {
+		t.Errorf("config token should win when flag is unset, got %q", got)
+	}
+
+	if err := cmd.Flags().Set("auth-token", "from-flag"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := resolveAuthToken(cmd, "from-flag", cfg); got != "from-flag" {
+		t.Errorf("explicit flag should override config, got %q", got)
+	}
+
+	cmd2 := &cobra.Command{}
+	cmd2.Flags().String("auth-token", "", "")
+	if err := cmd2.Flags().Set("auth-token", ""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := resolveAuthToken(cmd2, "", cfg); got != "" {
+		t.Errorf("explicitly empty flag should suppress config, got %q", got)
+	}
+}
+
 func TestBuildFilterSpec_RejectsUnknownTool(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().StringSlice("enable-groups", nil, "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -358,6 +358,11 @@ func applyEnvOverrides(cfg *Config, log *debug.Logger) {
 		cfg.MCP.EnableWrites = &enable
 		log.Printf("Config: env override REDMINE_MCP_ENABLE_WRITES is set")
 	}
+
+	if val := os.Getenv("REDMINE_MCP_AUTH_TOKEN"); val != "" {
+		cfg.MCP.AuthToken = val
+		log.Printf("Config: env override REDMINE_MCP_AUTH_TOKEN is set")
+	}
 }
 
 // splitCSV trims, splits on commas, and drops empty entries.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -527,3 +527,20 @@ func TestApplyEnvOverrides_MCPListsAndBool(t *testing.T) {
 		t.Errorf("EnableWrites should be true (got %v)", cfg.MCP.EnableWrites)
 	}
 }
+
+func TestApplyEnvOverrides_MCPAuthToken(t *testing.T) {
+	t.Setenv("REDMINE_MCP_AUTH_TOKEN", "from-env")
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server: https://example.com\napi_key: k\nmcp:\n  auth_token: from-file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath, "", debug.New(nil))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.MCP.AuthToken != "from-env" {
+		t.Errorf("AuthToken = %q, want from-env (env should override file)", cfg.MCP.AuthToken)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -28,6 +28,10 @@ type MCPConfig struct {
 	EnableTools []string `mapstructure:"enable_tools" yaml:"enable_tools,omitempty"`
 	// DisableTools is a deny-list of tool names applied last.
 	DisableTools []string `mapstructure:"disable_tools" yaml:"disable_tools,omitempty"`
+	// AuthToken, when non-empty, becomes the default for `--auth-token` on
+	// the MCP HTTP transport. Bearer tokens supplied here are used as the
+	// shared secret clients must present in the Authorization header.
+	AuthToken string `mapstructure:"auth_token" yaml:"auth_token,omitempty"`
 }
 
 // ProfileConfig holds the top-level configuration with multiple profiles.

--- a/internal/mcpserver/bind.go
+++ b/internal/mcpserver/bind.go
@@ -1,0 +1,47 @@
+package mcpserver
+
+import (
+	"net"
+	"strings"
+)
+
+// NormalizeBindAddr applies the convenience defaults used by `redmine mcp
+// serve --http <addr>`:
+//
+//   - An empty string returns "" with isLoopback=false (caller skips HTTP).
+//   - An address starting with ":" (no host) is rewritten to bind on
+//     127.0.0.1 only. Listening on all interfaces is opt-in, never the
+//     default.
+//   - Explicit hosts are returned unchanged. The boolean reports whether the
+//     resolved host is a loopback address; callers use it to decide whether
+//     to warn about exposing the server without an auth token.
+//
+// Unparsable addresses are returned as-is with isLoopback=false; the bind
+// will fail downstream with a clearer error.
+func NormalizeBindAddr(addr string) (normalized string, isLoopback bool) {
+	if addr == "" {
+		return "", false
+	}
+	if strings.HasPrefix(addr, ":") {
+		return "127.0.0.1" + addr, true
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr, false
+	}
+	if host == "" {
+		return net.JoinHostPort("127.0.0.1", port), true
+	}
+	return addr, isLoopbackHost(host)
+}
+
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost":
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/internal/mcpserver/http.go
+++ b/internal/mcpserver/http.go
@@ -96,13 +96,12 @@ func WrapAuthToken(h http.Handler, token string) http.Handler {
 	}
 	expected := []byte(token)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		header := r.Header.Get("Authorization")
-		const prefix = "Bearer "
-		if !strings.HasPrefix(header, prefix) {
+		fields := strings.Fields(r.Header.Get("Authorization"))
+		if len(fields) != 2 || !strings.EqualFold(fields[0], "Bearer") {
 			unauthorized(w, "missing bearer token")
 			return
 		}
-		got := []byte(strings.TrimPrefix(header, prefix))
+		got := []byte(fields[1])
 		if subtle.ConstantTimeCompare(got, expected) != 1 {
 			unauthorized(w, "invalid bearer token")
 			return

--- a/internal/mcpserver/http.go
+++ b/internal/mcpserver/http.go
@@ -1,0 +1,117 @@
+package mcpserver
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+)
+
+// HTTPOptions controls how BuildHTTPServer assembles the streamable HTTP
+// transport. Zero values yield safe defaults suitable for a localhost bind.
+type HTTPOptions struct {
+	// Addr is the listen address passed to http.Server. Required.
+	Addr string
+
+	// AuthToken, when non-empty, requires every request to carry an
+	// `Authorization: Bearer <token>` header that matches it. Compared in
+	// constant time.
+	AuthToken string
+
+	// ReadHeaderTimeout, ReadTimeout, WriteTimeout, IdleTimeout override the
+	// http.Server timeouts when non-zero. Defaults are applied when left as
+	// the zero value.
+	ReadHeaderTimeout time.Duration
+	ReadTimeout       time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
+}
+
+// Default timeouts applied when HTTPOptions leaves them at zero. WriteTimeout
+// stays at zero because tool calls can take a while (slow Redmine instances,
+// large attachments) and the streamable handler does not need a write deadline
+// to be safe.
+const (
+	defaultReadHeaderTimeout = 10 * time.Second
+	defaultReadTimeout       = 30 * time.Second
+	defaultIdleTimeout       = 120 * time.Second
+)
+
+// BuildHTTPHandler constructs a streamable HTTP handler backed by the same MCP
+// server definition used for stdio. It does not apply any auth or timeouts on
+// its own — wrap it with WrapAuthToken and host it on a configured
+// http.Server, or use BuildHTTPServer to get both in one call.
+func BuildHTTPHandler(client *api.Client, opts Options) http.Handler {
+	srv := BuildServer(client, opts)
+	return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return srv
+	}, &mcp.StreamableHTTPOptions{
+		JSONResponse: true,
+	})
+}
+
+// BuildHTTPServer returns a fully configured *http.Server that exposes the
+// MCP transport with hardened timeouts and an optional bearer-token gate.
+// Caller is responsible for calling ListenAndServe / Shutdown.
+func BuildHTTPServer(client *api.Client, opts Options, httpOpts HTTPOptions) *http.Server {
+	handler := BuildHTTPHandler(client, opts)
+	if httpOpts.AuthToken != "" {
+		handler = WrapAuthToken(handler, httpOpts.AuthToken)
+	}
+
+	readHeader := httpOpts.ReadHeaderTimeout
+	if readHeader == 0 {
+		readHeader = defaultReadHeaderTimeout
+	}
+	read := httpOpts.ReadTimeout
+	if read == 0 {
+		read = defaultReadTimeout
+	}
+	idle := httpOpts.IdleTimeout
+	if idle == 0 {
+		idle = defaultIdleTimeout
+	}
+
+	return &http.Server{
+		Addr:              httpOpts.Addr,
+		Handler:           handler,
+		ReadHeaderTimeout: readHeader,
+		ReadTimeout:       read,
+		WriteTimeout:      httpOpts.WriteTimeout,
+		IdleTimeout:       idle,
+	}
+}
+
+// WrapAuthToken gates h behind a constant-time bearer-token check. An empty
+// token disables the gate (the handler is returned untouched). Failed checks
+// respond 401 with a WWW-Authenticate header so MCP clients can retry with
+// credentials.
+func WrapAuthToken(h http.Handler, token string) http.Handler {
+	if token == "" {
+		return h
+	}
+	expected := []byte(token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header := r.Header.Get("Authorization")
+		const prefix = "Bearer "
+		if !strings.HasPrefix(header, prefix) {
+			unauthorized(w, "missing bearer token")
+			return
+		}
+		got := []byte(strings.TrimPrefix(header, prefix))
+		if subtle.ConstantTimeCompare(got, expected) != 1 {
+			unauthorized(w, "invalid bearer token")
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+func unauthorized(w http.ResponseWriter, msg string) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="redmine-cli"`)
+	http.Error(w, msg, http.StatusUnauthorized)
+}

--- a/internal/mcpserver/http_hardening_test.go
+++ b/internal/mcpserver/http_hardening_test.go
@@ -29,6 +29,28 @@ func TestWrapAuthToken_AllowsValidBearer(t *testing.T) {
 	}
 }
 
+func TestWrapAuthToken_AllowsCaseInsensitiveSchemeAndExtraSpaces(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler := WrapAuthToken(inner, "s3cret")
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "bearer    s3cret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("inner handler never invoked for valid token")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
 func TestWrapAuthToken_RejectsMissingHeader(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("inner handler should not run when token is missing")

--- a/internal/mcpserver/http_hardening_test.go
+++ b/internal/mcpserver/http_hardening_test.go
@@ -1,0 +1,184 @@
+package mcpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWrapAuthToken_AllowsValidBearer(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler := WrapAuthToken(inner, "s3cret")
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("inner handler never invoked for valid token")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
+func TestWrapAuthToken_RejectsMissingHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("inner handler should not run when token is missing")
+	})
+
+	handler := WrapAuthToken(inner, "s3cret")
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got == "" {
+		t.Error("expected WWW-Authenticate header on 401")
+	}
+}
+
+func TestWrapAuthToken_RejectsWrongToken(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("inner handler should not run when token is wrong")
+	})
+
+	handler := WrapAuthToken(inner, "s3cret")
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer nope")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestWrapAuthToken_EmptyTokenIsPassThrough(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := WrapAuthToken(inner, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no gate)", rec.Code)
+	}
+}
+
+func TestBuildHTTPServer_AppliesDefaultTimeouts(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer closeTS()
+
+	srv := BuildHTTPServer(apiClient, Options{Version: "v0"}, HTTPOptions{Addr: "127.0.0.1:0"})
+
+	if srv.Addr != "127.0.0.1:0" {
+		t.Errorf("Addr = %q, want 127.0.0.1:0", srv.Addr)
+	}
+	if srv.ReadHeaderTimeout != defaultReadHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout = %s, want %s", srv.ReadHeaderTimeout, defaultReadHeaderTimeout)
+	}
+	if srv.ReadTimeout != defaultReadTimeout {
+		t.Errorf("ReadTimeout = %s, want %s", srv.ReadTimeout, defaultReadTimeout)
+	}
+	if srv.IdleTimeout != defaultIdleTimeout {
+		t.Errorf("IdleTimeout = %s, want %s", srv.IdleTimeout, defaultIdleTimeout)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %s, want 0 (intentionally unbounded for slow tool calls)", srv.WriteTimeout)
+	}
+	if srv.Handler == nil {
+		t.Fatal("Handler is nil")
+	}
+}
+
+func TestBuildHTTPServer_OverridesTakePrecedence(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer closeTS()
+
+	srv := BuildHTTPServer(apiClient, Options{Version: "v0"}, HTTPOptions{
+		Addr:              "127.0.0.1:0",
+		ReadHeaderTimeout: 1 * time.Second,
+		ReadTimeout:       2 * time.Second,
+		WriteTimeout:      3 * time.Second,
+		IdleTimeout:       4 * time.Second,
+	})
+
+	if srv.ReadHeaderTimeout != 1*time.Second {
+		t.Errorf("ReadHeaderTimeout = %s, want 1s", srv.ReadHeaderTimeout)
+	}
+	if srv.ReadTimeout != 2*time.Second {
+		t.Errorf("ReadTimeout = %s, want 2s", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 3*time.Second {
+		t.Errorf("WriteTimeout = %s, want 3s", srv.WriteTimeout)
+	}
+	if srv.IdleTimeout != 4*time.Second {
+		t.Errorf("IdleTimeout = %s, want 4s", srv.IdleTimeout)
+	}
+}
+
+func TestBuildHTTPServer_WrapsHandlerWhenAuthTokenSet(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer closeTS()
+
+	srv := BuildHTTPServer(apiClient, Options{Version: "v0"}, HTTPOptions{
+		Addr:      "127.0.0.1:0",
+		AuthToken: "s3cret",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without bearer token, got %d", rec.Code)
+	}
+}
+
+func TestNormalizeBindAddr(t *testing.T) {
+	cases := []struct {
+		in           string
+		wantAddr     string
+		wantLoopback bool
+	}{
+		{"", "", false},
+		{":8080", "127.0.0.1:8080", true},
+		{"127.0.0.1:8080", "127.0.0.1:8080", true},
+		{"localhost:8080", "localhost:8080", true},
+		{"[::1]:8080", "[::1]:8080", true},
+		{"0.0.0.0:8080", "0.0.0.0:8080", false},
+		{"[::]:8080", "[::]:8080", false},
+		{"10.0.0.5:8080", "10.0.0.5:8080", false},
+		{"not-an-addr", "not-an-addr", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			gotAddr, gotLoopback := NormalizeBindAddr(tc.in)
+			if gotAddr != tc.wantAddr {
+				t.Errorf("addr = %q, want %q", gotAddr, tc.wantAddr)
+			}
+			if gotLoopback != tc.wantLoopback {
+				t.Errorf("isLoopback = %v, want %v", gotLoopback, tc.wantLoopback)
+			}
+		})
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1,8 +1,6 @@
 package mcpserver
 
 import (
-	"net/http"
-
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/aarondpn/redmine-cli/v2/internal/api"
@@ -26,15 +24,4 @@ func BuildServer(client *api.Client, opts Options) *mcp.Server {
 	registerPrompts(srv)
 
 	return srv
-}
-
-// BuildHTTPHandler constructs a streamable HTTP handler backed by the same MCP
-// server definition used for stdio.
-func BuildHTTPHandler(client *api.Client, opts Options) http.Handler {
-	srv := BuildServer(client, opts)
-	return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
-		return srv
-	}, &mcp.StreamableHTTPOptions{
-		JSONResponse: true,
-	})
 }


### PR DESCRIPTION
## Summary

Two release-blockers for the next MCP-focused release:

1. **HTTP transport hardening.** `redmine mcp serve --http :8080` previously bound on every interface with no auth gate and no `http.Server` timeouts. This change adds `--auth-token` (also `mcp.auth_token` in config and `REDMINE_MCP_AUTH_TOKEN` in env), rewrites a bare `:port` to `127.0.0.1:port`, prints a stderr warning when binding non-loopback without a token, and applies `ReadHeaderTimeout=10s`, `ReadTimeout=30s`, `IdleTimeout=120s`. `WriteTimeout` is left at zero so slow Redmine instances don't terminate in-flight tool calls. Auth check uses `subtle.ConstantTimeCompare`; a 401 ships a `WWW-Authenticate: Bearer realm="redmine-cli"` header.
2. **MCP e2e coverage.** The MCP surface had zero e2e tests despite stdio and streamable HTTP being headline features. Adds five tests (initialize + `tools/list` + a live `list_projects` call on stdio and HTTP, write-gating without `--enable-writes`, `--enable-groups issues` filter, and an unauthenticated 401 probe).

The HTTP wiring is split out of `server.go` into a new `mcpserver/http.go` (`BuildHTTPServer`, `BuildHTTPHandler`, `WrapAuthToken`) and `mcpserver/bind.go` (`NormalizeBindAddr`). `cmd/mcp/serve.go` just composes them.

Documentation updated across `README.md`, `README.ja.md`, `README.zh-CN.md`, and both English and zh-CN versions of the AI agent guide.

## Test plan

- [x] `go vet ./...` and `go vet -tags=e2e ./e2e/...` - clean
- [x] `golangci-lint run` - 0 issues
- [x] `go test ./...` - all packages green, including new unit tests in `internal/mcpserver` (timeouts, auth-token middleware, bind normalization, override precedence) and `internal/cmd/mcp` (`resolveAuthToken`)
- [x] `make e2e-up E2E_VERSION=6.1 && make e2e-test E2E_VERSION=6.1` - 22/22 pass, including 5 new MCP tests
- [x] `make e2e-down`
- [x] Spot-check `redmine mcp serve --http 0.0.0.0:8080` warning is visible without `--auth-token`
- [x] Spot-check `redmine mcp serve --http :8080` actually binds 127.0.0.1 (`ss -tlnp | grep 8080`)