### PR TITLE
Add roles commands and membership role resolution

### DIFF
--- a/docs/src/content/docs/commands/memberships.mdx
+++ b/docs/src/content/docs/commands/memberships.mdx
@@ -53,11 +53,12 @@ Adds a user or group to a project with the specified roles.
 | `--project`    | Project name, identifier, or ID — falls back to the default project of the active profile |
 | `--user-id`    | User ID to add |
 | `--group-id`   | Group ID to add |
-| `--role-ids`   | Comma-separated role IDs — <Badge text="required" variant="danger" /> |
+| `--role-ids`   | Comma-separated role IDs |
+| `--roles`      | Comma-separated role names or IDs — <Badge text="required" variant="danger" /> when `--role-ids` is omitted |
 | `-o, --output` | Output format |
 
 <Aside type="note">
-  Exactly one of `--user-id` or `--group-id` must be supplied — they are mutually exclusive.
+  Exactly one of `--user-id` or `--group-id` must be supplied, and exactly one of `--role-ids` or `--roles` must be supplied. Use `redmine roles list` to discover valid role names and IDs.
 </Aside>
 
 ## update
@@ -70,7 +71,8 @@ Only the assigned roles can be changed on an existing membership.
 
 | Flag | Description |
 |------|-------------|
-| `--role-ids` | Comma-separated role IDs — <Badge text="required" variant="danger" /> |
+| `--role-ids` | Comma-separated role IDs |
+| `--roles`    | Comma-separated role names or IDs — <Badge text="required" variant="danger" /> when `--role-ids` is omitted |
 
 ## delete
 

--- a/docs/src/content/docs/commands/roles.mdx
+++ b/docs/src/content/docs/commands/roles.mdx
@@ -1,0 +1,33 @@
+---
+title: Roles
+description: List Redmine roles and inspect role permissions.
+---
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+The `roles` command lets you discover assignable project roles and inspect the permissions attached to a role.
+
+<CardGrid>
+  <LinkCard title="list" href="#list" description="List all roles configured in this Redmine instance." />
+  <LinkCard title="get" href="#get" description="View a single role by ID or name." />
+</CardGrid>
+
+## list
+
+```bash
+redmine roles list [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-o, --output` | Output format |
+
+## get
+
+```bash
+redmine roles get <id-or-name> [flags]
+```
+
+Aliases: `show`, `view`. Accepts a numeric ID or role name.
+
+The detail view includes permissions and visibility settings when Redmine exposes them.

--- a/docs/src/content/docs/zh-cn/commands/memberships.mdx
+++ b/docs/src/content/docs/zh-cn/commands/memberships.mdx
@@ -53,11 +53,12 @@ redmine memberships create [flags]
 | `--project`    | 项目名称、标识符或 ID——默认回退至活跃配置文件的默认项目 |
 | `--user-id`    | 要添加的用户 ID |
 | `--group-id`   | 要添加的用户组 ID |
-| `--role-ids`   | 逗号分隔的角色 ID — <Badge text="必填" variant="danger" /> |
+| `--role-ids`   | 逗号分隔的角色 ID |
+| `--roles`      | 逗号分隔的角色名称或 ID——当未提供 `--role-ids` 时 <Badge text="必填" variant="danger" /> |
 | `-o, --output` | 输出格式 |
 
 <Aside type="note">
-  `--user-id` 和 `--group-id` 二者必须且只能提供其中一个，二者互斥。
+  `--user-id` 与 `--group-id` 二者必须且只能提供其一；`--role-ids` 与 `--roles` 也必须且只能提供其一。可使用 `redmine roles list` 查看可用的角色名称与 ID。
 </Aside>
 
 ## update
@@ -70,7 +71,8 @@ redmine memberships update <id> [flags]
 
 | 标志 | 描述 |
 |------|------|
-| `--role-ids` | 逗号分隔的角色 ID — <Badge text="必填" variant="danger" /> |
+| `--role-ids` | 逗号分隔的角色 ID |
+| `--roles`    | 逗号分隔的角色名称或 ID——当未提供 `--role-ids` 时 <Badge text="必填" variant="danger" /> |
 
 ## delete
 

--- a/docs/src/content/docs/zh-cn/commands/roles.mdx
+++ b/docs/src/content/docs/zh-cn/commands/roles.mdx
@@ -1,0 +1,33 @@
+---
+title: 角色
+description: 列出 Redmine 角色并查看角色权限。
+---
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+`roles` 命令用于发现可分配的项目角色，并查看某个角色附带的权限。
+
+<CardGrid>
+  <LinkCard title="list" href="#list" description="列出当前 Redmine 实例中配置的所有角色。" />
+  <LinkCard title="get" href="#get" description="按 ID 或名称查看单个角色。" />
+</CardGrid>
+
+## list
+
+```bash
+redmine roles list [flags]
+```
+
+| 标志 | 描述 |
+|------|------|
+| `-o, --output` | 输出格式 |
+
+## get
+
+```bash
+redmine roles get <id-or-name> [flags]
+```
+
+别名：`show`、`view`。接受数字 ID 或角色名称。
+
+详情视图会在 Redmine 提供这些字段时显示权限和可见性设置。

--- a/e2e/fixtures_test.go
+++ b/e2e/fixtures_test.go
@@ -207,10 +207,15 @@ func createTestGroup(t *testing.T, r *cliRunner) *groupFixture {
 	return &groupFixture{ID: created.ID, Name: created.Name}
 }
 
-// firstRoleID returns the ID of the first non-builtin role on the server.
-// Built-in roles ("Anonymous", "Non member") cannot be assigned to project
-// memberships, so tests skip them.
-func firstRoleID(t *testing.T, r *cliRunner) int {
+type roleFixture struct {
+	ID   int
+	Name string
+}
+
+// firstRole returns the first non-builtin role on the server. Built-in roles
+// ("Anonymous", "Non member") cannot be assigned to project memberships, so
+// tests skip them when Redmine exposes the builtin markers.
+func firstRole(t *testing.T, r *cliRunner) roleFixture {
 	t.Helper()
 	type role struct {
 		ID         int    `json:"id"`
@@ -227,14 +232,19 @@ func firstRoleID(t *testing.T, r *cliRunner) int {
 		if role.Builtin || role.IsBuiltin {
 			continue
 		}
-		return role.ID
+		return roleFixture{ID: role.ID, Name: role.Name}
 	}
 	if len(resp.Roles) == 0 {
 		t.Fatal("no roles available on server")
 	}
 	// Fall back to the first role; older Redmine builds don't expose builtin
 	// flag here.
-	return resp.Roles[0].ID
+	return roleFixture{ID: resp.Roles[0].ID, Name: resp.Roles[0].Name}
+}
+
+func firstRoleID(t *testing.T, r *cliRunner) int {
+	t.Helper()
+	return firstRole(t, r).ID
 }
 
 // uniqueShortSuffix returns a short alphanumeric token unique per test +

--- a/e2e/memberships_test.go
+++ b/e2e/memberships_test.go
@@ -158,6 +158,35 @@ func TestMemberships_GroupCreate(t *testing.T) {
 	}
 }
 
+func TestMemberships_RoleNameResolution(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+	user := createTestUser(t, r)
+	role := firstRole(t, r)
+
+	var created struct {
+		ID    int `json:"id"`
+		Roles []struct {
+			ID int `json:"id"`
+		} `json:"roles"`
+	}
+	r.runJSON(t, &created, "memberships", "create",
+		"--project", proj.Identifier,
+		"--user-id", strconv.Itoa(user.ID),
+		"--roles", role.Name)
+	if !containsRoleID(created.Roles, role.ID) {
+		t.Fatalf("created membership roles = %+v, want role %d", created.Roles, role.ID)
+	}
+
+	var updated actionEnvelope
+	r.runJSON(t, &updated, "memberships", "update", strconv.Itoa(created.ID),
+		"--roles", strconv.Itoa(role.ID))
+	if !updated.Ok {
+		t.Fatalf("unexpected update envelope: %+v", updated)
+	}
+}
+
 // TestMemberships_CreateRequiresUserOrGroup verifies the mutual-exclusivity
 // validation at internal/cmd/membership/create.go:33: omitting both
 // --user-id and --group-id must exit non-zero with the membership cmd's own

--- a/e2e/roles_test.go
+++ b/e2e/roles_test.go
@@ -1,0 +1,41 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRoles_ListAndGet(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	role := firstRole(t, r)
+
+	var roles []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	r.runJSON(t, &roles, "roles", "list")
+	if len(roles) == 0 {
+		t.Fatal("roles list returned no roles")
+	}
+
+	found := false
+	for _, item := range roles {
+		if item.ID == role.ID && item.Name == role.Name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("roles list did not include %+v", role)
+	}
+
+	stdout := r.run(t, "roles", "get", strconv.Itoa(role.ID), "--output", "table")
+	text := string(stdout)
+	if !strings.Contains(text, role.Name) {
+		t.Fatalf("roles get output missing %q\nstdout:\n%s", role.Name, stdout)
+	}
+}

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -16,6 +16,10 @@
     "description": "Fetch a single Redmine project by identifier or ID."
   },
   {
+    "name": "get_role",
+    "description": "Fetch a single Redmine role by ID, including permissions when available."
+  },
+  {
     "name": "get_time_entry",
     "description": "Fetch a single time entry by ID."
   },
@@ -54,6 +58,10 @@
   {
     "name": "list_projects",
     "description": "List Redmine projects."
+  },
+  {
+    "name": "list_roles",
+    "description": "List all Redmine roles configured in this instance."
   },
   {
     "name": "list_statuses",

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -35,6 +35,7 @@ type Client struct {
 	Users        *UserService
 	Trackers     *TrackerService
 	Statuses     *StatusService
+	Roles        *RoleService
 	Enumerations *EnumerationService
 	Versions     *VersionService
 	Categories   *CategoryService
@@ -107,6 +108,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Users = &UserService{client: c}
 	c.Trackers = &TrackerService{client: c}
 	c.Statuses = &StatusService{client: c}
+	c.Roles = &RoleService{client: c}
 	c.Enumerations = &EnumerationService{client: c}
 	c.Versions = &VersionService{client: c}
 	c.Categories = &CategoryService{client: c}

--- a/internal/api/roles.go
+++ b/internal/api/roles.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+// RoleService handles role-related API calls.
+type RoleService struct {
+	client *Client
+}
+
+// List retrieves all roles.
+func (s *RoleService) List(ctx context.Context) ([]models.Role, error) {
+	var resp struct {
+		Roles []models.Role `json:"roles"`
+	}
+	if err := s.client.Get(ctx, "/roles.json", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Roles, nil
+}
+
+// Get retrieves a single role by ID.
+func (s *RoleService) Get(ctx context.Context, id int) (*models.Role, error) {
+	var resp struct {
+		Role models.Role `json:"role"`
+	}
+	if err := s.client.Get(ctx, fmt.Sprintf("/roles/%d.json", id), nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Role, nil
+}

--- a/internal/cmd/membership/create.go
+++ b/internal/cmd/membership/create.go
@@ -16,6 +16,7 @@ func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
 		userID  int
 		groupID int
 		roleIDs []int
+		roles   []string
 		format  string
 	)
 
@@ -26,6 +27,9 @@ func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
 		Long:    "Create a new membership, adding a user or group to a project with specified roles.",
 		Example: `  # Add a user with roles
   redmine memberships create --project myproject --user-id 5 --role-ids 1,2
+
+  # Add a user with roles resolved by name
+  redmine memberships create --project myproject --user-id 5 --roles Manager,Developer
 
   # Add a group with a role
   redmine memberships create --project myproject --group-id 10 --role-ids 3`,
@@ -45,6 +49,17 @@ func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			resolvedRoleIDs, err := resolveRoleIDs(
+				context.Background(),
+				client,
+				roleIDs,
+				roles,
+				cmd.Flags().Changed("role-ids"),
+				cmd.Flags().Changed("roles"),
+			)
+			if err != nil {
+				return err
+			}
 
 			memberID := userID
 			if hasGroup {
@@ -56,7 +71,7 @@ func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
 			m, err := ops.CreateMembership(context.Background(), client, ops.CreateMembershipInput{
 				ProjectID: project,
 				UserID:    memberID,
-				RoleIDs:   roleIDs,
+				RoleIDs:   resolvedRoleIDs,
 			})
 			stop()
 			if err != nil {
@@ -71,12 +86,14 @@ func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&project, "project", "", "Project name, identifier, or ID (required)")
 	cmd.Flags().IntVar(&userID, "user-id", 0, "User ID to add")
 	cmd.Flags().IntVar(&groupID, "group-id", 0, "Group ID to add")
-	cmd.Flags().IntSliceVar(&roleIDs, "role-ids", nil, "Role IDs to assign (required)")
-	cmd.MarkFlagRequired("role-ids")
+	cmd.Flags().IntSliceVar(&roleIDs, "role-ids", nil, "Role IDs to assign")
+	cmd.Flags().StringSliceVar(&roles, "roles", nil, "Role names or IDs to assign (repeatable or comma-separated)")
 	cmd.MarkFlagsMutuallyExclusive("user-id", "group-id")
+	cmd.MarkFlagsMutuallyExclusive("role-ids", "roles")
 	cmdutil.AddOutputFlag(cmd, &format)
 
 	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+	_ = cmd.RegisterFlagCompletionFunc("roles", cmdutil.CompleteRoles(f))
 
 	return cmd
 }

--- a/internal/cmd/membership/roles.go
+++ b/internal/cmd/membership/roles.go
@@ -1,0 +1,43 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+	"github.com/aarondpn/redmine-cli/v2/internal/resolver"
+)
+
+func resolveRoleIDs(ctx context.Context, client *api.Client, numeric []int, names []string, hasNumeric, hasNames bool) ([]int, error) {
+	switch {
+	case hasNumeric && hasNames:
+		return nil, fmt.Errorf("use either --role-ids or --roles, not both")
+	case !hasNumeric && !hasNames:
+		return nil, fmt.Errorf("either --role-ids or --roles is required")
+	case hasNumeric:
+		return numeric, nil
+	}
+
+	ids := make([]int, 0, len(names))
+	seen := make(map[int]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		id, err := resolver.ResolveRole(ctx, client, name)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("--roles requires at least one non-empty role name or ID")
+	}
+	return ids, nil
+}

--- a/internal/cmd/membership/roles_test.go
+++ b/internal/cmd/membership/roles_test.go
@@ -1,0 +1,69 @@
+package membership
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+	"github.com/aarondpn/redmine-cli/v2/internal/config"
+	"github.com/aarondpn/redmine-cli/v2/internal/debug"
+)
+
+func TestResolveRoleIDs_RequiresOneFlagSource(t *testing.T) {
+	client := newMembershipTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s", r.URL.Path)
+	}))
+
+	_, err := resolveRoleIDs(context.Background(), client, nil, nil, false, false)
+	if err == nil || !strings.Contains(err.Error(), "either --role-ids or --roles is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveRoleIDs_RejectsMixedFlags(t *testing.T) {
+	client := newMembershipTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s", r.URL.Path)
+	}))
+
+	_, err := resolveRoleIDs(context.Background(), client, []int{1}, []string{"Manager"}, true, true)
+	if err == nil || !strings.Contains(err.Error(), "either --role-ids or --roles") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveRoleIDs_ResolvesNamesAndDeduplicates(t *testing.T) {
+	client := newMembershipTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/roles.json" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"roles":[{"id":1,"name":"Manager"},{"id":2,"name":"Developer"}]}`))
+	}))
+
+	got, err := resolveRoleIDs(context.Background(), client, nil, []string{"Manager", "2", "Manager"}, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("resolved role IDs = %v, want [1 2]", got)
+	}
+}
+
+func newMembershipTestClient(t *testing.T, handler http.Handler) *api.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client, err := api.NewClient(&config.Config{
+		Server:     srv.URL,
+		APIKey:     "test",
+		AuthMethod: "apikey",
+	}, debug.New(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}

--- a/internal/cmd/membership/update.go
+++ b/internal/cmd/membership/update.go
@@ -13,7 +13,10 @@ import (
 )
 
 func newCmdMembershipUpdate(f *cmdutil.Factory) *cobra.Command {
-	var roleIDs []int
+	var (
+		roleIDs []int
+		roles   []string
+	)
 
 	cmd := &cobra.Command{
 		Use:     "update <id>",
@@ -27,11 +30,18 @@ func newCmdMembershipUpdate(f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("membership ID must be a number: %s", args[0])
 			}
 
-			if !cmd.Flags().Changed("role-ids") {
-				return fmt.Errorf("--role-ids is required")
-			}
-
 			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			resolvedRoleIDs, err := resolveRoleIDs(
+				context.Background(),
+				client,
+				roleIDs,
+				roles,
+				cmd.Flags().Changed("role-ids"),
+				cmd.Flags().Changed("roles"),
+			)
 			if err != nil {
 				return err
 			}
@@ -41,7 +51,7 @@ func newCmdMembershipUpdate(f *cmdutil.Factory) *cobra.Command {
 			stop := printer.Spinner("Updating membership...")
 			_, err = ops.UpdateMembership(context.Background(), client, ops.UpdateMembershipInput{
 				ID:      id,
-				RoleIDs: roleIDs,
+				RoleIDs: resolvedRoleIDs,
 			})
 			stop()
 			if err != nil {
@@ -53,6 +63,9 @@ func newCmdMembershipUpdate(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().IntSliceVar(&roleIDs, "role-ids", nil, "Role IDs to assign (required)")
+	cmd.Flags().IntSliceVar(&roleIDs, "role-ids", nil, "Role IDs to assign")
+	cmd.Flags().StringSliceVar(&roles, "roles", nil, "Role names or IDs to assign (repeatable or comma-separated)")
+	cmd.MarkFlagsMutuallyExclusive("role-ids", "roles")
+	_ = cmd.RegisterFlagCompletionFunc("roles", cmdutil.CompleteRoles(f))
 	return cmd
 }

--- a/internal/cmd/output_contract_test.go
+++ b/internal/cmd/output_contract_test.go
@@ -69,6 +69,8 @@ var commandOutputContracts = map[string]commandContract{
 	"redmine projects list":      {Mode: outputContractStructured},
 	"redmine projects members":   {Mode: outputContractStructured},
 	"redmine projects update":    {Mode: outputContractStructured},
+	"redmine roles get":          {Mode: outputContractStructured},
+	"redmine roles list":         {Mode: outputContractStructured},
 	"redmine search":             {Mode: outputContractStructured},
 	"redmine search browse":      {Mode: outputContractInteractive, Reason: "launches the TUI search browser"},
 	"redmine search issues":      {Mode: outputContractStructured},

--- a/internal/cmd/role/get.go
+++ b/internal/cmd/role/get.go
@@ -1,0 +1,80 @@
+package role
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+	"github.com/aarondpn/redmine-cli/v2/internal/resolver"
+)
+
+func newCmdRoleGet(f *cmdutil.Factory) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:     "get <id-or-name>",
+		Aliases: []string{"show", "view"},
+		Short:   "Show role details",
+		Long:    "Show role details. Accepts a numeric ID or role name.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			id, err := resolver.ResolveRole(context.Background(), client, args[0])
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer(format)
+
+			stop := printer.Spinner("Fetching role...")
+			role, err := ops.GetRole(context.Background(), client, ops.GetRoleInput{ID: id})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(role)
+				return nil
+			}
+
+			details := []output.KeyValue{
+				{Key: "ID", Value: fmt.Sprintf("%d", role.ID)},
+				{Key: "Name", Value: role.Name},
+			}
+			if role.Assignable != nil {
+				details = append(details, output.KeyValue{Key: "Assignable", Value: optionalBoolLabel(role.Assignable)})
+			}
+			if builtin := optionalBoolLabel(builtinPtr(*role)); builtin != "" {
+				details = append(details, output.KeyValue{Key: "Builtin", Value: builtin})
+			}
+			if role.IssuesVisibility != "" {
+				details = append(details, output.KeyValue{Key: "Issues Visibility", Value: role.IssuesVisibility})
+			}
+			if role.TimeEntriesVisibility != "" {
+				details = append(details, output.KeyValue{Key: "Time Entries Visibility", Value: role.TimeEntriesVisibility})
+			}
+			if role.UsersVisibility != "" {
+				details = append(details, output.KeyValue{Key: "Users Visibility", Value: role.UsersVisibility})
+			}
+			if len(role.Permissions) > 0 {
+				details = append(details, output.KeyValue{Key: "Permissions", Value: strings.Join(role.Permissions, ", ")})
+			}
+
+			printer.Detail(details)
+			return nil
+		},
+	}
+
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}

--- a/internal/cmd/role/list.go
+++ b/internal/cmd/role/list.go
@@ -1,0 +1,70 @@
+package role
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+)
+
+func newCmdRoleList(f *cmdutil.Factory) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all roles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			stop := printer.Spinner("Fetching roles...")
+			result, err := ops.ListRoles(context.Background(), client, struct{}{})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			cmdutil.RenderCollection(printer, result.Roles, []string{"ID", "Name", "Assignable", "Builtin"}, func(r models.Role, styled bool) []string {
+				id := fmt.Sprintf("%d", r.ID)
+				if styled {
+					id = output.StyleID.Render(id)
+				}
+				return []string{id, r.Name, optionalBoolLabel(r.Assignable), optionalBoolLabel(builtinPtr(r))}
+			})
+			return nil
+		},
+	}
+
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}
+
+func optionalBoolLabel(v *bool) string {
+	if v == nil {
+		return ""
+	}
+	if *v {
+		return "yes"
+	}
+	return "no"
+}
+
+func builtinPtr(r models.Role) *bool {
+	if r.Builtin != nil {
+		if r.IsBuiltin != nil && *r.IsBuiltin && !*r.Builtin {
+			value := true
+			return &value
+		}
+		return r.Builtin
+	}
+	return r.IsBuiltin
+}

--- a/internal/cmd/role/role.go
+++ b/internal/cmd/role/role.go
@@ -1,0 +1,21 @@
+package role
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+)
+
+// NewCmdRoles creates the roles command group.
+func NewCmdRoles(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "roles",
+		Short: "Manage roles",
+		Long:  "List and inspect Redmine roles and their permissions.",
+	}
+
+	cmd.AddCommand(newCmdRoleList(f))
+	cmd.AddCommand(newCmdRoleGet(f))
+
+	return cmd
+}

--- a/internal/cmd/role/role_test.go
+++ b/internal/cmd/role/role_test.go
@@ -1,0 +1,81 @@
+package role
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+func TestRoleList_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"roles":[{"id":1,"name":"Manager","assignable":true},{"id":2,"name":"Reporter","assignable":false}]}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdRoleList(f)
+	cmd.SetArgs([]string{"--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	if !strings.Contains(stdout, `"name": "Manager"`) || !strings.Contains(stdout, `"assignable": true`) {
+		t.Fatalf("unexpected JSON output:\n%s", stdout)
+	}
+}
+
+func TestRoleList_Table(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"roles":[{"id":1,"name":"Manager","assignable":true,"builtin":false},{"id":2,"name":"Anonymous","builtin":true}]}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdRoleList(f)
+	cmd.SetArgs([]string{"--output", "table"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Manager", "Anonymous", "yes"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("table output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRoleGet_DetailByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/roles.json":
+			_, _ = w.Write([]byte(`{"roles":[{"id":7,"name":"Reporter"}]}`))
+		case "/roles/7.json":
+			_, _ = w.Write([]byte(`{"role":{"id":7,"name":"Reporter","assignable":true,"issues_visibility":"default","permissions":["view_issues","add_issue_notes"]}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdRoleGet(f)
+	cmd.SetArgs([]string{"Reporter"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Reporter", "default", "view_issues"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("detail output missing %q:\n%s", want, stdout)
+		}
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	mcpcmd "github.com/aarondpn/redmine-cli/v2/internal/cmd/mcp"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/membership"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/project"
+	"github.com/aarondpn/redmine-cli/v2/internal/cmd/role"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/search"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/status"
 	timecmd "github.com/aarondpn/redmine-cli/v2/internal/cmd/time"
@@ -92,6 +93,7 @@ func NewRootCmdWithFactory(version string) (*cobra.Command, *cmdutil.Factory) {
 	cmd.AddCommand(group.NewCmdGroup(f))
 	cmd.AddCommand(membership.NewCmdMemberships(f))
 	cmd.AddCommand(project.NewCmdProject(f))
+	cmd.AddCommand(role.NewCmdRoles(f))
 	cmd.AddCommand(timecmd.NewCmdTime(f))
 	cmd.AddCommand(user.NewCmdUser(f))
 	cmd.AddCommand(tracker.NewCmdTrackers(f))

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -149,6 +149,28 @@ func CompleteStatuses(f *Factory) func(cmd *cobra.Command, args []string, toComp
 	}
 }
 
+// CompleteRoles returns a completion function for role-related flags.
+func CompleteRoles(f *Factory) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		client, ctx, cancel := completionClient(f)
+		if client == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		defer cancel()
+
+		roles, err := client.Roles.List(ctx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		items := make([]string, 0, len(roles))
+		for _, r := range roles {
+			items = append(items, fmt.Sprintf("%s\tID %d", r.Name, r.ID))
+		}
+		return filterCompletions(items, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 // CompleteIssueListStatus returns a completion function for the --status flag
 // on the issues list command, which also accepts special values.
 func CompleteIssueListStatus(f *Factory) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -165,6 +165,9 @@ func CompleteRoles(f *Factory) func(cmd *cobra.Command, args []string, toComplet
 
 		items := make([]string, 0, len(roles))
 		for _, r := range roles {
+			if r.IsBuiltIn() || (r.Assignable != nil && !r.IsAssignable()) {
+				continue
+			}
 			items = append(items, fmt.Sprintf("%s\tID %d", r.Name, r.ID))
 		}
 		return filterCompletions(items, toComplete), cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmdutil/completions_test.go
+++ b/internal/cmdutil/completions_test.go
@@ -1,66 +1,29 @@
-package cmdutil
+package cmdutil_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
 )
 
-func TestFilterCompletions(t *testing.T) {
-	items := []string{
-		"Bug",
-		"Feature",
-		"Support",
-		"buecher\tBücher",
-		"backend\tBackend Project",
-	}
+func TestCompleteRoles_FiltersBuiltInAndUnassignable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"roles":[{"id":1,"name":"Manager","assignable":true},{"id":2,"name":"Reporter","assignable":false},{"id":3,"name":"Anonymous","builtin":true},{"id":4,"name":"Non member","is_builtin":true}]}`))
+	}))
+	defer srv.Close()
 
-	tests := []struct {
-		name       string
-		toComplete string
-		want       []string
-	}{
-		{
-			name:       "empty prefix returns all",
-			toComplete: "",
-			want:       items,
-		},
-		{
-			name:       "exact prefix match",
-			toComplete: "Bug",
-			want:       []string{"Bug"},
-		},
-		{
-			name:       "case insensitive",
-			toComplete: "bug",
-			want:       []string{"Bug"},
-		},
-		{
-			name:       "partial prefix",
-			toComplete: "b",
-			want:       []string{"Bug", "buecher\tBücher", "backend\tBackend Project"},
-		},
-		{
-			name:       "matches value before tab description",
-			toComplete: "bue",
-			want:       []string{"buecher\tBücher"},
-		},
-		{
-			name:       "no match returns nil",
-			toComplete: "xyz",
-			want:       nil,
-		},
+	f := testutil.NewFactory(t, srv.URL)
+	got, directive := cmdutil.CompleteRoles(f)(&cobra.Command{}, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want %v", directive, cobra.ShellCompDirectiveNoFileComp)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := filterCompletions(items, tt.toComplete)
-			if len(got) != len(tt.want) {
-				t.Fatalf("got %d results, want %d: %v", len(got), len(tt.want), got)
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
-				}
-			}
-		})
+	if len(got) != 1 || got[0] != "Manager\tID 1" {
+		t.Fatalf("completions = %v, want [Manager\\tID 1]", got)
 	}
 }

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -94,7 +94,7 @@ func TestWriteGate_HidesMutatingTools(t *testing.T) {
 		"list_users", "get_user", "me",
 		"search",
 		"list_versions", "get_version",
-		"list_trackers", "list_statuses", "list_categories",
+		"list_trackers", "list_statuses", "list_categories", "list_roles", "get_role",
 		"list_wiki_pages", "get_wiki_page",
 		"list_memberships", "get_membership",
 	}

--- a/internal/mcpserver/tools_roles_test.go
+++ b/internal/mcpserver/tools_roles_test.go
@@ -1,0 +1,76 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListRolesTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/roles.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"roles":[{"id":1,"name":"Manager","assignable":true},{"id":2,"name":"Reporter","assignable":false}]}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_roles"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"name":"Manager"`, `"assignable":true`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}
+
+func TestGetRoleTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/roles/5.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"role":{"id":5,"name":"Reporter","assignable":true,"permissions":["view_issues","add_issue_notes"]}}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "get_role",
+		Arguments: map[string]any{"id": 5},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"id":5`, `"Reporter"`, `"permissions":["view_issues","add_issue_notes"]`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}
+
+func containsText(text string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(text, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -158,6 +158,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Writes:      true,
 		Call:        ops.DeleteVersion,
 	})
+	registerToolSpec(s, client, opts, toolSpec[ops.GetRoleInput, *models.Role]{
+		Name:        "get_role",
+		Description: "Fetch a single Redmine role by ID, including permissions when available.",
+		Category:    "meta",
+		Call:        ops.GetRole,
+	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetVersionInput, *models.Version]{
 		Name:        "get_version",
 		Description: "Fetch a single version (milestone) by ID.",
@@ -169,6 +175,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Description: "List issue categories for a project.",
 		Category:    "meta",
 		Call:        ops.ListCategories,
+	})
+	registerToolSpec(s, client, opts, toolSpec[struct{}, ops.RolesListResult]{
+		Name:        "list_roles",
+		Description: "List all Redmine roles configured in this instance.",
+		Category:    "meta",
+		Call:        ops.ListRoles,
 	})
 	registerToolSpec(s, client, opts, toolSpec[struct{}, ops.StatusesListResult]{
 		Name:        "list_statuses",
@@ -380,8 +392,10 @@ func generatedToolDescriptors() []ToolDescriptor {
 		{Name: "update_membership", Description: "Replace the roles on a project membership. Requires --enable-writes.", Group: "memberships", Writes: true},
 		{Name: "create_version", Description: "Create a project version (milestone). Requires --enable-writes.", Group: "meta", Writes: true},
 		{Name: "delete_version", Description: "Delete a version (milestone). Destructive. Requires --enable-writes.", Group: "meta", Writes: true},
+		{Name: "get_role", Description: "Fetch a single Redmine role by ID, including permissions when available.", Group: "meta", Writes: false},
 		{Name: "get_version", Description: "Fetch a single version (milestone) by ID.", Group: "meta", Writes: false},
 		{Name: "list_categories", Description: "List issue categories for a project.", Group: "meta", Writes: false},
+		{Name: "list_roles", Description: "List all Redmine roles configured in this instance.", Group: "meta", Writes: false},
 		{Name: "list_statuses", Description: "List all issue statuses configured in this Redmine instance.", Group: "meta", Writes: false},
 		{Name: "list_trackers", Description: "List all trackers (Bug, Feature, ...) configured in this Redmine instance.", Group: "meta", Writes: false},
 		{Name: "list_versions", Description: "List versions (milestones) for a project.", Group: "meta", Writes: false},

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -1,0 +1,29 @@
+package models
+
+// Role represents a Redmine project role and its permissions.
+type Role struct {
+	ID                    int      `json:"id"`
+	Name                  string   `json:"name"`
+	Assignable            *bool    `json:"assignable,omitempty"`
+	Builtin               *bool    `json:"builtin,omitempty"`
+	IsBuiltin             *bool    `json:"is_builtin,omitempty"`
+	IssuesVisibility      string   `json:"issues_visibility,omitempty"`
+	TimeEntriesVisibility string   `json:"time_entries_visibility,omitempty"`
+	UsersVisibility       string   `json:"users_visibility,omitempty"`
+	Permissions           []string `json:"permissions,omitempty"`
+}
+
+// IsBuiltIn reports whether the role is one of Redmine's built-in roles.
+func (r Role) IsBuiltIn() bool {
+	return boolValue(r.Builtin) || boolValue(r.IsBuiltin)
+}
+
+// IsAssignable reports whether the role is assignable when the API exposed
+// that attribute.
+func (r Role) IsAssignable() bool {
+	return boolValue(r.Assignable)
+}
+
+func boolValue(v *bool) bool {
+	return v != nil && *v
+}

--- a/internal/ops/memberships.go
+++ b/internal/ops/memberships.go
@@ -27,12 +27,12 @@ type GetMembershipInput struct {
 type CreateMembershipInput struct {
 	ProjectID string `json:"project_id" jsonschema:"Project identifier or numeric ID."`
 	UserID    int    `json:"user_id" jsonschema:"Numeric user ID to add as a member."`
-	RoleIDs   []int  `json:"role_ids" jsonschema:"One or more role IDs to grant."`
+	RoleIDs   []int  `json:"role_ids" jsonschema:"One or more role IDs to grant. Use list_roles to discover valid values."`
 }
 
 type UpdateMembershipInput struct {
 	ID      int   `json:"id" jsonschema:"Numeric membership ID."`
-	RoleIDs []int `json:"role_ids" jsonschema:"Replacement set of role IDs."`
+	RoleIDs []int `json:"role_ids" jsonschema:"Replacement set of role IDs. Use list_roles to discover valid values."`
 }
 
 type DeleteMembershipInput struct {

--- a/internal/ops/meta.go
+++ b/internal/ops/meta.go
@@ -63,9 +63,18 @@ type TrackersListResult struct {
 	Count    int              `json:"count"`
 }
 
+type RolesListResult struct {
+	Roles []models.Role `json:"roles"`
+	Count int           `json:"count"`
+}
+
 type StatusesListResult struct {
 	Statuses []models.IssueStatus `json:"issue_statuses"`
 	Count    int                  `json:"count"`
+}
+
+type GetRoleInput struct {
+	ID int `json:"id" jsonschema:"Numeric role ID."`
 }
 
 //mcpgen:tool list_versions
@@ -140,6 +149,24 @@ func ListTrackers(ctx context.Context, client *api.Client, _ struct{}) (Trackers
 		return TrackersListResult{}, err
 	}
 	return TrackersListResult{Trackers: trackers, Count: len(trackers)}, nil
+}
+
+//mcpgen:tool list_roles
+//mcpgen:description List all Redmine roles configured in this instance.
+//mcpgen:category meta
+func ListRoles(ctx context.Context, client *api.Client, _ struct{}) (RolesListResult, error) {
+	roles, err := client.Roles.List(ctx)
+	if err != nil {
+		return RolesListResult{}, err
+	}
+	return RolesListResult{Roles: roles, Count: len(roles)}, nil
+}
+
+//mcpgen:tool get_role
+//mcpgen:description Fetch a single Redmine role by ID, including permissions when available.
+//mcpgen:category meta
+func GetRole(ctx context.Context, client *api.Client, input GetRoleInput) (*models.Role, error) {
+	return client.Roles.Get(ctx, input.ID)
 }
 
 //mcpgen:tool list_statuses

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -255,6 +255,21 @@ func ResolveStatus(ctx context.Context, client *api.Client, input string) (int, 
 	})
 }
 
+// ResolveRole resolves a role by name or numeric ID.
+func ResolveRole(ctx context.Context, client *api.Client, input string) (int, error) {
+	return Resolve(input, "role", client, func() ([]Option, error) {
+		roles, err := client.Roles.List(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch roles: %w", err)
+		}
+		opts := make([]Option, len(roles))
+		for i, r := range roles {
+			opts[i] = Option{ID: r.ID, Name: r.Name}
+		}
+		return opts, nil
+	})
+}
+
 // ResolvePriority resolves a priority by name or numeric ID.
 func ResolvePriority(ctx context.Context, client *api.Client, input string) (int, error) {
 	return Resolve(input, "priority", client, func() ([]Option, error) {


### PR DESCRIPTION
## Summary
- add first-class roles API, CLI, and MCP support with `roles list` and `roles get`
- allow membership create/update to resolve roles by name via `--roles` in addition to numeric `--role-ids`
- add docs, completions, MCP catalog updates, and test coverage for the new role workflows

## Testing
- go generate ./...
- go test ./...
- go test -tags e2e ./e2e -run 'TestRoles_ListAndGet|TestMemberships_RoleNameResolution|TestMCPStdio_ToolCatalogStable'

Closes #79