### PR TITLE
feat(trackers): expose richer tracker metadata

### DIFF
--- a/docs/src/content/docs/commands/other.mdx
+++ b/docs/src/content/docs/commands/other.mdx
@@ -75,9 +75,10 @@ Lists issue categories for a project.
 
 ```bash
 redmine trackers list
+redmine trackers get Bug
 ```
 
-Lists all available trackers.
+Lists all available trackers. The list view includes the default status for each tracker, and `trackers get` shows richer metadata such as enabled standard fields when the Redmine server exposes them.
 
 ## statuses
 

--- a/docs/src/content/docs/zh-cn/commands/other.mdx
+++ b/docs/src/content/docs/zh-cn/commands/other.mdx
@@ -75,9 +75,10 @@ redmine categories list --project <identifier>
 
 ```bash
 redmine trackers list
+redmine trackers get Bug
 ```
 
-列出所有可用的跟踪类型。
+列出所有可用的跟踪类型。列表视图会显示每个跟踪类型的默认状态，而 `trackers get` 会在 Redmine 服务器提供这些数据时展示更完整的元数据，例如启用的标准字段。
 
 ## statuses
 

--- a/e2e/mcp_extended_test.go
+++ b/e2e/mcp_extended_test.go
@@ -172,6 +172,66 @@ func TestMCPStdio_MultipleEnableGroups(t *testing.T) {
 	}
 }
 
+func TestMCPStdio_GetTrackerTool(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session := r.startMCPStdio(t, ctx)
+
+	listOut, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_trackers"})
+	if err != nil {
+		t.Fatalf("CallTool list_trackers: %v", err)
+	}
+	if listOut.IsError {
+		t.Fatalf("list_trackers returned IsError: %s", structuredJSON(listOut))
+	}
+
+	var listed struct {
+		Trackers []struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"trackers"`
+	}
+	if err := json.Unmarshal([]byte(mcpExtTextContent(t, listOut)), &listed); err != nil {
+		t.Fatalf("decode list_trackers: %v\npayload:\n%s", err, structuredJSON(listOut))
+	}
+	if len(listed.Trackers) == 0 {
+		t.Fatal("list_trackers returned no trackers")
+	}
+
+	getOut, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "get_tracker",
+		Arguments: map[string]any{"id": listed.Trackers[0].ID},
+	})
+	if err != nil {
+		t.Fatalf("CallTool get_tracker: %v", err)
+	}
+	if getOut.IsError {
+		t.Fatalf("get_tracker returned IsError: %s", structuredJSON(getOut))
+	}
+
+	var got struct {
+		ID            int    `json:"id"`
+		Name          string `json:"name"`
+		DefaultStatus struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"default_status"`
+	}
+	if err := json.Unmarshal([]byte(mcpExtTextContent(t, getOut)), &got); err != nil {
+		t.Fatalf("decode get_tracker: %v\npayload:\n%s", err, structuredJSON(getOut))
+	}
+	if got.ID != listed.Trackers[0].ID || got.Name != listed.Trackers[0].Name {
+		t.Fatalf("get_tracker returned %+v, want id=%d name=%q", got, listed.Trackers[0].ID, listed.Trackers[0].Name)
+	}
+	if got.DefaultStatus.ID == 0 || got.DefaultStatus.Name == "" {
+		t.Fatalf("get_tracker missing default status: %+v", got.DefaultStatus)
+	}
+}
+
 // TestMCPStdio_DisableGroupOverridesEnable pins the precedence rule from
 // internal/cmd/mcp/serve.go: --disable-groups wins over --enable-groups when
 // both name the same group.
@@ -411,6 +471,18 @@ func mcpExtIssueSubjectFromResult(t *testing.T, out *mcp.CallToolResult) string 
 		return s
 	}
 	return ""
+}
+
+func mcpExtTextContent(t *testing.T, out *mcp.CallToolResult) string {
+	t.Helper()
+	if len(out.Content) == 0 {
+		t.Fatal("call tool result contained no content blocks")
+	}
+	tc, ok := out.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", out.Content[0])
+	}
+	return tc.Text
 }
 
 // mcpExtFieldFromResult returns the named top-level field from a CallToolResult.

--- a/e2e/metadata_test.go
+++ b/e2e/metadata_test.go
@@ -24,9 +24,45 @@ func TestMetadata_TrackersListCSV(t *testing.T) {
 	if len(rows) < 2 {
 		t.Fatalf("expected header + at least 1 tracker row, got %d rows\nstdout:\n%s", len(rows), stdout)
 	}
-	wantHeaders := []string{"ID", "Name", "Description"}
+	wantHeaders := []string{"ID", "Name", "Default Status", "Description"}
 	if !slices.Equal(rows[0], wantHeaders) {
 		t.Fatalf("trackers CSV header mismatch:\n got: %v\nwant: %v", rows[0], wantHeaders)
+	}
+}
+
+func TestMetadata_TrackerGetJSON(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	type tracker struct {
+		ID            int    `json:"id"`
+		Name          string `json:"name"`
+		DefaultStatus struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"default_status"`
+		EnabledStandardFields []string `json:"enabled_standard_fields"`
+	}
+
+	var trackers []tracker
+	r.runJSON(t, &trackers, "trackers", "list")
+	if len(trackers) == 0 {
+		t.Fatal("trackers list returned no trackers")
+	}
+
+	var got tracker
+	r.runJSON(t, &got, "trackers", "get", trackers[0].Name)
+
+	if got.ID != trackers[0].ID || got.Name != trackers[0].Name {
+		t.Fatalf("trackers get returned %+v, want id=%d name=%q", got, trackers[0].ID, trackers[0].Name)
+	}
+	if got.DefaultStatus.ID == 0 || got.DefaultStatus.Name == "" {
+		t.Fatalf("tracker default status missing: %+v", got.DefaultStatus)
+	}
+	for _, field := range got.EnabledStandardFields {
+		if field == "" {
+			t.Fatalf("tracker enabled standard fields contains blank entry: %+v", got.EnabledStandardFields)
+		}
 	}
 }
 

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -20,6 +20,10 @@
     "description": "Fetch a single Redmine role by ID, including permissions when available."
   },
   {
+    "name": "get_tracker",
+    "description": "Fetch a single tracker by ID, including default status and enabled standard fields when available."
+  },
+  {
     "name": "get_time_entry",
     "description": "Fetch a single time entry by ID."
   },

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -20,12 +20,12 @@
     "description": "Fetch a single Redmine role by ID, including permissions when available."
   },
   {
-    "name": "get_tracker",
-    "description": "Fetch a single tracker by ID, including default status and enabled standard fields when available."
-  },
-  {
     "name": "get_time_entry",
     "description": "Fetch a single time entry by ID."
+  },
+  {
+    "name": "get_tracker",
+    "description": "Fetch a single tracker by ID, including default status and enabled standard fields when available."
   },
   {
     "name": "get_user",

--- a/internal/api/trackers.go
+++ b/internal/api/trackers.go
@@ -39,6 +39,5 @@ func (s *TrackerService) Get(ctx context.Context, id int) (*models.Tracker, erro
 	return nil, &APIError{
 		StatusCode: http.StatusNotFound,
 		Errors:     []string{fmt.Sprintf("tracker %d not found", id)},
-		URL:        fmt.Sprintf("%s/trackers.json", s.client.baseURL),
 	}
 }

--- a/internal/api/trackers.go
+++ b/internal/api/trackers.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/aarondpn/redmine-cli/v2/internal/models"
 )
@@ -20,4 +22,23 @@ func (s *TrackerService) List(ctx context.Context) ([]models.Tracker, error) {
 		return nil, err
 	}
 	return resp.Trackers, nil
+}
+
+// Get retrieves a single tracker by ID by resolving it from the tracker list
+// endpoint, which is the only tracker endpoint Redmine exposes.
+func (s *TrackerService) Get(ctx context.Context, id int) (*models.Tracker, error) {
+	trackers, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range trackers {
+		if trackers[i].ID == id {
+			return &trackers[i], nil
+		}
+	}
+	return nil, &APIError{
+		StatusCode: http.StatusNotFound,
+		Errors:     []string{fmt.Sprintf("tracker %d not found", id)},
+		URL:        fmt.Sprintf("%s/trackers.json", s.client.baseURL),
+	}
 }

--- a/internal/api/trackers_test.go
+++ b/internal/api/trackers_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTrackerServiceGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/trackers.json" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description"]}]}`))
+	}))
+	defer ts.Close()
+
+	client := newTestClient(ts)
+	client.Trackers = &TrackerService{client: client}
+	tracker, err := client.Trackers.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if tracker.Name != "Bug" {
+		t.Fatalf("tracker name = %q, want Bug", tracker.Name)
+	}
+	if tracker.DefaultStatus == nil || tracker.DefaultStatus.Name != "New" {
+		t.Fatalf("default status = %+v, want New", tracker.DefaultStatus)
+	}
+	if len(tracker.EnabledStandardFields) != 1 || tracker.EnabledStandardFields[0] != "description" {
+		t.Fatalf("enabled standard fields = %v", tracker.EnabledStandardFields)
+	}
+}
+
+func TestTrackerServiceGetNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/trackers.json" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug"}]}`))
+	}))
+	defer ts.Close()
+
+	client := newTestClient(ts)
+	client.Trackers = &TrackerService{client: client}
+	_, err := client.Trackers.Get(context.Background(), 99)
+	if err == nil {
+		t.Fatal("Get returned nil error, want not found")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("Get error type = %T, want *APIError", err)
+	}
+	if !apiErr.IsNotFound() {
+		t.Fatalf("Get error status = %d, want 404", apiErr.StatusCode)
+	}
+}

--- a/internal/cmd/output_contract_test.go
+++ b/internal/cmd/output_contract_test.go
@@ -85,6 +85,7 @@ var commandOutputContracts = map[string]commandContract{
 	"redmine time log":           {Mode: outputContractStructured},
 	"redmine time summary":       {Mode: outputContractStructured},
 	"redmine time update":        {Mode: outputContractStructured},
+	"redmine trackers get":       {Mode: outputContractStructured},
 	"redmine trackers list":      {Mode: outputContractStructured},
 	"redmine update":             {Mode: outputContractStructured},
 	"redmine users create":       {Mode: outputContractStructured},

--- a/internal/cmd/tracker/get_test.go
+++ b/internal/cmd/tracker/get_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
 )
 
-func TestTrackerList_JSON(t *testing.T) {
+func TestTrackerGet_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","description":"Bug reports","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description"]}]}`))
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","description":"Bug reports","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description","due_date"]}]}`))
 	}))
 	defer srv.Close()
 
 	f := testutil.NewFactory(t, srv.URL)
-	cmd := newCmdTrackerList(f)
-	cmd.SetArgs([]string{"--output", "json"})
+	cmd := newCmdTrackerGet(f)
+	cmd.SetArgs([]string{"Bug", "--output", "json"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -31,24 +31,24 @@ func TestTrackerList_JSON(t *testing.T) {
 	}
 }
 
-func TestTrackerList_Table(t *testing.T) {
+func TestTrackerGet_Table(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","description":"Bug reports","default_status":{"id":2,"name":"New"}},{"id":2,"name":"Feature","description":"","default_status":{"id":3,"name":"In Progress"}}]}`))
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","description":"Bug reports","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description","due_date"]}]}`))
 	}))
 	defer srv.Close()
 
 	f := testutil.NewFactory(t, srv.URL)
-	cmd := newCmdTrackerList(f)
-	cmd.SetArgs([]string{"--output", "table"})
+	cmd := newCmdTrackerGet(f)
+	cmd.SetArgs([]string{"1", "--output", "table"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
 	stdout := testutil.Stdout(f)
-	for _, want := range []string{"Bug", "Feature", "Default Status", "New", "In Progress"} {
+	for _, want := range []string{"Default Status", "New (ID: 2)", "Enabled Standard Fields", "description, due_date"} {
 		if !strings.Contains(stdout, want) {
-			t.Errorf("table output missing %q:\n%s", want, stdout)
+			t.Errorf("detail output missing %q:\n%s", want, stdout)
 		}
 	}
 }

--- a/internal/cmd/tracker/get_test.go
+++ b/internal/cmd/tracker/get_test.go
@@ -1,8 +1,11 @@
 package tracker
 
 import (
+	"bytes"
+	"encoding/csv"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -50,5 +53,39 @@ func TestTrackerGet_Table(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("detail output missing %q:\n%s", want, stdout)
 		}
+	}
+}
+
+func TestTrackerGet_CSV(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","description":"Bug reports","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description","due_date"]}]}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdTrackerGet(f)
+	cmd.SetArgs([]string{"1", "--output", "csv"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := csv.NewReader(bytes.NewBufferString(testutil.Stdout(f))).ReadAll()
+	if err != nil {
+		t.Fatalf("decode CSV: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("CSV rows = %d, want 2", len(rows))
+	}
+
+	wantHeaders := []string{"ID", "Name", "Default Status", "Description", "Enabled Standard Fields"}
+	if !slices.Equal(rows[0], wantHeaders) {
+		t.Fatalf("CSV header mismatch:\n got: %v\nwant: %v", rows[0], wantHeaders)
+	}
+
+	wantRow := []string{"1", "Bug", "New (ID: 2)", "Bug reports", "description, due_date"}
+	if !slices.Equal(rows[1], wantRow) {
+		t.Fatalf("CSV row mismatch:\n got: %v\nwant: %v", rows[1], wantRow)
 	}
 }

--- a/internal/cmd/tracker/list.go
+++ b/internal/cmd/tracker/list.go
@@ -3,12 +3,15 @@ package tracker
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
 
 	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
 	"github.com/aarondpn/redmine-cli/v2/internal/models"
 	"github.com/aarondpn/redmine-cli/v2/internal/ops"
 	"github.com/aarondpn/redmine-cli/v2/internal/output"
-	"github.com/spf13/cobra"
+	"github.com/aarondpn/redmine-cli/v2/internal/resolver"
 )
 
 // NewCmdTrackers creates the trackers command group.
@@ -16,9 +19,11 @@ func NewCmdTrackers(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trackers",
 		Short: "Manage trackers",
+		Long:  "List and inspect Redmine trackers and their supported standard fields.",
 	}
 
 	cmd.AddCommand(newCmdTrackerList(f))
+	cmd.AddCommand(newCmdTrackerGet(f))
 	return cmd
 }
 
@@ -44,12 +49,12 @@ func newCmdTrackerList(f *cmdutil.Factory) *cobra.Command {
 			}
 			trackers := result.Trackers
 
-			cmdutil.RenderCollection(printer, trackers, []string{"ID", "Name", "Description"}, func(t models.Tracker, styled bool) []string {
+			cmdutil.RenderCollection(printer, trackers, []string{"ID", "Name", "Default Status", "Description"}, func(t models.Tracker, styled bool) []string {
 				id := fmt.Sprintf("%d", t.ID)
 				if styled {
 					id = output.StyleID.Render(id)
 				}
-				return []string{id, t.Name, t.Description}
+				return []string{id, t.Name, trackerDefaultStatus(t), t.Description}
 			})
 			return nil
 		},
@@ -57,4 +62,83 @@ func newCmdTrackerList(f *cmdutil.Factory) *cobra.Command {
 
 	cmdutil.AddOutputFlag(cmd, &format)
 	return cmd
+}
+
+func newCmdTrackerGet(f *cmdutil.Factory) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:               "get <id-or-name>",
+		Aliases:           []string{"show", "view"},
+		Short:             "Show tracker details",
+		Long:              "Show tracker details. Accepts a numeric ID or tracker name.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cmdutil.CompleteTrackers(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			id, err := resolver.ResolveTracker(ctx, client, args[0])
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer(format)
+			stop := printer.Spinner("Fetching tracker...")
+			tracker, err := ops.GetTracker(ctx, client, ops.GetTrackerInput{ID: id})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(tracker)
+				return nil
+			}
+
+			details := []output.KeyValue{
+				{Key: "ID", Value: fmt.Sprintf("%d", tracker.ID)},
+				{Key: "Name", Value: tracker.Name},
+			}
+			if value := trackerDefaultStatusDetail(tracker); value != "" {
+				details = append(details, output.KeyValue{Key: "Default Status", Value: value})
+			}
+			if tracker.Description != "" {
+				details = append(details, output.KeyValue{Key: "Description", Value: tracker.Description})
+			}
+			if value := trackerStandardFields(tracker); value != "" {
+				details = append(details, output.KeyValue{Key: "Enabled Standard Fields", Value: value})
+			}
+
+			printer.Detail(details)
+			return nil
+		},
+	}
+
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}
+
+func trackerDefaultStatus(t models.Tracker) string {
+	if t.DefaultStatus == nil {
+		return ""
+	}
+	return t.DefaultStatus.Name
+}
+
+func trackerDefaultStatusDetail(t *models.Tracker) string {
+	if t.DefaultStatus == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s (ID: %d)", t.DefaultStatus.Name, t.DefaultStatus.ID)
+}
+
+func trackerStandardFields(t *models.Tracker) string {
+	if len(t.EnabledStandardFields) == 0 {
+		return ""
+	}
+	return strings.Join(t.EnabledStandardFields, ", ")
 }

--- a/internal/cmd/tracker/list.go
+++ b/internal/cmd/tracker/list.go
@@ -104,9 +104,9 @@ func newCmdTrackerGet(f *cmdutil.Factory) *cobra.Command {
 					[][]string{{
 						fmt.Sprintf("%d", tracker.ID),
 						tracker.Name,
-						trackerDefaultStatusDetail(tracker),
+						trackerDefaultStatusDetail(*tracker),
 						tracker.Description,
-						trackerStandardFields(tracker),
+						trackerStandardFields(*tracker),
 					}},
 				)
 				return nil
@@ -116,13 +116,13 @@ func newCmdTrackerGet(f *cmdutil.Factory) *cobra.Command {
 				{Key: "ID", Value: fmt.Sprintf("%d", tracker.ID)},
 				{Key: "Name", Value: tracker.Name},
 			}
-			if value := trackerDefaultStatusDetail(tracker); value != "" {
+			if value := trackerDefaultStatusDetail(*tracker); value != "" {
 				details = append(details, output.KeyValue{Key: "Default Status", Value: value})
 			}
 			if tracker.Description != "" {
 				details = append(details, output.KeyValue{Key: "Description", Value: tracker.Description})
 			}
-			if value := trackerStandardFields(tracker); value != "" {
+			if value := trackerStandardFields(*tracker); value != "" {
 				details = append(details, output.KeyValue{Key: "Enabled Standard Fields", Value: value})
 			}
 
@@ -142,14 +142,14 @@ func trackerDefaultStatus(t models.Tracker) string {
 	return t.DefaultStatus.Name
 }
 
-func trackerDefaultStatusDetail(t *models.Tracker) string {
+func trackerDefaultStatusDetail(t models.Tracker) string {
 	if t.DefaultStatus == nil {
 		return ""
 	}
 	return fmt.Sprintf("%s (ID: %d)", t.DefaultStatus.Name, t.DefaultStatus.ID)
 }
 
-func trackerStandardFields(t *models.Tracker) string {
+func trackerStandardFields(t models.Tracker) string {
 	if len(t.EnabledStandardFields) == 0 {
 		return ""
 	}

--- a/internal/cmd/tracker/list.go
+++ b/internal/cmd/tracker/list.go
@@ -98,6 +98,19 @@ func newCmdTrackerGet(f *cmdutil.Factory) *cobra.Command {
 				printer.JSON(tracker)
 				return nil
 			}
+			if printer.Format() == output.FormatCSV {
+				printer.CSV(
+					[]string{"ID", "Name", "Default Status", "Description", "Enabled Standard Fields"},
+					[][]string{{
+						fmt.Sprintf("%d", tracker.ID),
+						tracker.Name,
+						trackerDefaultStatusDetail(tracker),
+						tracker.Description,
+						trackerStandardFields(tracker),
+					}},
+				)
+				return nil
+			}
 
 			details := []output.KeyValue{
 				{Key: "ID", Value: fmt.Sprintf("%d", tracker.ID)},

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -94,7 +94,7 @@ func TestWriteGate_HidesMutatingTools(t *testing.T) {
 		"list_users", "get_user", "me",
 		"search",
 		"list_versions", "get_version",
-		"list_trackers", "list_statuses", "list_categories", "list_roles", "get_role",
+		"list_trackers", "get_tracker", "list_statuses", "list_categories", "list_roles", "get_role",
 		"list_wiki_pages", "get_wiki_page",
 		"list_memberships", "get_membership",
 	}

--- a/internal/mcpserver/tools_trackers_test.go
+++ b/internal/mcpserver/tools_trackers_test.go
@@ -1,0 +1,76 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListTrackersTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/trackers.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description"]}]}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_trackers"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"name":"Bug"`, `"default_status":{"id":2,"name":"New"}`, `"enabled_standard_fields":["description"]`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}
+
+func TestGetTrackerTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/trackers.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"trackers":[{"id":1,"name":"Bug","default_status":{"id":2,"name":"New"},"enabled_standard_fields":["description","due_date"]}]}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "get_tracker",
+		Arguments: map[string]any{"id": 1},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"id":1`, `"name":"Bug"`, `"enabled_standard_fields":["description","due_date"]`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}
+
+func containsText(text string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(text, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcpserver/tools_trackers_test.go
+++ b/internal/mcpserver/tools_trackers_test.go
@@ -3,7 +3,6 @@ package mcpserver
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -64,13 +63,4 @@ func TestGetTrackerTool_RoundTrip(t *testing.T) {
 	if !containsText(text, `"id":1`, `"name":"Bug"`, `"enabled_standard_fields":["description","due_date"]`) {
 		t.Fatalf("unexpected tool payload: %s", text)
 	}
-}
-
-func containsText(text string, parts ...string) bool {
-	for _, part := range parts {
-		if !strings.Contains(text, part) {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -164,6 +164,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Category:    "meta",
 		Call:        ops.GetRole,
 	})
+	registerToolSpec(s, client, opts, toolSpec[ops.GetTrackerInput, *models.Tracker]{
+		Name:        "get_tracker",
+		Description: "Fetch a single tracker by ID, including default status and enabled standard fields when available.",
+		Category:    "meta",
+		Call:        ops.GetTracker,
+	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetVersionInput, *models.Version]{
 		Name:        "get_version",
 		Description: "Fetch a single version (milestone) by ID.",
@@ -393,6 +399,7 @@ func generatedToolDescriptors() []ToolDescriptor {
 		{Name: "create_version", Description: "Create a project version (milestone). Requires --enable-writes.", Group: "meta", Writes: true},
 		{Name: "delete_version", Description: "Delete a version (milestone). Destructive. Requires --enable-writes.", Group: "meta", Writes: true},
 		{Name: "get_role", Description: "Fetch a single Redmine role by ID, including permissions when available.", Group: "meta", Writes: false},
+		{Name: "get_tracker", Description: "Fetch a single tracker by ID, including default status and enabled standard fields when available.", Group: "meta", Writes: false},
 		{Name: "get_version", Description: "Fetch a single version (milestone) by ID.", Group: "meta", Writes: false},
 		{Name: "list_categories", Description: "List issue categories for a project.", Group: "meta", Writes: false},
 		{Name: "list_roles", Description: "List all Redmine roles configured in this instance.", Group: "meta", Writes: false},

--- a/internal/models/tracker.go
+++ b/internal/models/tracker.go
@@ -4,7 +4,7 @@ package models
 type Tracker struct {
 	ID                    int      `json:"id"`
 	Name                  string   `json:"name"`
-	Description           string   `json:"description,omitempty"`
+	Description           string   `json:"description"`
 	DefaultStatus         *IDName  `json:"default_status,omitempty"`
 	EnabledStandardFields []string `json:"enabled_standard_fields,omitempty"`
 }

--- a/internal/models/tracker.go
+++ b/internal/models/tracker.go
@@ -2,7 +2,9 @@ package models
 
 // Tracker represents a Redmine tracker (e.g., Bug, Feature, Support).
 type Tracker struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	ID                    int      `json:"id"`
+	Name                  string   `json:"name"`
+	Description           string   `json:"description,omitempty"`
+	DefaultStatus         *IDName  `json:"default_status,omitempty"`
+	EnabledStandardFields []string `json:"enabled_standard_fields,omitempty"`
 }

--- a/internal/ops/meta.go
+++ b/internal/ops/meta.go
@@ -68,6 +68,10 @@ type RolesListResult struct {
 	Count int           `json:"count"`
 }
 
+type GetTrackerInput struct {
+	ID int `json:"id" jsonschema:"Numeric tracker ID."`
+}
+
 type StatusesListResult struct {
 	Statuses []models.IssueStatus `json:"issue_statuses"`
 	Count    int                  `json:"count"`
@@ -167,6 +171,13 @@ func ListRoles(ctx context.Context, client *api.Client, _ struct{}) (RolesListRe
 //mcpgen:category meta
 func GetRole(ctx context.Context, client *api.Client, input GetRoleInput) (*models.Role, error) {
 	return client.Roles.Get(ctx, input.ID)
+}
+
+//mcpgen:tool get_tracker
+//mcpgen:description Fetch a single tracker by ID, including default status and enabled standard fields when available.
+//mcpgen:category meta
+func GetTracker(ctx context.Context, client *api.Client, input GetTrackerInput) (*models.Tracker, error) {
+	return client.Trackers.Get(ctx, input.ID)
 }
 
 //mcpgen:tool list_statuses


### PR DESCRIPTION
## Summary
- extend tracker metadata to expose default status and enabled standard fields
- add `trackers get` and MCP `get_tracker` for detail-oriented inspection
- cover the new tracker surface with unit, MCP, and end-to-end tests

## Testing
- go test ./...
- REDMINE_E2E=1 ... go test -tags=e2e ./e2e -run 'TestMetadata_(TrackersListCSV|TrackerGetJSON)|TestMCPStdio_GetTrackerTool' -v

Closes #83