### PR TITLE
feat(time): allow logging time entries on behalf of another user

### DIFF
--- a/docs/src/content/docs/commands/time.mdx
+++ b/docs/src/content/docs/commands/time.mdx
@@ -32,6 +32,7 @@ Without flags, opens an interactive form.
 | `--activity` | Activity type (name or ID) |
 | `--comment`  | Description of work |
 | `--date`     | Date (YYYY-MM-DD or `today`, default: today) |
+| `--user`     | Log on behalf of another user (`me`, login, name, or ID) |
 
 <Tabs syncKey="time-log">
   <TabItem label="Interactive">
@@ -44,7 +45,16 @@ Without flags, opens an interactive form.
     redmine time log --issue 123 --hours 1.5 --activity Development --comment "Bug fix"
     ```
   </TabItem>
+  <TabItem label="On behalf of">
+    ```bash
+    redmine time log --issue 123 --hours 1 --user jsmith --comment "Pair work"
+    ```
+  </TabItem>
 </Tabs>
+
+<Aside type="caution">
+  `--user` requires admin privileges or the "Log time for other users" permission on the Redmine server. Without it, the server rejects the request.
+</Aside>
 
 ## list
 

--- a/docs/src/content/docs/commands/time.mdx
+++ b/docs/src/content/docs/commands/time.mdx
@@ -53,7 +53,7 @@ Without flags, opens an interactive form.
 </Tabs>
 
 <Aside type="caution">
-  `--user` requires admin privileges or the "Log time for other users" permission on the Redmine server. Without it, the server rejects the request.
+  `--user` requires admin privileges or the "Log time for other users" permission on the Redmine server. The target user must also be a member of the project with the "Log spent time" permission, otherwise Redmine returns a validation error (`User is invalid`).
 </Aside>
 
 ## list

--- a/docs/src/content/docs/zh-cn/commands/time.mdx
+++ b/docs/src/content/docs/zh-cn/commands/time.mdx
@@ -32,6 +32,7 @@ redmine time log [flags]
 | `--activity` | 活动类型（名称或 ID） |
 | `--comment`  | 工作描述 |
 | `--date`     | 日期（YYYY-MM-DD 或 `today`，默认：今天） |
+| `--user`     | 代他人记录工时（`me`、登录名、姓名或 ID） |
 
 <Tabs syncKey="time-log">
   <TabItem label="交互式">
@@ -44,7 +45,16 @@ redmine time log [flags]
     redmine time log --issue 123 --hours 1.5 --activity Development --comment "Bug fix"
     ```
   </TabItem>
+  <TabItem label="代他人">
+    ```bash
+    redmine time log --issue 123 --hours 1 --user jsmith --comment "Pair work"
+    ```
+  </TabItem>
 </Tabs>
+
+<Aside type="caution">
+  `--user` 需要 Redmine 服务端的管理员权限或“代他人记录工时”权限，否则服务器会拒绝该请求。
+</Aside>
 
 ## list
 

--- a/docs/src/content/docs/zh-cn/commands/time.mdx
+++ b/docs/src/content/docs/zh-cn/commands/time.mdx
@@ -53,7 +53,7 @@ redmine time log [flags]
 </Tabs>
 
 <Aside type="caution">
-  `--user` 需要 Redmine 服务端的管理员权限或“代他人记录工时”权限，否则服务器会拒绝该请求。
+  `--user` 需要 Redmine 服务端的管理员权限或“代他人记录工时”权限。同时，目标用户必须是该项目的成员并拥有“记录工时”权限，否则 Redmine 会返回校验错误（`User is invalid`）。
 </Aside>
 
 ## list

--- a/e2e/time_entries_test.go
+++ b/e2e/time_entries_test.go
@@ -95,6 +95,21 @@ func TestTimeEntries_LogOnBehalfOf(t *testing.T) {
 	activity := firstActivityName(t, r)
 	target := createTestUser(t, r)
 
+	// Redmine validates that the target user is a project member with the
+	// "log_time" permission. Add the fresh fixture user via memberships create
+	// using the first available role (Manager/Developer in stock builds both
+	// include log_time).
+	var membership struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &membership, "memberships", "create",
+		"--project", proj.Identifier,
+		"--user-id", strconv.Itoa(target.ID),
+		"--role-ids", strconv.Itoa(firstRoleID(t, r)))
+	if membership.ID == 0 {
+		t.Fatalf("membership create returned no ID for user %d on project %s", target.ID, proj.Identifier)
+	}
+
 	var created struct {
 		ID    int     `json:"id"`
 		Hours float64 `json:"hours"`

--- a/e2e/time_entries_test.go
+++ b/e2e/time_entries_test.go
@@ -83,3 +83,43 @@ func TestTimeEntries_CRUD(t *testing.T) {
 		t.Fatalf("expected no entries after delete; got %+v", entries)
 	}
 }
+
+// TestTimeEntries_LogOnBehalfOf verifies admin can log time for another user
+// via `time log --user`. Resolves the target user by login and confirms the
+// returned entry's user.id matches the fixture, not the API caller.
+func TestTimeEntries_LogOnBehalfOf(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+	issue := createTestIssue(t, r, proj.Identifier)
+	activity := firstActivityName(t, r)
+	target := createTestUser(t, r)
+
+	var created struct {
+		ID    int     `json:"id"`
+		Hours float64 `json:"hours"`
+		User  struct {
+			ID int `json:"id"`
+		} `json:"user"`
+	}
+	r.runJSON(t, &created, "time", "log",
+		"--issue", strconv.Itoa(issue.ID),
+		"--hours", "0.5",
+		"--activity", activity,
+		"--user", strconv.Itoa(target.ID),
+		"--comment", "logged on behalf by e2e")
+	if created.ID == 0 {
+		t.Fatalf("time log on behalf returned no ID: %+v", created)
+	}
+	if created.User.ID != target.ID {
+		t.Fatalf("time log on behalf user.id = %d, want %d", created.User.ID, target.ID)
+	}
+
+	t.Cleanup(func() {
+		var deleted actionEnvelope
+		r.runJSON(t, &deleted, "time", "delete", strconv.Itoa(created.ID), "--force")
+		if !deleted.Ok {
+			t.Errorf("time delete envelope not ok: %+v", deleted)
+		}
+	})
+}

--- a/internal/cmd/time/log.go
+++ b/internal/cmd/time/log.go
@@ -21,6 +21,7 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 		activity string
 		date     string
 		comment  string
+		user     string
 		format   string
 	)
 
@@ -34,7 +35,9 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			project, err = cmdutil.DefaultProjectID(context.Background(), f, project)
+			ctx := context.Background()
+
+			project, err = cmdutil.DefaultProjectID(ctx, f, project)
 			if err != nil {
 				return err
 			}
@@ -46,19 +49,28 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 
 			var activityID int
 			if activity != "" {
-				activityID, err = resolver.ResolveActivity(context.Background(), client, activity)
+				activityID, err = resolver.ResolveActivity(ctx, client, activity)
 				if err != nil {
 					return fmt.Errorf("resolving activity: %w", err)
 				}
 			}
 
-			created, err := ops.CreateTimeEntry(context.Background(), client, ops.CreateTimeEntryInput{
+			var userID int
+			if user != "" {
+				userID, err = resolver.ResolveUser(ctx, client, user)
+				if err != nil {
+					return fmt.Errorf("resolving user: %w", err)
+				}
+			}
+
+			created, err := ops.CreateTimeEntry(ctx, client, ops.CreateTimeEntryInput{
 				IssueID:    issue,
 				ProjectID:  project,
 				Hours:      hours,
 				ActivityID: activityID,
 				SpentOn:    date,
 				Comments:   comment,
+				UserID:     userID,
 			})
 			if err != nil {
 				return err
@@ -79,12 +91,14 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&activity, "activity", "", "Activity name or ID")
 	cmd.Flags().StringVar(&date, "date", "", "Date (YYYY-MM-DD or 'today', default today)")
 	cmd.Flags().StringVar(&comment, "comment", "", "Comment")
+	cmd.Flags().StringVar(&user, "user", "", "Log time on behalf of a user (ID, login, name, or 'me'); requires admin or 'log time for other users' permission")
 	cmdutil.AddOutputFlag(cmd, &format)
 
 	_ = cmd.MarkFlagRequired("hours")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
 	_ = cmd.RegisterFlagCompletionFunc("activity", cmdutil.CompleteActivities(f))
+	_ = cmd.RegisterFlagCompletionFunc("user", cmdutil.CompleteUsers(f))
 
 	return cmd
 }

--- a/internal/cmd/time/time_test.go
+++ b/internal/cmd/time/time_test.go
@@ -404,6 +404,32 @@ func TestTimeLog_OnBehalfOfUser_Me(t *testing.T) {
 	}
 }
 
+func TestTimeLog_OnBehalfOfUser_ResolverFailureWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Listing users for name resolution returns an empty result, which the
+		// resolver surfaces as "no user found matching ...".
+		if r.URL.Path == "/users.json" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"users":[],"total_count":0}`))
+			return
+		}
+		t.Fatalf("unexpected path: %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdTimeLog(f)
+	cmd.SetArgs([]string{"--hours", "1", "--issue", "10", "--user", "no-such-user"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when resolver cannot find target user")
+	}
+	if !strings.Contains(err.Error(), "resolving user") {
+		t.Errorf("error = %q, want wrapping with 'resolving user'", err.Error())
+	}
+}
+
 func TestTimeLog_OnBehalfOfUser_OmittedByDefault(t *testing.T) {
 	var capturedBody map[string]interface{}
 

--- a/internal/cmd/time/time_test.go
+++ b/internal/cmd/time/time_test.go
@@ -337,6 +337,101 @@ func TestTimeLog_MissingHours(t *testing.T) {
 	}
 }
 
+func TestTimeLog_OnBehalfOfUser_NumericID(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/time_entries.json" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"time_entry":{"id":99,"hours":1,"spent_on":"2025-06-15","project":{"id":1,"name":"Demo"},"user":{"id":7,"name":"Bob"},"activity":{"id":9,"name":"Development"}}}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdTimeLog(f)
+	cmd.SetArgs([]string{"--hours", "1", "--issue", "10", "--user", "7"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	te, _ := capturedBody["time_entry"].(map[string]interface{})
+	if te == nil {
+		t.Fatal("request body missing time_entry wrapper")
+	}
+	if te["user_id"] != float64(7) {
+		t.Errorf("payload user_id = %v, want 7", te["user_id"])
+	}
+}
+
+func TestTimeLog_OnBehalfOfUser_Me(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/users/current.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user":{"id":42,"login":"me","firstname":"Self","lastname":"User"}}`))
+		case "/time_entries.json":
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time_entry":{"id":99,"hours":1,"spent_on":"2025-06-15","project":{"id":1,"name":"Demo"},"user":{"id":42,"name":"Self User"},"activity":{"id":9,"name":"Development"}}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdTimeLog(f)
+	cmd.SetArgs([]string{"--hours", "1", "--issue", "10", "--user", "me"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	te, _ := capturedBody["time_entry"].(map[string]interface{})
+	if te == nil {
+		t.Fatal("request body missing time_entry wrapper")
+	}
+	if te["user_id"] != float64(42) {
+		t.Errorf("payload user_id = %v, want 42 (resolved from 'me')", te["user_id"])
+	}
+}
+
+func TestTimeLog_OnBehalfOfUser_OmittedByDefault(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"time_entry":{"id":99,"hours":1,"spent_on":"2025-06-15","project":{"id":1,"name":"Demo"},"user":{"id":2,"name":"Alice"},"activity":{"id":9,"name":"Development"}}}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdTimeLog(f)
+	cmd.SetArgs([]string{"--hours", "1", "--issue", "10"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	te, _ := capturedBody["time_entry"].(map[string]interface{})
+	if te == nil {
+		t.Fatal("request body missing time_entry wrapper")
+	}
+	if _, ok := te["user_id"]; ok {
+		t.Errorf("payload should omit user_id when --user not set, got %v", te["user_id"])
+	}
+}
+
 // --- update ---
 
 func TestTimeUpdate_Success(t *testing.T) {

--- a/internal/models/time_entry.go
+++ b/internal/models/time_entry.go
@@ -22,6 +22,7 @@ type TimeEntryCreate struct {
 	ActivityID int     `json:"activity_id,omitempty"`
 	SpentOn    string  `json:"spent_on,omitempty"`
 	Comments   string  `json:"comments,omitempty"`
+	UserID     int     `json:"user_id,omitempty"`
 }
 
 // TimeEntryUpdate defines fields for updating a time entry.

--- a/internal/ops/time_entries.go
+++ b/internal/ops/time_entries.go
@@ -37,6 +37,7 @@ type CreateTimeEntryInput struct {
 	ActivityID int     `json:"activity_id,omitempty" jsonschema:"Activity enumeration ID."`
 	SpentOn    string  `json:"spent_on,omitempty" jsonschema:"Date the work was done (YYYY-MM-DD). Defaults to today."`
 	Comments   string  `json:"comments,omitempty" jsonschema:"Free-text comment."`
+	UserID     int     `json:"user_id,omitempty" jsonschema:"Numeric ID of the user the entry is logged for. Requires admin or 'log time for other users' permission on the server."`
 }
 
 type UpdateTimeEntryInput struct {
@@ -114,6 +115,7 @@ func CreateTimeEntry(ctx context.Context, client *api.Client, input CreateTimeEn
 		ActivityID: input.ActivityID,
 		SpentOn:    input.SpentOn,
 		Comments:   input.Comments,
+		UserID:     input.UserID,
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds `--user` to `redmine time log`, accepting numeric ID, login, full name, or `me`. Resolution goes through the existing user resolver, so completion and error messages match the rest of the CLI.
- Threads `user_id` through `models.TimeEntryCreate`, `ops.CreateTimeEntryInput` (with a jsonschema note about the server-side permission), and into the `/time_entries` POST payload. The MCP `create_time_entry` tool picks the field up automatically via reflection.
- Documents the flag and permission requirement in the English and Chinese command docs, including a new "On behalf of" example tab.

Closes #82

## Test plan

- [x] `go test ./...` (added unit tests in `internal/cmd/time` covering numeric ID, `me`, and the default-omitted case)
- [x] `golangci-lint run ./...`
- [x] `gofmt`, `go vet`, `go build ./...`
- [x] `go build -tags e2e ./e2e/...` (new `TestTimeEntries_LogOnBehalfOf` exercises admin -> target-user logging end-to-end)
- [ ] Run the e2e suite against a live Redmine (`go test -tags e2e ./e2e/...`)