### PR TITLE
feat(queries): add saved query support and issue listing by query ID

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
 					items: [
 						{ label: 'Auth', translations: { 'zh-CN': '身份验证' }, slug: 'commands/auth' },
 						{ label: 'Issues', translations: { 'zh-CN': '工单' }, slug: 'commands/issues' },
+						{ label: 'Queries', translations: { 'zh-CN': '自定义查询' }, slug: 'commands/queries' },
 						{ label: 'Projects', translations: { 'zh-CN': '项目' }, slug: 'commands/projects' },
 						{ label: 'Memberships', translations: { 'zh-CN': '成员关系' }, slug: 'commands/memberships' },
 						{ label: 'Versions', translations: { 'zh-CN': '版本' }, slug: 'commands/versions' },

--- a/docs/src/content/docs/commands/issues.mdx
+++ b/docs/src/content/docs/commands/issues.mdx
@@ -34,6 +34,8 @@ redmine issues list [flags]
 | `--status`      | Filter by status: `open`, `closed`, `*`, name, or ID |
 | `--assignee`    | Filter by assignee: `me`, name, or ID |
 | `--version`     | Filter by target version (name or ID) |
+| `--query`       | Run a saved query by name (see [`queries`](/redmine-cli/commands/queries/)) |
+| `--query-id`    | Run a saved query by numeric ID (mutually exclusive with `--query`) |
 | `--sort`        | Sort order, e.g. `updated_on:desc` |
 | `--include`     | Include related data: `attachments`, `relations` |
 | `--attachments` | Shorthand for `--include attachments` |

--- a/docs/src/content/docs/commands/queries.mdx
+++ b/docs/src/content/docs/commands/queries.mdx
@@ -45,7 +45,7 @@ Aliases: `show`, `view`. Accepts a numeric ID or query name.
 
 | Flag | Description |
 |------|-------------|
-| `--project`    | Project identifier or numeric ID — disambiguates per-project queries that share a name with a global query |
+| `--project`    | Project identifier or numeric ID - disambiguates per-project queries that share a name with a global query |
 | `-o, --output` | Output format |
 
 ## Running a saved query
@@ -53,10 +53,10 @@ Aliases: `show`, `view`. Accepts a numeric ID or query name.
 Once you know the query ID (or name), run it through the issues endpoint:
 
 ```bash
-# By ID — no extra round trip
+# By ID - no extra round trip
 redmine issues list --query-id 12
 
-# By name — the CLI resolves the ID first
+# By name - the CLI resolves the ID first
 redmine issues list --query "My open issues"
 
 # Combine with --project to disambiguate per-project queries

--- a/docs/src/content/docs/commands/queries.mdx
+++ b/docs/src/content/docs/commands/queries.mdx
@@ -1,0 +1,66 @@
+---
+title: Queries
+description: List Redmine saved queries (custom filters) and run them from the CLI.
+---
+
+import { CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
+
+The `queries` command (alias `q`) lists saved queries (custom filters) defined in the Redmine web UI and lets you reuse them from the CLI.
+
+<CardGrid>
+  <LinkCard title="list" href="#list" description="List saved queries visible to the authenticated user." />
+  <LinkCard title="get"  href="#get"  description="Inspect a single saved query by ID or name." />
+</CardGrid>
+
+<Aside type="note">
+  Saved queries can only be created or edited in the Redmine web UI. The CLI is read-only here and reuses the existing query through the `query_id` parameter on the issues endpoint.
+</Aside>
+
+## list
+
+```bash
+redmine queries list [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--limit`      | Maximum number of results (0 for all) |
+| `--offset`     | Result offset for pagination |
+| `-o, --output` | Output format: `table`, `json`, `csv` |
+
+Each row reports the query ID, name, visibility (`public` or `private`), and scope (`global` or `project <id>`).
+
+```bash
+redmine queries list
+redmine queries list -o json
+```
+
+## get
+
+```bash
+redmine queries get <id-or-name> [flags]
+```
+
+Aliases: `show`, `view`. Accepts a numeric ID or query name.
+
+| Flag | Description |
+|------|-------------|
+| `--project`    | Project identifier or numeric ID — disambiguates per-project queries that share a name with a global query |
+| `-o, --output` | Output format |
+
+## Running a saved query
+
+Once you know the query ID (or name), run it through the issues endpoint:
+
+```bash
+# By ID — no extra round trip
+redmine issues list --query-id 12
+
+# By name — the CLI resolves the ID first
+redmine issues list --query "My open issues"
+
+# Combine with --project to disambiguate per-project queries
+redmine issues list --project myproject --query "Sprint backlog"
+```
+
+The saved query's filters apply server-side. You can still pair `--query-id` with `--sort`, `--limit`, `--offset`, and `--include` to shape the result set.

--- a/docs/src/content/docs/zh-cn/commands/issues.mdx
+++ b/docs/src/content/docs/zh-cn/commands/issues.mdx
@@ -34,6 +34,8 @@ redmine issues list [flags]
 | `--status`      | 按状态过滤：`open`、`closed`、`*`、名称或 ID |
 | `--assignee`    | 按指派人过滤：`me`、名称或 ID |
 | `--version`     | 按目标版本过滤（名称或 ID） |
+| `--query`       | 按名称运行自定义查询（参见 [`queries`](/redmine-cli/zh-cn/commands/queries/)） |
+| `--query-id`    | 按数字 ID 运行自定义查询（与 `--query` 互斥） |
 | `--sort`        | 排序方式，例如 `updated_on:desc` |
 | `--include`     | 包含关联数据：`attachments`、`relations` |
 | `--attachments` | `--include attachments` 的简写 |

--- a/docs/src/content/docs/zh-cn/commands/queries.mdx
+++ b/docs/src/content/docs/zh-cn/commands/queries.mdx
@@ -1,0 +1,66 @@
+---
+title: 自定义查询
+description: 列出 Redmine 已保存的自定义查询，并在 CLI 中复用它们。
+---
+
+import { CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
+
+`queries` 命令（别名 `q`）用于列出在 Redmine Web UI 中保存的自定义查询，并允许在 CLI 中直接复用这些过滤条件。
+
+<CardGrid>
+  <LinkCard title="list" href="#list" description="列出当前用户可见的所有自定义查询。" />
+  <LinkCard title="get"  href="#get"  description="按 ID 或名称查看单个自定义查询。" />
+</CardGrid>
+
+<Aside type="note">
+  自定义查询只能通过 Redmine Web UI 创建或修改。CLI 仅提供只读访问，并通过工单接口的 `query_id` 参数复用已有查询。
+</Aside>
+
+## list
+
+```bash
+redmine queries list [flags]
+```
+
+| 标志 | 描述 |
+|------|------|
+| `--limit`      | 最大结果数（0 表示全部） |
+| `--offset`     | 分页偏移量 |
+| `-o, --output` | 输出格式：`table`、`json`、`csv` |
+
+每一行包含查询 ID、名称、可见性（`public` 或 `private`）以及作用域（`global` 或 `project <id>`）。
+
+```bash
+redmine queries list
+redmine queries list -o json
+```
+
+## get
+
+```bash
+redmine queries get <id-or-name> [flags]
+```
+
+别名：`show`、`view`。接受数字 ID 或查询名称。
+
+| 标志 | 描述 |
+|------|------|
+| `--project`    | 项目标识符或数字 ID — 用于区分与全局查询同名的项目级查询 |
+| `-o, --output` | 输出格式 |
+
+## 运行自定义查询
+
+获得查询 ID（或名称）后，通过工单接口直接运行：
+
+```bash
+# 按 ID — 无需额外查询
+redmine issues list --query-id 12
+
+# 按名称 — CLI 会先解析为 ID
+redmine issues list --query "我的未关闭工单"
+
+# 与 --project 配合，避免项目级查询与全局查询同名时的歧义
+redmine issues list --project myproject --query "迭代待办"
+```
+
+自定义查询中的过滤条件由服务端应用。`--query-id` 仍可与 `--sort`、`--limit`、`--offset` 和 `--include` 等参数组合使用，以进一步控制返回结果。

--- a/docs/src/content/docs/zh-cn/commands/queries.mdx
+++ b/docs/src/content/docs/zh-cn/commands/queries.mdx
@@ -45,7 +45,7 @@ redmine queries get <id-or-name> [flags]
 
 | 标志 | 描述 |
 |------|------|
-| `--project`    | 项目标识符或数字 ID — 用于区分与全局查询同名的项目级查询 |
+| `--project`    | 项目标识符或数字 ID - 用于区分与全局查询同名的项目级查询 |
 | `-o, --output` | 输出格式 |
 
 ## 运行自定义查询
@@ -53,10 +53,10 @@ redmine queries get <id-or-name> [flags]
 获得查询 ID（或名称）后，通过工单接口直接运行：
 
 ```bash
-# 按 ID — 无需额外查询
+# 按 ID - 无需额外查询
 redmine issues list --query-id 12
 
-# 按名称 — CLI 会先解析为 ID
+# 按名称 - CLI 会先解析为 ID
 redmine issues list --query "我的未关闭工单"
 
 # 与 --project 配合，避免项目级查询与全局查询同名时的歧义

--- a/e2e/bootstrap-redmine.sh
+++ b/e2e/bootstrap-redmine.sh
@@ -28,11 +28,28 @@ docker compose -f "$compose_file" exec -T \
       admin.must_change_passwd = false
       admin.save!
     end
+
+    # Seed a public, global saved query so the queries e2e suite has a stable
+    # fixture. Redmine has no REST endpoint for creating queries, so the
+    # bootstrap is the only place this can live without re-implementing
+    # session auth + CSRF in the test harness.
+    query_name = "E2E All Open Issues"
+    seeded_query = IssueQuery.find_or_initialize_by(name: query_name)
+    if seeded_query.new_record?
+      seeded_query.user = admin
+      seeded_query.visibility = IssueQuery::VISIBILITY_PUBLIC
+      seeded_query.filters = { "status_id" => { operator: "o", values: [""] } }
+      seeded_query.column_names = [:tracker, :status, :priority, :subject, :assigned_to, :updated_on]
+      seeded_query.save!
+    end
+
     puts({
       rest_api_enabled: Setting.rest_api_enabled?,
       admin_api_key_present: admin.api_key.to_s != "",
       admin_password_set: ENV["REDMINE_E2E_PASSWORD"].to_s != "",
       trackers: Tracker.count,
-      statuses: IssueStatus.count
+      statuses: IssueStatus.count,
+      seeded_query_id: seeded_query.id,
+      seeded_query_name: seeded_query.name
     }.inspect)
   ' 2>/dev/null | tail -n 1

--- a/e2e/queries_test.go
+++ b/e2e/queries_test.go
@@ -4,33 +4,109 @@ package e2e
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 )
 
-// TestQueries_ListAndFilter exercises the queries surface end-to-end. Redmine
-// does not expose a REST endpoint to create saved queries, so the test only
-// asserts that `queries list` returns a well-formed (possibly empty) JSON
-// array. When the bootstrap data set happens to include a saved query
-// (depends on the Redmine version) the test additionally runs
-// `issues list --query-id <id>` to verify the filter is wired end-to-end.
-// Passing a non-existent query_id is skipped because Redmine returns a 404
-// in that case, which would mask real regressions.
-func TestQueries_ListAndFilter(t *testing.T) {
+// seededQueryName matches the saved query inserted by e2e/bootstrap-redmine.sh.
+// Tests rely on this fixture because Redmine has no REST endpoint to create
+// saved queries, so the bootstrap is the only seeding hook the harness has.
+const seededQueryName = "E2E All Open Issues"
+
+// TestQueries_ListIncludesSeededFixture asserts that the saved query the
+// bootstrap script seeds is visible to `redmine queries list`. Together with
+// the issues-list test below this gives end-to-end coverage of both the
+// `queries` group and the `--query`/`--query-id` filter wiring.
+func TestQueries_ListIncludesSeededFixture(t *testing.T) {
 	requireE2E(t)
 	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
 
+	id := requireSeededQueryID(t, r)
+	if id <= 0 {
+		t.Fatalf("seeded query ID = %d, want positive", id)
+	}
+}
+
+// TestIssues_ListByQueryID exercises the happy path for the `--query-id` flag
+// against a real saved query. Redmine returns the query's filtered result
+// set; we only assert that the call succeeded and produced a JSON array
+// because the fixture has no committed issues yet, so an empty list is
+// valid.
+func TestIssues_ListByQueryID(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	id := requireSeededQueryID(t, r)
+
+	var issues []struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &issues, "issues", "list", "--query-id", strconv.Itoa(id), "--limit", "5")
+}
+
+// TestIssues_ListByQueryName proves that `--query` resolves a name to an ID
+// against the live Redmine instance and that the resolved ID then drives a
+// successful issues list call.
+func TestIssues_ListByQueryName(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	// Verify the seed exists before asserting on the name path so a missing
+	// fixture surfaces as a clear setup error rather than a name-resolution
+	// failure deep inside the resolver.
+	_ = requireSeededQueryID(t, r)
+
+	var issues []struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &issues, "issues", "list", "--query", seededQueryName, "--limit", "5")
+}
+
+// TestIssues_ListByUnknownQueryID verifies the negative path: passing a
+// query_id that no saved query owns must surface as a not_found error
+// envelope. This proves the parameter actually reaches Redmine (rather than
+// being silently dropped by the CLI) and that the error is mapped through
+// the standard envelope plumbing.
+func TestIssues_ListByUnknownQueryID(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	stdout, _ := r.runExpectError(t, "issues", "list", "--query-id", "2147483600")
+	assertErrorCode(t, stdout, "not_found")
+}
+
+// TestQueries_GetRoundTrip exercises `queries get` against the seeded fixture
+// and verifies the detail rendering reports the query as public + global.
+func TestQueries_GetRoundTrip(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	id := requireSeededQueryID(t, r)
+
+	stdout := r.run(t, "queries", "get", strconv.Itoa(id), "--output", "table")
+	for _, want := range []string{seededQueryName, "public", "global"} {
+		if !strings.Contains(string(stdout), want) {
+			t.Fatalf("queries get output missing %q\nstdout:\n%s", want, stdout)
+		}
+	}
+}
+
+// requireSeededQueryID returns the ID of the saved query named seededQueryName
+// or fails the test. Tests use this rather than searching inline so a missing
+// bootstrap fixture surfaces with a single, descriptive failure.
+func requireSeededQueryID(t *testing.T, r *cliRunner) int {
+	t.Helper()
 	var queries []struct {
 		ID   int    `json:"id"`
 		Name string `json:"name"`
 	}
 	r.runJSON(t, &queries, "queries", "list")
 
-	if len(queries) == 0 {
-		t.Skip("no saved queries on this Redmine instance; skipping --query-id wire check")
+	for _, q := range queries {
+		if q.Name == seededQueryName {
+			return q.ID
+		}
 	}
-
-	var issues []struct {
-		ID int `json:"id"`
-	}
-	r.runJSON(t, &issues, "issues", "list", "--query-id", strconv.Itoa(queries[0].ID), "--limit", "5")
+	t.Fatalf("seeded query %q not found in queries list (did the bootstrap run?); got: %+v", seededQueryName, queries)
+	return 0
 }

--- a/e2e/queries_test.go
+++ b/e2e/queries_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestQueries_ListAndFilter exercises the queries surface end-to-end. Redmine
+// does not expose a REST endpoint to create saved queries, so the test only
+// asserts that:
+//
+//   - `queries list` returns a well-formed (possibly empty) JSON array.
+//   - `issues list --query-id <id>` accepts the flag and runs successfully.
+//     When the server has no saved queries, the test still verifies that the
+//     CLI threads --query-id through without parsing errors by passing a
+//     positive integer; Redmine returns the unfiltered issue list when the
+//     query_id is not a real saved query, which is exactly the wire-format
+//     check we want.
+func TestQueries_ListAndFilter(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	var queries []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	r.runJSON(t, &queries, "queries", "list")
+
+	queryID := 1
+	if len(queries) > 0 {
+		queryID = queries[0].ID
+	}
+
+	var issues []struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &issues, "issues", "list", "--query-id", strconv.Itoa(queryID), "--limit", "5")
+}

--- a/e2e/queries_test.go
+++ b/e2e/queries_test.go
@@ -9,15 +9,12 @@ import (
 
 // TestQueries_ListAndFilter exercises the queries surface end-to-end. Redmine
 // does not expose a REST endpoint to create saved queries, so the test only
-// asserts that:
-//
-//   - `queries list` returns a well-formed (possibly empty) JSON array.
-//   - `issues list --query-id <id>` accepts the flag and runs successfully.
-//     When the server has no saved queries, the test still verifies that the
-//     CLI threads --query-id through without parsing errors by passing a
-//     positive integer; Redmine returns the unfiltered issue list when the
-//     query_id is not a real saved query, which is exactly the wire-format
-//     check we want.
+// asserts that `queries list` returns a well-formed (possibly empty) JSON
+// array. When the bootstrap data set happens to include a saved query
+// (depends on the Redmine version) the test additionally runs
+// `issues list --query-id <id>` to verify the filter is wired end-to-end.
+// Passing a non-existent query_id is skipped because Redmine returns a 404
+// in that case, which would mask real regressions.
 func TestQueries_ListAndFilter(t *testing.T) {
 	requireE2E(t)
 	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
@@ -28,13 +25,12 @@ func TestQueries_ListAndFilter(t *testing.T) {
 	}
 	r.runJSON(t, &queries, "queries", "list")
 
-	queryID := 1
-	if len(queries) > 0 {
-		queryID = queries[0].ID
+	if len(queries) == 0 {
+		t.Skip("no saved queries on this Redmine instance; skipping --query-id wire check")
 	}
 
 	var issues []struct {
 		ID int `json:"id"`
 	}
-	r.runJSON(t, &issues, "issues", "list", "--query-id", strconv.Itoa(queryID), "--limit", "5")
+	r.runJSON(t, &issues, "issues", "list", "--query-id", strconv.Itoa(queries[0].ID), "--limit", "5")
 }

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -65,7 +65,7 @@
   },
   {
     "name": "list_queries",
-    "description": "List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter."
+    "description": "List saved queries (custom filters) visible to the authenticated user. Pass the returned id to list_issues as query_id to run the query."
   },
   {
     "name": "list_roles",

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -64,6 +64,10 @@
     "description": "List Redmine projects."
   },
   {
+    "name": "list_queries",
+    "description": "List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter."
+  },
+  {
     "name": "list_roles",
     "description": "List all Redmine roles configured in this instance."
   },

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	Memberships  *MembershipService
 	Attachments  *AttachmentService
 	Wikis        *WikiService
+	Queries      *QueryService
 }
 
 // DebugLog returns the client's debug logger.
@@ -117,6 +118,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Memberships = &MembershipService{client: c}
 	c.Attachments = &AttachmentService{client: c}
 	c.Wikis = &WikiService{client: c}
+	c.Queries = &QueryService{client: c}
 
 	return c, nil
 }

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -32,6 +32,9 @@ func (s *IssueService) List(ctx context.Context, filter models.IssueFilter) ([]m
 	if filter.FixedVersionID > 0 {
 		params.Set("fixed_version_id", strconv.Itoa(filter.FixedVersionID))
 	}
+	if filter.QueryID > 0 {
+		params.Set("query_id", strconv.Itoa(filter.QueryID))
+	}
 	if len(filter.Includes) > 0 {
 		params.Set("include", joinStrings(filter.Includes, ","))
 	}

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+// QueryService handles saved-query API calls.
+type QueryService struct {
+	client *Client
+}
+
+// List retrieves saved queries visible to the authenticated user. Redmine's
+// /queries.json endpoint does not accept a project filter; callers receive
+// every visible query (global plus project-specific) and can filter by the
+// ProjectID field client-side if needed.
+func (s *QueryService) List(ctx context.Context, limit, offset int) ([]models.SavedQuery, int, error) {
+	params := url.Values{}
+	if offset > 0 {
+		params.Set("offset", strconv.Itoa(offset))
+	}
+	return FetchAll[models.SavedQuery](ctx, s.client, "/queries.json", params, "queries", limit)
+}

--- a/internal/cmd/issue/filter_resolution.go
+++ b/internal/cmd/issue/filter_resolution.go
@@ -22,6 +22,23 @@ func resolveIssueStatusFilter(ctx context.Context, client *api.Client, status st
 	return strconv.Itoa(id), nil
 }
 
+func resolveIssueQueryFilter(ctx context.Context, client *api.Client, query string, queryID int, projectIdentifier string) (int, error) {
+	if queryID > 0 && query != "" {
+		return 0, fmt.Errorf("--query and --query-id are mutually exclusive; pick one")
+	}
+	if queryID > 0 {
+		return queryID, nil
+	}
+	if query == "" {
+		return 0, nil
+	}
+	id, err := resolver.ResolveQuery(ctx, client, query, projectIdentifier)
+	if err != nil {
+		return 0, fmt.Errorf("resolving query: %w", err)
+	}
+	return id, nil
+}
+
 func resolveIssueAssigneeFilter(ctx context.Context, client *api.Client, assignee string, printer output.Printer) (string, error) {
 	if assignee == "" || assignee == "me" {
 		return assignee, nil

--- a/internal/cmd/issue/filter_resolution.go
+++ b/internal/cmd/issue/filter_resolution.go
@@ -22,21 +22,27 @@ func resolveIssueStatusFilter(ctx context.Context, client *api.Client, status st
 	return strconv.Itoa(id), nil
 }
 
-func resolveIssueQueryFilter(ctx context.Context, client *api.Client, query string, queryID int, projectIdentifier string) (int, error) {
-	if queryID > 0 && query != "" {
-		return 0, fmt.Errorf("--query and --query-id are mutually exclusive; pick one")
-	}
-	if queryID > 0 {
+// resolveIssueQueryFilter validates the --query / --query-id flags and
+// returns the saved query ID to thread into the issues list request. Mutual
+// exclusion is enforced by cobra at flag-parse time, so callers reaching
+// here have at most one of the two set. A non-positive --query-id is
+// rejected because Redmine's query_id is a positive integer; treating zero
+// as "no filter" would silently swallow user typos.
+func resolveIssueQueryFilter(ctx context.Context, client *api.Client, query string, queryID int, queryIDChanged bool, projectIdentifier string) (int, error) {
+	if queryIDChanged {
+		if queryID <= 0 {
+			return 0, fmt.Errorf("--query-id must be a positive integer, got %d", queryID)
+		}
 		return queryID, nil
 	}
 	if query == "" {
 		return 0, nil
 	}
-	id, err := resolver.ResolveQuery(ctx, client, query, projectIdentifier)
+	q, err := resolver.ResolveQuery(ctx, client, query, projectIdentifier)
 	if err != nil {
 		return 0, fmt.Errorf("resolving query: %w", err)
 	}
-	return id, nil
+	return q.ID, nil
 }
 
 func resolveIssueAssigneeFilter(ctx context.Context, client *api.Client, assignee string, printer output.Printer) (string, error) {

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -101,7 +101,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				versionID = id
 			}
 
-			resolvedQueryID, err := resolveIssueQueryFilter(ctx, client, query, queryID, project)
+			resolvedQueryID, err := resolveIssueQueryFilter(ctx, client, query, queryID, cmd.Flags().Changed("query-id"), project)
 			if err != nil {
 				return err
 			}
@@ -190,6 +190,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&version, "version", "", "Filter by version name or ID")
 	cmd.Flags().StringVar(&query, "query", "", "Run a saved query by name (mutually exclusive with --query-id)")
 	cmd.Flags().IntVar(&queryID, "query-id", 0, "Run a saved query by numeric ID")
+	cmd.MarkFlagsMutuallyExclusive("query", "query-id")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort field (e.g., updated_on:desc)")
 	cmd.Flags().StringVar(&include, "include", "", "Include related data: attachments,relations")
 	cmd.Flags().BoolVar(&attachments, "attachments", false, "Include attachments (shorthand for --include attachments)")

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -21,6 +21,8 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		status      string
 		assignee    string
 		version     string
+		query       string
+		queryID     int
 		sort        string
 		include     string
 		attachments bool
@@ -53,7 +55,11 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
   redmine issues list --status closed --assignee me --sort updated_on:desc
 
   # All issues regardless of status
-  redmine issues list --project myproject --status "*" --limit 0 -o json`,
+  redmine issues list --project myproject --status "*" --limit 0 -o json
+
+  # Run a saved query by name or ID
+  redmine issues list --query "My open issues"
+  redmine issues list --query-id 12`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := f.ApiClient()
 			if err != nil {
@@ -95,6 +101,11 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				versionID = id
 			}
 
+			resolvedQueryID, err := resolveIssueQueryFilter(ctx, client, query, queryID, project)
+			if err != nil {
+				return err
+			}
+
 			var includes []string
 			if include != "" {
 				includes = strings.Split(include, ",")
@@ -113,6 +124,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				StatusID:       resolvedStatus,
 				AssignedToID:   resolvedAssignee,
 				FixedVersionID: versionID,
+				QueryID:        resolvedQueryID,
 				Sort:           sort,
 				Includes:       includes,
 				Limit:          cmdutil.OpsLimit(limit),
@@ -176,6 +188,8 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&status, "status", "open", "Status filter: open, closed, *, status name, or ID")
 	cmd.Flags().StringVar(&assignee, "assignee", "", "Assignee ID or 'me'")
 	cmd.Flags().StringVar(&version, "version", "", "Filter by version name or ID")
+	cmd.Flags().StringVar(&query, "query", "", "Run a saved query by name (mutually exclusive with --query-id)")
+	cmd.Flags().IntVar(&queryID, "query-id", 0, "Run a saved query by numeric ID")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort field (e.g., updated_on:desc)")
 	cmd.Flags().StringVar(&include, "include", "", "Include related data: attachments,relations")
 	cmd.Flags().BoolVar(&attachments, "attachments", false, "Include attachments (shorthand for --include attachments)")

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -101,6 +101,11 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				versionID = id
 			}
 
+			// MarkFlagsMutuallyExclusive (below) catches `--query foo --query-id N`,
+			// but it relies on cobra's `Changed` bookkeeping. We thread the same
+			// signal into the resolver so a lone `--query-id 0` (which leaves
+			// IntVar at its zero value) is rejected explicitly instead of being
+			// silently treated as "no filter".
 			resolvedQueryID, err := resolveIssueQueryFilter(ctx, client, query, queryID, cmd.Flags().Changed("query-id"), project)
 			if err != nil {
 				return err

--- a/internal/cmd/issue/list_test.go
+++ b/internal/cmd/issue/list_test.go
@@ -276,8 +276,28 @@ func TestCmdIssueList_QueryAndQueryIDMutuallyExclusive(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for mutually exclusive flags")
 	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Fatalf("error = %v, want mutually-exclusive message", err)
+	msg := err.Error()
+	if !strings.Contains(msg, "query") || !strings.Contains(msg, "query-id") {
+		t.Fatalf("error = %v, want both flag names mentioned", err)
+	}
+}
+
+func TestCmdIssueList_RejectsNonPositiveQueryID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("API should not be called when --query-id is rejected")
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdList(f)
+	cmd.SetArgs([]string{"--query-id", "0", "--output", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --query-id 0")
+	}
+	if !strings.Contains(err.Error(), "positive integer") {
+		t.Fatalf("error = %v, want positive-integer message", err)
 	}
 }
 

--- a/internal/cmd/issue/list_test.go
+++ b/internal/cmd/issue/list_test.go
@@ -206,6 +206,81 @@ func TestCmdIssueList_ResolvesAssigneeNameToID(t *testing.T) {
 	}
 }
 
+func TestCmdIssueList_PassesQueryID(t *testing.T) {
+	var issuesQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/issues.json" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		issuesQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"issues":[],"total_count":0}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdList(f)
+	cmd.SetArgs([]string{"--query-id", "42", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(issuesQuery, "query_id=42") {
+		t.Fatalf("issues query = %q, want query_id=42", issuesQuery)
+	}
+}
+
+func TestCmdIssueList_ResolvesQueryNameToID(t *testing.T) {
+	var issuesQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/queries.json":
+			_, _ = w.Write([]byte(`{"queries":[{"id":11,"name":"Sprint backlog","is_public":true}],"total_count":1}`))
+		case "/issues.json":
+			issuesQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"issues":[],"total_count":0}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdList(f)
+	cmd.SetArgs([]string{"--query", "Sprint backlog", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(issuesQuery, "query_id=11") {
+		t.Fatalf("issues query = %q, want query_id=11", issuesQuery)
+	}
+}
+
+func TestCmdIssueList_QueryAndQueryIDMutuallyExclusive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issues":[],"total_count":0}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdList(f)
+	cmd.SetArgs([]string{"--query", "Mine", "--query-id", "1", "--output", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually-exclusive message", err)
+	}
+}
+
 func TestCmdIssueList_IgnoresAssigneeNameWhenUserLookupForbidden(t *testing.T) {
 	var issuesQuery string
 

--- a/internal/cmd/output_contract_test.go
+++ b/internal/cmd/output_contract_test.go
@@ -69,6 +69,8 @@ var commandOutputContracts = map[string]commandContract{
 	"redmine projects list":      {Mode: outputContractStructured},
 	"redmine projects members":   {Mode: outputContractStructured},
 	"redmine projects update":    {Mode: outputContractStructured},
+	"redmine queries get":        {Mode: outputContractStructured},
+	"redmine queries list":       {Mode: outputContractStructured},
 	"redmine roles get":          {Mode: outputContractStructured},
 	"redmine roles list":         {Mode: outputContractStructured},
 	"redmine search":             {Mode: outputContractStructured},

--- a/internal/cmd/query/get.go
+++ b/internal/cmd/query/get.go
@@ -29,40 +29,46 @@ func newCmdQueryGet(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 			ctx := context.Background()
-
-			id, err := resolver.ResolveQuery(ctx, client, args[0], project)
-			if err != nil {
-				return err
-			}
-
 			printer := f.Printer(format)
+
 			stop := printer.Spinner("Fetching saved query...")
-			queries, _, err := client.Queries.List(ctx, 0, 0)
+			match, err := resolver.ResolveQuery(ctx, client, args[0], project)
 			stop()
 			if err != nil {
 				return err
 			}
 
-			for _, q := range queries {
-				if q.ID != id {
-					continue
+			// Numeric input short-circuits the resolver and returns a stub
+			// with only the ID populated. Redmine has no /queries/:id.json
+			// endpoint, so list once and pick the matching record to fill
+			// in name / visibility / scope.
+			if match.Name == "" {
+				queries, _, err := client.Queries.List(ctx, 0, 0)
+				if err != nil {
+					return err
 				}
-				if printer.Format() == output.FormatJSON {
-					printer.JSON(q)
-					return nil
+				for i := range queries {
+					if queries[i].ID == match.ID {
+						match = &queries[i]
+						break
+					}
 				}
-
-				details := []output.KeyValue{
-					{Key: "ID", Value: fmt.Sprintf("%d", q.ID)},
-					{Key: "Name", Value: q.Name},
-					{Key: "Visibility", Value: queryVisibility(q)},
-					{Key: "Scope", Value: queryScope(q)},
+				if match.Name == "" {
+					return fmt.Errorf("saved query %d not found", match.ID)
 				}
-				printer.Detail(details)
-				return nil
 			}
 
-			return fmt.Errorf("saved query %d not found", id)
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(match)
+				return nil
+			}
+			printer.Detail([]output.KeyValue{
+				{Key: "ID", Value: fmt.Sprintf("%d", match.ID)},
+				{Key: "Name", Value: match.Name},
+				{Key: "Visibility", Value: queryVisibility(*match)},
+				{Key: "Scope", Value: queryScope(*match)},
+			})
+			return nil
 		},
 	}
 

--- a/internal/cmd/query/get.go
+++ b/internal/cmd/query/get.go
@@ -1,0 +1,72 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+	"github.com/aarondpn/redmine-cli/v2/internal/resolver"
+)
+
+func newCmdQueryGet(f *cmdutil.Factory) *cobra.Command {
+	var (
+		format  string
+		project string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "get <id-or-name>",
+		Aliases: []string{"show", "view"},
+		Short:   "Show saved query details",
+		Long:    "Show saved query details. Accepts a numeric ID or query name. Use --project to disambiguate per-project queries that share a name with a global query.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+
+			id, err := resolver.ResolveQuery(ctx, client, args[0], project)
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer(format)
+			stop := printer.Spinner("Fetching saved query...")
+			queries, _, err := client.Queries.List(ctx, 0, 0)
+			stop()
+			if err != nil {
+				return err
+			}
+
+			for _, q := range queries {
+				if q.ID != id {
+					continue
+				}
+				if printer.Format() == output.FormatJSON {
+					printer.JSON(q)
+					return nil
+				}
+
+				details := []output.KeyValue{
+					{Key: "ID", Value: fmt.Sprintf("%d", q.ID)},
+					{Key: "Name", Value: q.Name},
+					{Key: "Visibility", Value: queryVisibility(q)},
+					{Key: "Scope", Value: queryScope(q)},
+				}
+				printer.Detail(details)
+				return nil
+			}
+
+			return fmt.Errorf("saved query %d not found", id)
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or numeric ID (used to disambiguate query names)")
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}

--- a/internal/cmd/query/get.go
+++ b/internal/cmd/query/get.go
@@ -54,7 +54,11 @@ func newCmdQueryGet(f *cmdutil.Factory) *cobra.Command {
 					}
 				}
 				if match.Name == "" {
-					return fmt.Errorf("saved query %d not found", match.ID)
+					// `/queries.json` only returns queries the API key can
+					// see (public, or private and owned by the current user),
+					// so a missing record could mean genuinely deleted or
+					// owned by someone else.
+					return fmt.Errorf("saved query %d not found or not visible to you", match.ID)
 				}
 			}
 

--- a/internal/cmd/query/list.go
+++ b/internal/cmd/query/list.go
@@ -27,9 +27,8 @@ func newCmdQueryList(f *cmdutil.Factory) *cobra.Command {
 		Example: `  # All saved queries you can see
   redmine queries list
 
-  # Run a saved query through the issues list command
-  redmine queries list -o json
-  redmine issues list --query-id 12`,
+  # JSON output for piping into jq or another tool
+  redmine queries list -o json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := f.ApiClient()
 			if err != nil {

--- a/internal/cmd/query/list.go
+++ b/internal/cmd/query/list.go
@@ -1,0 +1,87 @@
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+)
+
+func newCmdQueryList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		format string
+		limit  int
+		offset int
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List saved queries",
+		Long:    "List saved queries (custom filters) visible to the authenticated user. The list includes both global queries and queries scoped to a project.",
+		Example: `  # All saved queries you can see
+  redmine queries list
+
+  # Run a saved query through the issues list command
+  redmine queries list -o json
+  redmine issues list --query-id 12`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			stop := printer.Spinner("Fetching saved queries...")
+			result, err := ops.ListQueries(context.Background(), client, ops.ListQueriesInput{
+				Limit:  cmdutil.OpsLimit(limit),
+				Offset: offset,
+			})
+			stop()
+			if err != nil {
+				return err
+			}
+			queries := result.Queries
+
+			if cmdutil.HandleEmpty(printer, queries, "queries") {
+				return nil
+			}
+
+			cmdutil.RenderCollection(printer, queries, []string{"ID", "Name", "Visibility", "Scope"}, func(q models.SavedQuery, styled bool) []string {
+				id := fmt.Sprintf("%d", q.ID)
+				if styled {
+					id = output.StyleID.Render(id)
+				}
+				return []string{id, q.Name, queryVisibility(q), queryScope(q)}
+			})
+
+			cmdutil.WarnPagination(printer, cmdutil.PaginationResult{
+				Shown: len(queries), Total: result.TotalCount, Limit: limit, Offset: offset, Noun: "queries",
+			})
+			return nil
+		},
+	}
+
+	cmdutil.AddPaginationFlags(cmd, &limit, &offset)
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}
+
+func queryVisibility(q models.SavedQuery) string {
+	if q.IsPublic {
+		return "public"
+	}
+	return "private"
+}
+
+func queryScope(q models.SavedQuery) string {
+	if q.ProjectID == nil {
+		return "global"
+	}
+	return fmt.Sprintf("project %d", *q.ProjectID)
+}

--- a/internal/cmd/query/query.go
+++ b/internal/cmd/query/query.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+)
+
+// NewCmdQueries creates the queries command group.
+func NewCmdQueries(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "queries",
+		Aliases: []string{"q"},
+		Short:   "Manage saved queries",
+		Long:    "List Redmine saved queries (custom filters). Use the resulting ID with `issues list --query-id` to run a saved query from the CLI.",
+	}
+
+	cmd.AddCommand(newCmdQueryList(f))
+	cmd.AddCommand(newCmdQueryGet(f))
+
+	return cmd
+}

--- a/internal/cmd/query/query_test.go
+++ b/internal/cmd/query/query_test.go
@@ -1,0 +1,96 @@
+package query
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+func TestQueryList_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"My open","is_public":false},{"id":2,"name":"All bugs","is_public":true,"project_id":7}],"total_count":2}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryList(f)
+	cmd.SetArgs([]string{"--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	if !strings.Contains(stdout, `"name": "My open"`) || !strings.Contains(stdout, `"name": "All bugs"`) {
+		t.Fatalf("unexpected JSON output:\n%s", stdout)
+	}
+}
+
+func TestQueryList_Table(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Mine","is_public":false},{"id":2,"name":"Team","is_public":true,"project_id":4}],"total_count":2}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryList(f)
+	cmd.SetArgs([]string{"--output", "table"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Mine", "Team", "private", "public", "global", "project 4"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("table output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestQueryList_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[],"total_count":0}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryList(f)
+	cmd.SetArgs([]string{"--output", "table"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if stderr := testutil.Stderr(f); !strings.Contains(stderr, "No queries found") {
+		t.Fatalf("stderr = %q, want empty-state warning", stderr)
+	}
+}
+
+func TestQueryGet_DetailByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queries.json" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":7,"name":"Sprint","is_public":true,"project_id":3}],"total_count":1}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryGet(f)
+	cmd.SetArgs([]string{"Sprint"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Sprint", "public", "project 3"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("detail output missing %q:\n%s", want, stdout)
+		}
+	}
+}

--- a/internal/cmd/query/query_test.go
+++ b/internal/cmd/query/query_test.go
@@ -70,6 +70,78 @@ func TestQueryList_Empty(t *testing.T) {
 	}
 }
 
+func TestQueryGet_ByNumericID(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queries.json" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":3,"name":"Other"},{"id":7,"name":"Sprint","is_public":true,"project_id":3}],"total_count":2}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryGet(f)
+	cmd.SetArgs([]string{"7"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly one /queries.json call, got %d", calls)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Sprint", "public", "project 3"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("detail output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestQueryGet_ByNumericID_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Other"}],"total_count":1}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryGet(f)
+	cmd.SetArgs([]string{"99"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected not-found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %v, want not-found message", err)
+	}
+}
+
+func TestQueryGet_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":7,"name":"Sprint","is_public":true,"project_id":3}],"total_count":1}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdQueryGet(f)
+	cmd.SetArgs([]string{"Sprint", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{`"id": 7`, `"name": "Sprint"`, `"is_public": true`} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("JSON output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
 func TestQueryGet_DetailByName(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/queries.json" {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	mcpcmd "github.com/aarondpn/redmine-cli/v2/internal/cmd/mcp"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/membership"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/project"
+	"github.com/aarondpn/redmine-cli/v2/internal/cmd/query"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/role"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/search"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/status"
@@ -93,6 +94,7 @@ func NewRootCmdWithFactory(version string) (*cobra.Command, *cmdutil.Factory) {
 	cmd.AddCommand(group.NewCmdGroup(f))
 	cmd.AddCommand(membership.NewCmdMemberships(f))
 	cmd.AddCommand(project.NewCmdProject(f))
+	cmd.AddCommand(query.NewCmdQueries(f))
 	cmd.AddCommand(role.NewCmdRoles(f))
 	cmd.AddCommand(timecmd.NewCmdTime(f))
 	cmd.AddCommand(user.NewCmdUser(f))

--- a/internal/mcpserver/tools_queries_test.go
+++ b/internal/mcpserver/tools_queries_test.go
@@ -1,0 +1,36 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListQueriesTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queries.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":3,"name":"Sprint","is_public":true,"project_id":2}],"total_count":1}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_queries"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"id":3`, `"name":"Sprint"`, `"is_public":true`, `"project_id":2`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -182,6 +182,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Category:    "meta",
 		Call:        ops.ListCategories,
 	})
+	registerToolSpec(s, client, opts, toolSpec[ops.ListQueriesInput, ops.QueriesListResult]{
+		Name:        "list_queries",
+		Description: "List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter.",
+		Category:    "meta",
+		Call:        ops.ListQueries,
+	})
 	registerToolSpec(s, client, opts, toolSpec[struct{}, ops.RolesListResult]{
 		Name:        "list_roles",
 		Description: "List all Redmine roles configured in this instance.",
@@ -402,6 +408,7 @@ func generatedToolDescriptors() []ToolDescriptor {
 		{Name: "get_tracker", Description: "Fetch a single tracker by ID, including default status and enabled standard fields when available.", Group: "meta", Writes: false},
 		{Name: "get_version", Description: "Fetch a single version (milestone) by ID.", Group: "meta", Writes: false},
 		{Name: "list_categories", Description: "List issue categories for a project.", Group: "meta", Writes: false},
+		{Name: "list_queries", Description: "List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter.", Group: "meta", Writes: false},
 		{Name: "list_roles", Description: "List all Redmine roles configured in this instance.", Group: "meta", Writes: false},
 		{Name: "list_statuses", Description: "List all issue statuses configured in this Redmine instance.", Group: "meta", Writes: false},
 		{Name: "list_trackers", Description: "List all trackers (Bug, Feature, ...) configured in this Redmine instance.", Group: "meta", Writes: false},

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -184,7 +184,7 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListQueriesInput, ops.QueriesListResult]{
 		Name:        "list_queries",
-		Description: "List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter.",
+		Description: "List saved queries (custom filters) visible to the authenticated user. Pass the returned id to list_issues as query_id to run the query.",
 		Category:    "meta",
 		Call:        ops.ListQueries,
 	})
@@ -408,7 +408,7 @@ func generatedToolDescriptors() []ToolDescriptor {
 		{Name: "get_tracker", Description: "Fetch a single tracker by ID, including default status and enabled standard fields when available.", Group: "meta", Writes: false},
 		{Name: "get_version", Description: "Fetch a single version (milestone) by ID.", Group: "meta", Writes: false},
 		{Name: "list_categories", Description: "List issue categories for a project.", Group: "meta", Writes: false},
-		{Name: "list_queries", Description: "List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter.", Group: "meta", Writes: false},
+		{Name: "list_queries", Description: "List saved queries (custom filters) visible to the authenticated user. Pass the returned id to list_issues as query_id to run the query.", Group: "meta", Writes: false},
 		{Name: "list_roles", Description: "List all Redmine roles configured in this instance.", Group: "meta", Writes: false},
 		{Name: "list_statuses", Description: "List all issue statuses configured in this Redmine instance.", Group: "meta", Writes: false},
 		{Name: "list_trackers", Description: "List all trackers (Bug, Feature, ...) configured in this Redmine instance.", Group: "meta", Writes: false},

--- a/internal/models/issue.go
+++ b/internal/models/issue.go
@@ -40,6 +40,7 @@ type IssueFilter struct {
 	StatusID       string // "open", "closed", "*", or numeric ID
 	AssignedToID   string // numeric ID or "me"
 	FixedVersionID int
+	QueryID        int    // saved query ID (Redmine query_id parameter)
 	Sort           string // e.g., "updated_on:desc"
 	Includes       []string
 	Limit          int

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -4,6 +4,11 @@ package models
 // the /queries.json endpoint. Project queries carry a project_id; global
 // queries omit it. The is_public flag indicates whether the query is visible
 // to other users.
+//
+// ProjectID is a pointer because Redmine versions inconsistently encode the
+// "global query" case: some omit the project_id key entirely, others emit
+// `"project_id": null`. The pointer keeps both shapes distinguishable from
+// project_id == 0 (which is not a value Redmine ever returns).
 type SavedQuery struct {
 	ID        int    `json:"id"`
 	Name      string `json:"name"`

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -1,0 +1,12 @@
+package models
+
+// SavedQuery represents a Redmine saved query (custom filter) as returned by
+// the /queries.json endpoint. Project queries carry a project_id; global
+// queries omit it. The is_public flag indicates whether the query is visible
+// to other users.
+type SavedQuery struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	IsPublic  bool   `json:"is_public"`
+	ProjectID *int   `json:"project_id,omitempty"`
+}

--- a/internal/ops/issues.go
+++ b/internal/ops/issues.go
@@ -14,6 +14,7 @@ type ListIssuesInput struct {
 	StatusID       string   `json:"status_id,omitempty" jsonschema:"Status filter: 'open', 'closed', '*', or a numeric status ID."`
 	AssignedToID   string   `json:"assigned_to_id,omitempty" jsonschema:"Assignee: numeric user ID or 'me'."`
 	FixedVersionID int      `json:"fixed_version_id,omitempty" jsonschema:"Fixed version (milestone) ID."`
+	QueryID        int      `json:"query_id,omitempty" jsonschema:"Saved query ID. When set, the query's filters are applied server-side (use list_queries to discover)."`
 	Sort           string   `json:"sort,omitempty" jsonschema:"Sort expression, e.g. 'updated_on:desc'."`
 	Includes       []string `json:"includes,omitempty" jsonschema:"Extra fields to include: attachments, relations, children, watchers."`
 	Limit          int      `json:"limit,omitempty" jsonschema:"Max results to return. Defaults to 50 when omitted."`
@@ -101,6 +102,7 @@ func ListIssues(ctx context.Context, client *api.Client, input ListIssuesInput) 
 		StatusID:       input.StatusID,
 		AssignedToID:   input.AssignedToID,
 		FixedVersionID: input.FixedVersionID,
+		QueryID:        input.QueryID,
 		Sort:           input.Sort,
 		Includes:       input.Includes,
 		Limit:          ListLimit(input.Limit),

--- a/internal/ops/queries.go
+++ b/internal/ops/queries.go
@@ -1,0 +1,30 @@
+package ops
+
+import (
+	"context"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+type ListQueriesInput struct {
+	Limit  int `json:"limit,omitempty" jsonschema:"Max results to return. Defaults to 50 when omitted."`
+	Offset int `json:"offset,omitempty" jsonschema:"Number of leading results to skip (pagination)."`
+}
+
+type QueriesListResult struct {
+	Queries    []models.SavedQuery `json:"queries"`
+	Count      int                 `json:"count"`
+	TotalCount int                 `json:"total_count"`
+}
+
+//mcpgen:tool list_queries
+//mcpgen:description List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter.
+//mcpgen:category meta
+func ListQueries(ctx context.Context, client *api.Client, input ListQueriesInput) (QueriesListResult, error) {
+	queries, total, err := client.Queries.List(ctx, ListLimit(input.Limit), input.Offset)
+	if err != nil {
+		return QueriesListResult{}, err
+	}
+	return QueriesListResult{Queries: queries, Count: len(queries), TotalCount: total}, nil
+}

--- a/internal/ops/queries.go
+++ b/internal/ops/queries.go
@@ -19,7 +19,7 @@ type QueriesListResult struct {
 }
 
 //mcpgen:tool list_queries
-//mcpgen:description List saved queries (custom filters) visible to the authenticated user. Use the returned id with list_issues' query_id parameter.
+//mcpgen:description List saved queries (custom filters) visible to the authenticated user. Pass the returned id to list_issues as query_id to run the query.
 //mcpgen:category meta
 func ListQueries(ctx context.Context, client *api.Client, input ListQueriesInput) (QueriesListResult, error) {
 	queries, total, err := client.Queries.List(ctx, ListLimit(input.Limit), input.Offset)

--- a/internal/resolver/query_test.go
+++ b/internal/resolver/query_test.go
@@ -122,10 +122,29 @@ func TestResolveQuery_ExcludesOtherProjectScopedQueries(t *testing.T) {
 	}
 }
 
-func TestResolveQuery_MultipleGlobalMatches(t *testing.T) {
+func TestResolveQuery_AmbiguousAcrossScopes(t *testing.T) {
 	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint"},{"id":2,"name":"Sprint","project_id":3}],"total_count":2}`))
+	}))
+	defer close()
+
+	_, err := ResolveQuery(context.Background(), client, "Sprint", "")
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "multiple queries match") {
+		t.Fatalf("error = %v, want ambiguity message", err)
+	}
+}
+
+func TestResolveQuery_AmbiguousMultipleGlobals(t *testing.T) {
+	// Two purely-global queries with the same name should also surface as
+	// ambiguous. Redmine permits this through the web UI, so the resolver
+	// must not silently pick one.
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint","is_public":true},{"id":2,"name":"Sprint","is_public":true}],"total_count":2}`))
 	}))
 	defer close()
 

--- a/internal/resolver/query_test.go
+++ b/internal/resolver/query_test.go
@@ -1,0 +1,170 @@
+package resolver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+	"github.com/aarondpn/redmine-cli/v2/internal/config"
+	"github.com/aarondpn/redmine-cli/v2/internal/debug"
+)
+
+func newQueryResolverClient(t *testing.T, handler http.Handler) (*api.Client, func()) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	c, err := api.NewClient(&config.Config{Server: ts.URL}, debug.New(nil))
+	if err != nil {
+		t.Fatalf("api.NewClient: %v", err)
+	}
+	return c, ts.Close
+}
+
+func TestResolveQuery_NumericShortCircuits(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected API call to %s", r.URL.Path)
+	}))
+	defer close()
+
+	q, err := ResolveQuery(context.Background(), client, "42", "")
+	if err != nil {
+		t.Fatalf("ResolveQuery: %v", err)
+	}
+	if q.ID != 42 || q.Name != "" {
+		t.Fatalf("got %+v, want stub with ID 42 and empty Name", q)
+	}
+}
+
+func TestResolveQuery_NameMatchesGlobal(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":3,"name":"My open","is_public":false},{"id":4,"name":"All bugs","is_public":true}],"total_count":2}`))
+	}))
+	defer close()
+
+	q, err := ResolveQuery(context.Background(), client, "all bugs", "")
+	if err != nil {
+		t.Fatalf("ResolveQuery: %v", err)
+	}
+	if q.ID != 4 {
+		t.Fatalf("got ID %d, want 4", q.ID)
+	}
+}
+
+func TestResolveQuery_ProjectScopedWinsOverGlobal(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/queries.json":
+			_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint","is_public":true},{"id":2,"name":"Sprint","is_public":true,"project_id":7}],"total_count":2}`))
+		case "/projects/myproj.json":
+			_, _ = w.Write([]byte(`{"project":{"id":7,"name":"My","identifier":"myproj"}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer close()
+
+	q, err := ResolveQuery(context.Background(), client, "Sprint", "myproj")
+	if err != nil {
+		t.Fatalf("ResolveQuery: %v", err)
+	}
+	if q.ID != 2 {
+		t.Fatalf("got ID %d, want 2 (project-scoped)", q.ID)
+	}
+}
+
+func TestResolveQuery_FallsBackToGlobalWhenProjectHasNoMatch(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/queries.json":
+			_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint","is_public":true}],"total_count":1}`))
+		case "/projects/myproj.json":
+			_, _ = w.Write([]byte(`{"project":{"id":7,"name":"My","identifier":"myproj"}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer close()
+
+	q, err := ResolveQuery(context.Background(), client, "Sprint", "myproj")
+	if err != nil {
+		t.Fatalf("ResolveQuery: %v", err)
+	}
+	if q.ID != 1 {
+		t.Fatalf("got ID %d, want 1 (global fallback)", q.ID)
+	}
+}
+
+func TestResolveQuery_ExcludesOtherProjectScopedQueries(t *testing.T) {
+	// A query named "Sprint" exists only on project 99. With --project=myproj
+	// (id 7), neither a global match nor a matching project query exists, so
+	// resolution should fail rather than return the unrelated project's
+	// query.
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/queries.json":
+			_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint","is_public":true,"project_id":99}],"total_count":1}`))
+		case "/projects/myproj.json":
+			_, _ = w.Write([]byte(`{"project":{"id":7,"name":"My","identifier":"myproj"}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer close()
+
+	if _, err := ResolveQuery(context.Background(), client, "Sprint", "myproj"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestResolveQuery_MultipleGlobalMatches(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint"},{"id":2,"name":"Sprint","project_id":3}],"total_count":2}`))
+	}))
+	defer close()
+
+	_, err := ResolveQuery(context.Background(), client, "Sprint", "")
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "multiple queries match") {
+		t.Fatalf("error = %v, want ambiguity message", err)
+	}
+}
+
+func TestResolveQuery_NoMatchReturnsSuggestion(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"queries":[{"id":1,"name":"Sprint"}],"total_count":1}`))
+	}))
+	defer close()
+
+	_, err := ResolveQuery(context.Background(), client, "nope", "")
+	if err == nil {
+		t.Fatal("expected no-match error")
+	}
+	if !strings.Contains(err.Error(), "no match") {
+		t.Fatalf("error = %v, want no-match message", err)
+	}
+}
+
+func TestResolveQuery_ForbiddenSurfacesPermissionError(t *testing.T) {
+	client, close := newQueryResolverClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+	}))
+	defer close()
+
+	_, err := ResolveQuery(context.Background(), client, "Sprint", "")
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if !IsNameResolutionPermissionError(err) {
+		t.Fatalf("error = %v, want NameResolutionPermissionError", err)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -319,13 +319,12 @@ func ResolveQuery(ctx context.Context, client *api.Client, input string, project
 		}
 	}
 
-	// Prefer a project-scoped match when --project narrows the search; only
-	// fall back to global queries when no project-scoped query has the name.
+	// Prefer project-scoped matches when --project narrows the search; fall
+	// back to globals only when no project-scoped query exists with this
+	// name. With no --project, every match (project + global) is reported so
+	// the user gets the full ambiguity list.
 	matches := projectMatches
-	if projectFilterID > 0 && len(matches) == 0 {
-		matches = globalMatches
-	}
-	if projectFilterID == 0 {
+	if projectFilterID == 0 || len(matches) == 0 {
 		matches = append(matches, globalMatches...)
 	}
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -270,6 +270,74 @@ func ResolveRole(ctx context.Context, client *api.Client, input string) (int, er
 	})
 }
 
+// ResolveQuery resolves a saved query by name or numeric ID. When
+// projectIdentifier is set, queries scoped to other projects are excluded
+// from name matching so a per-project query name does not collide with a
+// global query of the same name.
+func ResolveQuery(ctx context.Context, client *api.Client, input string, projectIdentifier string) (int, error) {
+	if id, err := strconv.Atoi(input); err == nil {
+		client.DebugLog().Printf("Resolver: query %q is numeric, using ID %d directly", input, id)
+		return id, nil
+	}
+
+	client.DebugLog().Printf("Resolver: looking up query %q", input)
+
+	queries, _, err := client.Queries.List(ctx, 0, 0)
+	if err != nil {
+		if isForbiddenErr(err) {
+			return 0, &NameResolutionPermissionError{
+				message: "cannot resolve query by name (insufficient permissions). Use a numeric ID instead",
+			}
+		}
+		return 0, fmt.Errorf("failed to fetch saved queries: %w", err)
+	}
+
+	projectFilterID := 0
+	if projectIdentifier != "" {
+		if id, err := strconv.Atoi(projectIdentifier); err == nil {
+			projectFilterID = id
+		} else if proj, err := client.Projects.Get(ctx, projectIdentifier, nil); err == nil {
+			projectFilterID = proj.ID
+		}
+	}
+
+	needle := strings.ToLower(input)
+	var matches []models.SavedQuery
+	for _, q := range queries {
+		if strings.ToLower(q.Name) != needle {
+			continue
+		}
+		if projectFilterID > 0 && q.ProjectID != nil && *q.ProjectID != projectFilterID {
+			continue
+		}
+		matches = append(matches, q)
+	}
+
+	switch len(matches) {
+	case 0:
+		names := make([]string, len(queries))
+		ids := make([]int, len(queries))
+		for i, q := range queries {
+			names[i] = q.Name
+			ids[i] = q.ID
+		}
+		return 0, fmt.Errorf("%s", buildSuggestions(input, names, ids, "query"))
+	case 1:
+		client.DebugLog().Printf("Resolver: matched query %q -> ID %d", input, matches[0].ID)
+		return matches[0].ID, nil
+	default:
+		lines := make([]string, len(matches))
+		for i, q := range matches {
+			scope := "global"
+			if q.ProjectID != nil {
+				scope = fmt.Sprintf("project %d", *q.ProjectID)
+			}
+			lines[i] = fmt.Sprintf("  - %s (ID: %d, %s)", q.Name, q.ID, scope)
+		}
+		return 0, fmt.Errorf("multiple queries match %q, please use the numeric ID:\n%s", input, strings.Join(lines, "\n"))
+	}
+}
+
 // ResolvePriority resolves a priority by name or numeric ID.
 func ResolvePriority(ctx context.Context, client *api.Client, input string) (int, error) {
 	return Resolve(input, "priority", client, func() ([]Option, error) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -270,14 +270,18 @@ func ResolveRole(ctx context.Context, client *api.Client, input string) (int, er
 	})
 }
 
-// ResolveQuery resolves a saved query by name or numeric ID. When
-// projectIdentifier is set, queries scoped to other projects are excluded
-// from name matching so a per-project query name does not collide with a
-// global query of the same name.
-func ResolveQuery(ctx context.Context, client *api.Client, input string, projectIdentifier string) (int, error) {
+// ResolveQuery resolves a saved query by numeric ID or name. When the input
+// is numeric the underlying list is not fetched; the returned SavedQuery only
+// has its ID populated in that case. For name input every visible query is
+// listed and matched case-insensitively.
+//
+// When projectIdentifier is set, a project-scoped query whose ProjectID
+// matches wins over a global query with the same name. Queries scoped to a
+// different project are excluded entirely.
+func ResolveQuery(ctx context.Context, client *api.Client, input string, projectIdentifier string) (*models.SavedQuery, error) {
 	if id, err := strconv.Atoi(input); err == nil {
 		client.DebugLog().Printf("Resolver: query %q is numeric, using ID %d directly", input, id)
-		return id, nil
+		return &models.SavedQuery{ID: id}, nil
 	}
 
 	client.DebugLog().Printf("Resolver: looking up query %q", input)
@@ -285,11 +289,11 @@ func ResolveQuery(ctx context.Context, client *api.Client, input string, project
 	queries, _, err := client.Queries.List(ctx, 0, 0)
 	if err != nil {
 		if isForbiddenErr(err) {
-			return 0, &NameResolutionPermissionError{
+			return nil, &NameResolutionPermissionError{
 				message: "cannot resolve query by name (insufficient permissions). Use a numeric ID instead",
 			}
 		}
-		return 0, fmt.Errorf("failed to fetch saved queries: %w", err)
+		return nil, fmt.Errorf("failed to fetch saved queries: %w", err)
 	}
 
 	projectFilterID := 0
@@ -302,15 +306,27 @@ func ResolveQuery(ctx context.Context, client *api.Client, input string, project
 	}
 
 	needle := strings.ToLower(input)
-	var matches []models.SavedQuery
+	var projectMatches, globalMatches []models.SavedQuery
 	for _, q := range queries {
 		if strings.ToLower(q.Name) != needle {
 			continue
 		}
-		if projectFilterID > 0 && q.ProjectID != nil && *q.ProjectID != projectFilterID {
-			continue
+		switch {
+		case q.ProjectID == nil:
+			globalMatches = append(globalMatches, q)
+		case projectFilterID == 0 || *q.ProjectID == projectFilterID:
+			projectMatches = append(projectMatches, q)
 		}
-		matches = append(matches, q)
+	}
+
+	// Prefer a project-scoped match when --project narrows the search; only
+	// fall back to global queries when no project-scoped query has the name.
+	matches := projectMatches
+	if projectFilterID > 0 && len(matches) == 0 {
+		matches = globalMatches
+	}
+	if projectFilterID == 0 {
+		matches = append(matches, globalMatches...)
 	}
 
 	switch len(matches) {
@@ -321,10 +337,11 @@ func ResolveQuery(ctx context.Context, client *api.Client, input string, project
 			names[i] = q.Name
 			ids[i] = q.ID
 		}
-		return 0, fmt.Errorf("%s", buildSuggestions(input, names, ids, "query"))
+		return nil, fmt.Errorf("%s", buildSuggestions(input, names, ids, "query"))
 	case 1:
 		client.DebugLog().Printf("Resolver: matched query %q -> ID %d", input, matches[0].ID)
-		return matches[0].ID, nil
+		match := matches[0]
+		return &match, nil
 	default:
 		lines := make([]string, len(matches))
 		for i, q := range matches {
@@ -334,7 +351,7 @@ func ResolveQuery(ctx context.Context, client *api.Client, input string, project
 			}
 			lines[i] = fmt.Sprintf("  - %s (ID: %d, %s)", q.Name, q.ID, scope)
 		}
-		return 0, fmt.Errorf("multiple queries match %q, please use the numeric ID:\n%s", input, strings.Join(lines, "\n"))
+		return nil, fmt.Errorf("multiple queries match %q, please use the numeric ID:\n%s", input, strings.Join(lines, "\n"))
 	}
 }
 

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -14,6 +14,7 @@ Only these top-level commands exist. Do NOT invent subcommands that aren't liste
 | Command | Purpose |
 |---------|---------|
 | `issues` | Create, list, get, update, close, reopen, assign, comment, delete, search, browse issues |
+| `queries` | List Redmine saved queries; reuse them via `issues list --query` / `--query-id` |
 | `projects` | List, get, create, update, delete projects; list project members |
 | `time` | Log, list, get, update, delete, summarize time entries |
 | `versions` | Create, list, get, update, delete project versions (milestones) |


### PR DESCRIPTION
## Summary

- Adds a new `queries` command group (`list`, `get`) so users can discover saved queries from the CLI.
- Adds `--query` and `--query-id` flags on `issues list`, threading Redmine's `query_id` parameter all the way through the ops layer and the API client.
- Exposes `list_queries` as an MCP tool through `mcpgen`, and wires `query_id` into `ListIssuesInput` so MCP callers can run a saved query without negotiating filters by hand.
- Saved queries can carry the same name across global and project scopes; the new `ResolveQuery` resolver narrows by project when `--project` is provided to avoid ambiguous matches.

Closes #76.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass.
- [x] `gofmt -l .` and `golangci-lint run` (0 issues).
- [x] Unit tests: `go test ./...` (queries cmd, issues list flag wiring, MCP round-trip, output-contract registry, resolver).
- [x] e2e build verified with `go build -tags=e2e ./e2e/...`. `e2e/queries_test.go` exercises `queries list` and `issues list --query-id` against a real Redmine instance.
- [ ] Optional manual smoke test: create a saved query in the Redmine web UI, then run `redmine queries list` and `redmine issues list --query "<name>"`.