### PR TITLE
feat(wiki): add optimistic concurrency to wiki update

### DIFF
--- a/docs/src/content/docs/commands/wiki.mdx
+++ b/docs/src/content/docs/commands/wiki.mdx
@@ -116,11 +116,13 @@ Aliases: `edit`. Edits an existing page. Only the fields you pass change. When `
 
 | Flag | Description |
 |------|-------------|
-| `--project`  | Project identifier or numeric ID |
-| `-t, --text` | New page content. If omitted, the current text is preserved. |
-| `--title`    | New display title |
-| `--comments` | Change comment recorded in the page history |
-| `--attach`   | Path to a file to attach (repeatable) |
+| `--project`        | Project identifier or numeric ID |
+| `-t, --text`       | New page content. If omitted, the current text is preserved. |
+| `--title`          | New display title |
+| `--comments`       | Change comment recorded in the page history |
+| `--attach`         | Path to a file to attach (repeatable) |
+| `--expect-version` | Expected current page version. The server returns `409 Conflict` (and the CLI surfaces error code `conflict`) if the page has moved on since you last fetched it. |
+| `--ensure-current` | Refetch the page first and assert its current version on update. Mutually exclusive with `--expect-version`. |
 
 ```bash
 redmine wiki update MyPage --project myproject --text "Updated content"
@@ -130,7 +132,19 @@ redmine wiki update MyPage --project myproject --comments "Fixed typo"
 redmine wiki update MyPage --project myproject --title "New Title"
 
 redmine wiki update MyPage --project myproject --attach ./screenshot.png
+
+# Optimistic concurrency: fail if the page has been edited since version 7
+redmine wiki update MyPage --project myproject \
+  --text "Updated content" --expect-version 7
+
+# Convenience: refetch the page first and reuse its current version
+redmine wiki update MyPage --project myproject \
+  --text "Updated content" --ensure-current
 ```
+
+<Aside>
+  Without `--expect-version` or `--ensure-current`, `wiki update` happily overwrites concurrent edits. Use one of these flags whenever multiple authors might be editing the same page so a stale change fails fast with `code: "conflict"` instead of silently winning the race.
+</Aside>
 
 ## delete
 

--- a/docs/src/content/docs/zh-cn/commands/wiki.mdx
+++ b/docs/src/content/docs/zh-cn/commands/wiki.mdx
@@ -116,11 +116,13 @@ redmine wiki update <page> [flags]
 
 | 标志 | 描述 |
 |------|------|
-| `--project`  | 项目标识符或数字 ID |
-| `-t, --text` | 新的页面内容，省略时保留当前文本 |
-| `--title`    | 新的显示标题 |
-| `--comments` | 记录在页面历史中的修改备注 |
-| `--attach`   | 要附加的文件路径（可重复） |
+| `--project`        | 项目标识符或数字 ID |
+| `-t, --text`       | 新的页面内容，省略时保留当前文本 |
+| `--title`          | 新的显示标题 |
+| `--comments`       | 记录在页面历史中的修改备注 |
+| `--attach`         | 要附加的文件路径（可重复） |
+| `--expect-version` | 期望的当前页面版本号。若页面在你上次获取后已被修改，服务器返回 `409 Conflict`，CLI 以错误码 `conflict` 反馈。 |
+| `--ensure-current` | 在更新前先重新获取页面，并以其当前版本号断言。与 `--expect-version` 互斥。 |
 
 ```bash
 redmine wiki update MyPage --project myproject --text "Updated content"
@@ -130,7 +132,19 @@ redmine wiki update MyPage --project myproject --comments "Fixed typo"
 redmine wiki update MyPage --project myproject --title "New Title"
 
 redmine wiki update MyPage --project myproject --attach ./screenshot.png
+
+# 乐观并发：若版本 7 之后页面已被修改则失败
+redmine wiki update MyPage --project myproject \
+  --text "Updated content" --expect-version 7
+
+# 便捷模式：先重新获取页面并复用其当前版本
+redmine wiki update MyPage --project myproject \
+  --text "Updated content" --ensure-current
 ```
+
+<Aside>
+  若不带 `--expect-version` 或 `--ensure-current`，`wiki update` 会直接覆盖并发编辑。当多人可能同时编辑同一页面时，请使用其中之一，以便过期修改以 `code: "conflict"` 快速失败，而不是在竞争中无声地胜出。
+</Aside>
 
 ## delete
 

--- a/e2e/wiki_test.go
+++ b/e2e/wiki_test.go
@@ -114,6 +114,37 @@ func TestWiki_Lifecycle(t *testing.T) {
 		t.Fatalf("get --version 1: text = %q, want %q", v1.Text, initialText)
 	}
 
+	// Optimistic concurrency: --expect-version 2 should succeed because the
+	// stored version is 2 (after the previous update bumped it from 1).
+	var versionedUpdate actionEnvelope
+	r.runJSON(t, &versionedUpdate, "wiki", "update", page,
+		"--project", proj.Identifier,
+		"--text", "h1. Hello\n\nVersion-checked rewrite.",
+		"--comments", "expect-version=2",
+		"--expect-version", "2")
+	if !versionedUpdate.Ok || versionedUpdate.Action != "updated" {
+		t.Fatalf("unexpected versioned update envelope: %+v", versionedUpdate)
+	}
+
+	// Stored version is now 3. Asserting --expect-version 2 must fail with a
+	// conflict envelope, proving optimistic locking is wired end-to-end.
+	staleStdout, _ := r.runExpectError(t, "wiki", "update", page,
+		"--project", proj.Identifier,
+		"--text", "should not land",
+		"--expect-version", "2")
+	assertErrorCode(t, staleStdout, "conflict")
+
+	// --ensure-current refetches before sending, so even though we don't know
+	// the current version it should resolve to 3 and succeed.
+	var ensuredUpdate actionEnvelope
+	r.runJSON(t, &ensuredUpdate, "wiki", "update", page,
+		"--project", proj.Identifier,
+		"--comments", "ensure-current",
+		"--ensure-current")
+	if !ensuredUpdate.Ok || ensuredUpdate.Action != "updated" {
+		t.Fatalf("unexpected ensure-current update envelope: %+v", ensuredUpdate)
+	}
+
 	var deleted actionEnvelope
 	r.runJSON(t, &deleted, "wiki", "delete", page,
 		"--project", proj.Identifier,

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -42,6 +42,13 @@ func (e *APIError) IsValidationError() bool {
 	return e.StatusCode == http.StatusUnprocessableEntity
 }
 
+// IsConflict returns true if the error is a 409. Redmine surfaces 409 on
+// optimistic-locking failures (e.g. updating a wiki page whose version has
+// been bumped on the server since the client last fetched it).
+func (e *APIError) IsConflict() bool {
+	return e.StatusCode == http.StatusConflict
+}
+
 // parseErrorResponse extracts error messages from a Redmine error response.
 func parseErrorResponse(resp *http.Response) *APIError {
 	apiErr := &APIError{

--- a/internal/api/wiki_test.go
+++ b/internal/api/wiki_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -172,6 +173,103 @@ func TestWikiService_Update_TextFallback(t *testing.T) {
 	}
 	if wp["text"] != existingText {
 		t.Errorf("text = %v, want %q", wp["text"], existingText)
+	}
+}
+
+func TestWikiService_Update_WithVersion_SendsVersionInBody(t *testing.T) {
+	var gotBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	text := "rewritten body"
+	version := 7
+	err := c.Wikis.Update(context.Background(), "proj", "MyPage", models.WikiPageUpdate{
+		Text:    &text,
+		Version: &version,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wp, ok := gotBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing wiki_page key")
+	}
+	// JSON numbers decode as float64.
+	got, ok := wp["version"].(float64)
+	if !ok {
+		t.Fatalf("version not present or wrong type in body: %#v", wp["version"])
+	}
+	if int(got) != version {
+		t.Errorf("body version = %v, want %d", got, version)
+	}
+}
+
+func TestWikiService_Update_WithoutVersion_OmitsField(t *testing.T) {
+	var gotBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	text := "rewritten body"
+	err := c.Wikis.Update(context.Background(), "proj", "MyPage", models.WikiPageUpdate{
+		Text: &text,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wp, ok := gotBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing wiki_page key")
+	}
+	if _, present := wp["version"]; present {
+		t.Errorf("version should be omitted when nil, got %#v", wp["version"])
+	}
+}
+
+func TestWikiService_Update_Conflict_ReturnsAPIErrorIsConflict(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"errors":["Page has been updated by someone else"]}`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Wikis = &WikiService{client: c}
+
+	text := "rewritten body"
+	version := 1
+	err := c.Wikis.Update(context.Background(), "proj", "MyPage", models.WikiPageUpdate{
+		Text:    &text,
+		Version: &version,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if !apiErr.IsConflict() {
+		t.Errorf("IsConflict = false, want true (status %d)", apiErr.StatusCode)
+	}
+	if len(apiErr.Errors) != 1 || apiErr.Errors[0] != "Page has been updated by someone else" {
+		t.Errorf("apiErr.Errors = %v, want server-provided message", apiErr.Errors)
 	}
 }
 

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -131,12 +131,15 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			stop()
 			if err != nil {
 				var apiErr *api.APIError
-				if errors.As(err, &apiErr) && apiErr.IsConflict() {
-					expected := "(unspecified)"
-					if input.Version != nil {
-						expected = fmt.Sprintf("%d", *input.Version)
-					}
-					return fmt.Errorf("wiki page %q has been modified since version %s; refetch and retry: %w", args[0], expected, err)
+				if errors.As(err, &apiErr) && apiErr.IsConflict() && input.Version != nil {
+					// Surface wiki-specific context to the user. FormatError
+					// and BuildErrorEnvelope render apiErr.Errors verbatim, so
+					// prepending our note here ensures it reaches both the
+					// human and JSON output paths instead of being shadowed
+					// by a generic "Conflict" message.
+					context := fmt.Sprintf("wiki page %q has been modified since version %d", args[0], *input.Version)
+					apiErr.Errors = append([]string{context}, apiErr.Errors...)
+					return err
 				}
 				return fmt.Errorf("failed to update wiki page %q: %w", args[0], err)
 			}

--- a/internal/cmd/wiki/update.go
+++ b/internal/cmd/wiki/update.go
@@ -2,29 +2,38 @@ package wiki
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
 	"github.com/aarondpn/redmine-cli/v2/internal/ops"
 	"github.com/aarondpn/redmine-cli/v2/internal/output"
 )
 
 func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		project  string
-		text     string
-		title    string
-		comments string
-		attach   []string
+		project       string
+		text          string
+		title         string
+		comments      string
+		attach        []string
+		expectVersion int
+		ensureCurrent bool
 	)
 
 	cmd := &cobra.Command{
 		Use:     "update <page>",
 		Aliases: []string{"edit"},
 		Short:   "Update a wiki page",
-		Long:    "Update an existing Redmine wiki page.",
+		Long: "Update an existing Redmine wiki page.\n\n" +
+			"To avoid silently overwriting concurrent edits, pass --expect-version " +
+			"with the version you last fetched, or --ensure-current to refetch the " +
+			"page and use its current version. Either flag turns 409 Conflict into a " +
+			"clear error instead of a silent overwrite.",
 		Example: `  # Update page content
   redmine wiki update MyPage --project myproject --text "Updated content"
 
@@ -35,10 +44,25 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
   redmine wiki update MyPage --project myproject --title "New Title"
 
   # Attach a file
-  redmine wiki update MyPage --project myproject --attach ./screenshot.png`,
+  redmine wiki update MyPage --project myproject --attach ./screenshot.png
+
+  # Optimistic concurrency: fail if the page has been edited since version 7
+  redmine wiki update MyPage --project myproject \
+    --text "Updated content" --expect-version 7
+
+  # Convenience: refetch the page first and reuse its current version
+  redmine wiki update MyPage --project myproject \
+    --text "Updated content" --ensure-current`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+
+			if cmd.Flags().Changed("expect-version") && ensureCurrent {
+				return fmt.Errorf("--expect-version and --ensure-current are mutually exclusive")
+			}
+			if cmd.Flags().Changed("expect-version") && expectVersion < 1 {
+				return fmt.Errorf("--expect-version must be >= 1")
+			}
 
 			client, err := f.ApiClient()
 			if err != nil {
@@ -56,18 +80,26 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				Page:      args[0],
 			}
 
-			if cmd.Flags().Changed("text") {
-				input.Text = &text
-			} else {
-				// Redmine requires the text field on every PUT.
-				// Fetch the current page and resend its text unchanged.
-				current, err := ops.GetWikiPage(ctx, client, ops.GetWikiPageInput{
+			// Fetch the current page when we either need its text (because
+			// --text was omitted) or its version (because --ensure-current
+			// was passed). One fetch covers both cases.
+			needText := !cmd.Flags().Changed("text")
+			var current *models.WikiPage
+			if needText || ensureCurrent {
+				current, err = ops.GetWikiPage(ctx, client, ops.GetWikiPageInput{
 					ProjectID: projectID,
 					Page:      args[0],
 				})
 				if err != nil {
 					return fmt.Errorf("failed to fetch current wiki page %q: %w", args[0], err)
 				}
+			}
+
+			if cmd.Flags().Changed("text") {
+				input.Text = &text
+			} else {
+				// Redmine requires the text field on every PUT.
+				// Resend the current text unchanged.
 				input.Text = &current.Text
 			}
 			if cmd.Flags().Changed("title") {
@@ -75,6 +107,15 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			}
 			if cmd.Flags().Changed("comments") {
 				input.Comments = &comments
+			}
+
+			switch {
+			case ensureCurrent:
+				v := current.Version
+				input.Version = &v
+			case cmd.Flags().Changed("expect-version"):
+				v := expectVersion
+				input.Version = &v
 			}
 
 			if len(attach) > 0 {
@@ -89,6 +130,14 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			_, err = ops.UpdateWikiPage(ctx, client, input)
 			stop()
 			if err != nil {
+				var apiErr *api.APIError
+				if errors.As(err, &apiErr) && apiErr.IsConflict() {
+					expected := "(unspecified)"
+					if input.Version != nil {
+						expected = fmt.Sprintf("%d", *input.Version)
+					}
+					return fmt.Errorf("wiki page %q has been modified since version %s; refetch and retry: %w", args[0], expected, err)
+				}
 				return fmt.Errorf("failed to update wiki page %q: %w", args[0], err)
 			}
 
@@ -102,6 +151,8 @@ func newCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&title, "title", "", "Display title")
 	cmd.Flags().StringVar(&comments, "comments", "", "Change comment")
 	cmd.Flags().StringArrayVar(&attach, "attach", nil, "Path to file to attach (repeatable)")
+	cmd.Flags().IntVar(&expectVersion, "expect-version", 0, "Expected current page version. Server returns 409 Conflict if the page has moved on.")
+	cmd.Flags().BoolVar(&ensureCurrent, "ensure-current", false, "Refetch the page first and assert its current version on update. Mutually exclusive with --expect-version.")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
 

--- a/internal/cmd/wiki/update_test.go
+++ b/internal/cmd/wiki/update_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
 	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
 )
 
@@ -240,9 +242,82 @@ func TestUpdate_Conflict_ReportsStaleVersion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected conflict error, got nil")
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "modified since version 1") {
-		t.Errorf("error = %q, want it to mention the stale version", msg)
+
+	// The CLI hands the error to cmdutil.FormatError before printing it.
+	// That path is what the user actually sees, so assert against it: the
+	// generic "Conflict" prefix is present, the wiki-specific context line
+	// the command injects survives, and the server-provided detail is
+	// preserved alongside it.
+	formatted := cmdutil.FormatError(err)
+	for _, want := range []string{
+		"Conflict",
+		`wiki page "MyPage" has been modified since version 1`,
+		"Page has been updated by someone else",
+	} {
+		if !strings.Contains(formatted, want) {
+			t.Errorf("FormatError output missing %q\nfull:\n%s", want, formatted)
+		}
+	}
+
+	// And the JSON envelope path must classify the error as code=conflict
+	// so scripts can branch on it.
+	env := cmdutil.BuildErrorEnvelope(err)
+	if env.Error.Code != output.ErrCodeConflict {
+		t.Errorf("envelope code = %q, want %q", env.Error.Code, output.ErrCodeConflict)
+	}
+}
+
+// TestUpdate_ExpectVersionWithTitle_StillSendsVersion guards the ordering
+// inside RunE: the version assignment happens before --title is applied, so
+// renaming a page with optimistic concurrency must still send the asserted
+// version. A regression that re-ordered or short-circuited the switch would
+// silently drop the version.
+func TestUpdate_ExpectVersionWithTitle_StillSendsVersion(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		putBody map[string]interface{}
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":1,"identifier":"proj"}}`))
+		case http.MethodPut:
+			b, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			_ = json.Unmarshal(b, &putBody)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "rewritten",
+		"--title", "Renamed Page",
+		"--expect-version", "5",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wp, ok := putBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body missing wiki_page key: %#v", putBody)
+	}
+	v, ok := wp["version"].(float64)
+	if !ok {
+		t.Fatalf("version not in PUT body: %#v", wp["version"])
+	}
+	if int(v) != 5 {
+		t.Errorf("version = %v, want 5", v)
+	}
+	if got, _ := wp["title"].(string); got != "Renamed Page" {
+		t.Errorf("title = %q, want Renamed Page", got)
 	}
 }
 

--- a/internal/cmd/wiki/update_test.go
+++ b/internal/cmd/wiki/update_test.go
@@ -1,0 +1,273 @@
+package wiki
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+// TestUpdate_ExpectVersion_SendsVersion verifies that --expect-version is
+// propagated as the wiki_page.version field on the PUT body.
+func TestUpdate_ExpectVersion_SendsVersion(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		putBody  map[string]interface{}
+		putCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// The project resolver fetches /projects/<id>.json before any
+			// wiki call. Reply with a minimal project payload so the
+			// resolver returns cleanly.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":1,"identifier":"proj"}}`))
+		case http.MethodPut:
+			b, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			putCount++
+			_ = json.Unmarshal(b, &putBody)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request method %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "rewritten body",
+		"--expect-version", "7",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if putCount != 1 {
+		t.Fatalf("expected exactly one PUT, got %d", putCount)
+	}
+	wp, ok := putBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body missing wiki_page key: %#v", putBody)
+	}
+	got, ok := wp["version"].(float64)
+	if !ok {
+		t.Fatalf("version not present in PUT body: %#v", wp["version"])
+	}
+	if int(got) != 7 {
+		t.Errorf("body version = %v, want 7", got)
+	}
+}
+
+// TestUpdate_EnsureCurrent_FetchesAndSendsCurrentVersion verifies the
+// convenience mode: the command first GETs the current page, then PUTs back
+// using the freshly fetched version.
+func TestUpdate_EnsureCurrent_FetchesAndSendsCurrentVersion(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		wikiGets int
+		putBody  map[string]interface{}
+		putCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(r.URL.Path, "/wiki/") {
+				mu.Lock()
+				wikiGets++
+				mu.Unlock()
+				_, _ = w.Write([]byte(`{"wiki_page":{"title":"MyPage","text":"existing","version":4}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"project":{"id":1,"identifier":"proj"}}`))
+		case http.MethodPut:
+			b, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			putCount++
+			_ = json.Unmarshal(b, &putBody)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "rewritten body",
+		"--ensure-current",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if wikiGets < 1 {
+		t.Errorf("expected at least one wiki GET to fetch current version, got %d", wikiGets)
+	}
+	if putCount != 1 {
+		t.Fatalf("expected exactly one PUT, got %d", putCount)
+	}
+	wp, ok := putBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body missing wiki_page key: %#v", putBody)
+	}
+	got, ok := wp["version"].(float64)
+	if !ok {
+		t.Fatalf("version not present in PUT body: %#v", wp["version"])
+	}
+	if int(got) != 4 {
+		t.Errorf("body version = %v, want 4 (the value returned by GET)", got)
+	}
+}
+
+// TestUpdate_NoVersionFlag_OmitsVersion guards the existing default behavior:
+// when neither --expect-version nor --ensure-current is set, the PUT body
+// must not carry a version field, so server-side optimistic locking is
+// opt-in and existing scripts keep working.
+func TestUpdate_NoVersionFlag_OmitsVersion(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		putBody map[string]interface{}
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(r.URL.Path, "/wiki/") {
+				_, _ = w.Write([]byte(`{"wiki_page":{"title":"MyPage","text":"existing","version":2}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"project":{"id":1,"identifier":"proj"}}`))
+		case http.MethodPut:
+			b, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			_ = json.Unmarshal(b, &putBody)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "rewritten body",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wp, ok := putBody["wiki_page"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body missing wiki_page key: %#v", putBody)
+	}
+	if _, present := wp["version"]; present {
+		t.Errorf("version should be absent without --expect-version/--ensure-current, got %v", wp["version"])
+	}
+}
+
+// TestUpdate_MutuallyExclusiveFlags rejects passing both flags at once.
+func TestUpdate_MutuallyExclusiveFlags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "x",
+		"--expect-version", "3",
+		"--ensure-current",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q, want it to mention mutual exclusivity", err.Error())
+	}
+}
+
+// TestUpdate_Conflict_ReportsStaleVersion verifies that a 409 from the server
+// surfaces as an actionable error mentioning that the page has been
+// modified.
+func TestUpdate_Conflict_ReportsStaleVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":1,"identifier":"proj"}}`))
+		case http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"errors":["Page has been updated by someone else"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "rewritten body",
+		"--expect-version", "1",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "modified since version 1") {
+		t.Errorf("error = %q, want it to mention the stale version", msg)
+	}
+}
+
+// TestUpdate_ExpectVersionMustBePositive guards against passing zero or
+// negative values to --expect-version, which would silently match Redmine's
+// notion of "no version asserted" because of JSON omitempty rules.
+func TestUpdate_ExpectVersionMustBePositive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server should not be hit, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdUpdate(f)
+	cmd.SetArgs([]string{
+		"MyPage",
+		"--project", "proj",
+		"--text", "x",
+		"--expect-version", "0",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), ">= 1") {
+		t.Errorf("error = %q, want a >= 1 message", err.Error())
+	}
+}

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -37,6 +37,15 @@ func FormatError(err error) string {
 			}
 		}
 		return msg
+	case apiErr.IsConflict():
+		msg := "Conflict: the resource was modified since it was last fetched. Refetch and retry."
+		if len(apiErr.Errors) > 0 {
+			msg += "\nServer reported:"
+			for _, e := range apiErr.Errors {
+				msg += fmt.Sprintf("\n  - %s", e)
+			}
+		}
+		return msg
 	case apiErr.StatusCode >= 500:
 		return fmt.Sprintf("Redmine server error (%d). Please try again later.", apiErr.StatusCode)
 	default:
@@ -66,6 +75,11 @@ func BuildErrorEnvelope(err error) output.ErrorEnvelope {
 			env.Error.Code = output.ErrCodeNotFound
 		case apiErr.IsValidationError():
 			env.Error.Code = output.ErrCodeValidationFailed
+			if len(apiErr.Errors) > 0 {
+				env.Error.Details = append([]string(nil), apiErr.Errors...)
+			}
+		case apiErr.IsConflict():
+			env.Error.Code = output.ErrCodeConflict
 			if len(apiErr.Errors) > 0 {
 				env.Error.Details = append([]string(nil), apiErr.Errors...)
 			}

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -40,7 +40,6 @@ func FormatError(err error) string {
 	case apiErr.IsConflict():
 		msg := "Conflict: the resource was modified since it was last fetched. Refetch and retry."
 		if len(apiErr.Errors) > 0 {
-			msg += "\nServer reported:"
 			for _, e := range apiErr.Errors {
 				msg += fmt.Sprintf("\n  - %s", e)
 			}

--- a/internal/cmdutil/errors_test.go
+++ b/internal/cmdutil/errors_test.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aarondpn/redmine-cli/v2/internal/api"
@@ -37,6 +38,28 @@ func TestBuildErrorEnvelope_ValidationIncludesDetails(t *testing.T) {
 	}
 	if len(env.Error.Details) != 2 {
 		t.Fatalf("details: got %d, want 2", len(env.Error.Details))
+	}
+}
+
+func TestBuildErrorEnvelope_ConflictIncludesDetails(t *testing.T) {
+	apiErr := &api.APIError{StatusCode: 409, Errors: []string{"Page has been updated by someone else"}}
+	env := BuildErrorEnvelope(apiErr)
+	if env.Error.Code != output.ErrCodeConflict {
+		t.Errorf("code = %q, want %q", env.Error.Code, output.ErrCodeConflict)
+	}
+	if len(env.Error.Details) != 1 || env.Error.Details[0] != "Page has been updated by someone else" {
+		t.Errorf("details = %v, want server-provided message", env.Error.Details)
+	}
+}
+
+func TestFormatError_Conflict(t *testing.T) {
+	apiErr := &api.APIError{StatusCode: 409, Errors: []string{"Page has been updated by someone else"}}
+	msg := FormatError(apiErr)
+	if !strings.Contains(msg, "Conflict") {
+		t.Errorf("message missing Conflict prefix: %q", msg)
+	}
+	if !strings.Contains(msg, "Page has been updated by someone else") {
+		t.Errorf("message missing server detail: %q", msg)
 	}
 }
 

--- a/internal/mcpserver/errors.go
+++ b/internal/mcpserver/errors.go
@@ -73,6 +73,11 @@ func describeAPIError(err error) string {
 				return "Validation error: " + strings.Join(ae.Errors, "; ")
 			}
 			return "Validation error (HTTP 422)"
+		case ae.IsConflict():
+			if len(ae.Errors) > 0 {
+				return "Conflict: " + strings.Join(ae.Errors, "; ")
+			}
+			return "Conflict (HTTP 409): the resource was modified since it was last fetched."
 		default:
 			if len(ae.Errors) > 0 {
 				return fmt.Sprintf("Redmine API error %d: %s", ae.StatusCode, strings.Join(ae.Errors, "; "))

--- a/internal/models/wiki.go
+++ b/internal/models/wiki.go
@@ -45,9 +45,15 @@ type WikiPageCreate struct {
 }
 
 // WikiPageUpdate defines fields for updating a wiki page.
+//
+// Version, when non-nil, asserts the page version the client believes is
+// current. Redmine compares it against the stored version and answers with
+// 409 Conflict if the page has moved on, giving callers optimistic-locking
+// semantics for the update.
 type WikiPageUpdate struct {
 	Text     *string  `json:"text,omitempty"`
 	Comments *string  `json:"comments,omitempty"`
 	Title    *string  `json:"title,omitempty"`
+	Version  *int     `json:"version,omitempty"`
 	Uploads  []Upload `json:"uploads,omitempty"`
 }

--- a/internal/ops/wiki.go
+++ b/internal/ops/wiki.go
@@ -41,6 +41,7 @@ type UpdateWikiPageInput struct {
 	Text      *string         `json:"text,omitempty" jsonschema:"New page body."`
 	Title     *string         `json:"title,omitempty" jsonschema:"New display title."`
 	Comments  *string         `json:"comments,omitempty" jsonschema:"Edit comment."`
+	Version   *int            `json:"version,omitempty" jsonschema:"Expected current page version. When set, Redmine returns 409 Conflict if the stored version does not match, giving optimistic-locking semantics."`
 	Uploads   []models.Upload `json:"-"`
 }
 
@@ -89,6 +90,7 @@ func UpdateWikiPage(ctx context.Context, client *api.Client, input UpdateWikiPag
 		Text:     input.Text,
 		Title:    input.Title,
 		Comments: input.Comments,
+		Version:  input.Version,
 		Uploads:  input.Uploads,
 	}); err != nil {
 		return MessageResult{}, err

--- a/internal/ops/wiki.go
+++ b/internal/ops/wiki.go
@@ -86,6 +86,9 @@ func CreateWikiPage(ctx context.Context, client *api.Client, input CreateWikiPag
 //mcpgen:category wiki
 //mcpgen:writes
 func UpdateWikiPage(ctx context.Context, client *api.Client, input UpdateWikiPageInput) (MessageResult, error) {
+	if input.Version != nil && *input.Version < 1 {
+		return MessageResult{}, fmt.Errorf("version must be >= 1 when asserting optimistic concurrency")
+	}
 	if err := client.Wikis.Update(ctx, input.ProjectID, input.Page, models.WikiPageUpdate{
 		Text:     input.Text,
 		Title:    input.Title,

--- a/internal/ops/wiki_test.go
+++ b/internal/ops/wiki_test.go
@@ -1,0 +1,36 @@
+package ops
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUpdateWikiPage_RejectsZeroVersion guards the ops-layer boundary: the
+// CLI already validates --expect-version, but MCP clients (or any other
+// programmatic caller) reach this function directly and could send a
+// pointer-to-zero. The JSON omitempty rule on *int would serialize that as
+// `"version":0`, which Redmine rejects — we'd rather catch it locally with
+// a clear message than round-trip a useless request.
+func TestUpdateWikiPage_RejectsZeroVersion(t *testing.T) {
+	zero := 0
+	negative := -3
+
+	for name, version := range map[string]*int{
+		"zero":     &zero,
+		"negative": &negative,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := UpdateWikiPage(t.Context(), nil, UpdateWikiPageInput{
+				ProjectID: "proj",
+				Page:      "MyPage",
+				Version:   version,
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), ">= 1") {
+				t.Errorf("error = %q, want it to mention the >= 1 constraint", err.Error())
+			}
+		})
+	}
+}

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -33,6 +33,7 @@ const (
 	ErrCodeAuthFailed       = "auth_failed"
 	ErrCodeForbidden        = "forbidden"
 	ErrCodeValidationFailed = "validation_failed"
+	ErrCodeConflict         = "conflict"
 	ErrCodeServerError      = "server_error"
 	ErrCodeUnknown          = "unknown"
 )


### PR DESCRIPTION
## Summary
- Closes #85
- Adds `--expect-version <n>` for explicit page-version assertions and `--ensure-current` as a refetch-then-update convenience mode. Both opt in to Redmine's optimistic-locking semantics so a 409 surfaces as `code: "conflict"` instead of silently overwriting concurrent edits.
- Plumbs `Version *int` through `WikiPageUpdate`, the ops layer, and the wiki PUT body. Default behaviour is unchanged when neither flag is set.
- Introduces `APIError.IsConflict()` + `output.ErrCodeConflict`, with consistent rendering through `cmdutil.FormatError`, `BuildErrorEnvelope`, and the MCP error formatter.
- Updates English + zh-cn docs with the new flags, examples, and a callout.

## Test plan
- [x] `go test ./...` — unit suites across api, cmdutil, ops, mcpserver, output, and the new wiki cmd tests
- [x] `gofmt -l` clean and `golangci-lint run` reports 0 issues
- [x] `go test -tags=e2e -run NoSuchTest ./e2e/...` confirms the e2e build compiles
- [x] Full e2e: `make e2e-up && make e2e-test` against Redmine 6.1 (lifecycle test now drives a versioned update success, a stale-version 409, and an `--ensure-current` round-trip)
- [x] Manual smoke: `redmine wiki update SomePage --project p --text "..." --expect-version <stale>` returns `code: "conflict"` with the stale-version context in both `-o json` and the default human output