### PR TITLE
feat(custom-fields): add command group for admin field discovery

### DIFF
--- a/docs/src/content/docs/commands/other.mdx
+++ b/docs/src/content/docs/commands/other.mdx
@@ -100,7 +100,7 @@ redmine custom-fields get 7 --output json
 Lists or inspects custom field definitions. The list view surfaces target resource type, field format, and the required/filter/searchable/multiple flags. `custom-fields get` adds the default value, length and regexp constraints, possible values for list fields, plus the trackers and roles a field is restricted to.
 
 <Aside type="caution">
-  The underlying `GET /custom_fields.json` endpoint is admin-only — the command returns `403 Forbidden` for non-admin API keys.
+  The underlying `GET /custom_fields.json` endpoint is admin-only - the command returns `403 Forbidden` for non-admin API keys.
 </Aside>
 
 ## Shell completion

--- a/docs/src/content/docs/commands/other.mdx
+++ b/docs/src/content/docs/commands/other.mdx
@@ -1,6 +1,6 @@
 ---
 title: Other Commands
-description: API passthrough, categories, trackers, statuses, completion, and self-update.
+description: API passthrough, categories, trackers, statuses, custom fields, completion, and self-update.
 ---
 
 import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starlight/components';
@@ -8,12 +8,13 @@ import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starli
 A grab-bag of utility commands that don't fit the main resource families.
 
 <CardGrid>
-  <LinkCard title="api"        href="#api"        description="Authenticated requests to any Redmine endpoint." />
-  <LinkCard title="categories" href="#categories" description="List issue categories for a project." />
-  <LinkCard title="trackers"   href="#trackers"   description="List all available trackers." />
-  <LinkCard title="statuses"   href="#statuses"   description="List all issue statuses." />
-  <LinkCard title="completion" href="#shell-completion" description="Generate shell completion scripts." />
-  <LinkCard title="update"     href="#self-update" description="Self-update the binary." />
+  <LinkCard title="api"           href="#api"           description="Authenticated requests to any Redmine endpoint." />
+  <LinkCard title="categories"    href="#categories"    description="List issue categories for a project." />
+  <LinkCard title="trackers"      href="#trackers"      description="List all available trackers." />
+  <LinkCard title="statuses"      href="#statuses"      description="List all issue statuses." />
+  <LinkCard title="custom-fields" href="#custom-fields" description="Discover admin custom field definitions." />
+  <LinkCard title="completion"    href="#shell-completion" description="Generate shell completion scripts." />
+  <LinkCard title="update"        href="#self-update"   description="Self-update the binary." />
 </CardGrid>
 
 ## api
@@ -87,6 +88,20 @@ redmine statuses list
 ```
 
 Lists all issue statuses.
+
+## custom-fields
+
+```bash
+redmine custom-fields list
+redmine custom-fields get "Severity"
+redmine custom-fields get 7 --output json
+```
+
+Lists or inspects custom field definitions. The list view surfaces target resource type, field format, and the required/filter/searchable/multiple flags. `custom-fields get` adds the default value, length and regexp constraints, possible values for list fields, plus the trackers and roles a field is restricted to.
+
+<Aside type="caution">
+  The underlying `GET /custom_fields.json` endpoint is admin-only — the command returns `403 Forbidden` for non-admin API keys.
+</Aside>
 
 ## Shell completion
 

--- a/docs/src/content/docs/zh-cn/commands/other.mdx
+++ b/docs/src/content/docs/zh-cn/commands/other.mdx
@@ -100,7 +100,7 @@ redmine custom-fields get 7 --output json
 列出或查看自定义字段定义。列表视图会展示目标资源类型、字段格式以及是否必填、可筛选、可搜索、可多选等标志。`custom-fields get` 还会显示默认值、长度与正则约束、列表字段的可选值，以及该字段限定的跟踪类型与角色。
 
 <Aside type="caution">
-  底层的 `GET /custom_fields.json` 端点仅限管理员访问 — 使用非管理员 API key 时命令会返回 `403 Forbidden`。
+  底层的 `GET /custom_fields.json` 端点仅限管理员访问，使用非管理员 API key 时命令会返回 `403 Forbidden`。
 </Aside>
 
 ## Shell 补全

--- a/docs/src/content/docs/zh-cn/commands/other.mdx
+++ b/docs/src/content/docs/zh-cn/commands/other.mdx
@@ -1,6 +1,6 @@
 ---
 title: 其他命令
-description: API 透传、类别、跟踪类型、状态、shell 补全与自动更新。
+description: API 透传、类别、跟踪类型、状态、自定义字段、shell 补全与自动更新。
 ---
 
 import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starlight/components';
@@ -8,12 +8,13 @@ import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starli
 一组不归属于主要资源类别的实用命令。
 
 <CardGrid>
-  <LinkCard title="api"        href="#api"        description="向任意 Redmine 端点发送已认证的请求。" />
-  <LinkCard title="categories" href="#categories" description="列出项目的工单类别。" />
-  <LinkCard title="trackers"   href="#trackers"   description="列出所有可用的跟踪类型。" />
-  <LinkCard title="statuses"   href="#statuses"   description="列出所有工单状态。" />
-  <LinkCard title="completion" href="#shell-补全" description="生成 shell 补全脚本。" />
-  <LinkCard title="update"     href="#自动更新" description="自动更新二进制文件。" />
+  <LinkCard title="api"           href="#api"           description="向任意 Redmine 端点发送已认证的请求。" />
+  <LinkCard title="categories"    href="#categories"    description="列出项目的工单类别。" />
+  <LinkCard title="trackers"      href="#trackers"      description="列出所有可用的跟踪类型。" />
+  <LinkCard title="statuses"      href="#statuses"      description="列出所有工单状态。" />
+  <LinkCard title="custom-fields" href="#custom-fields" description="查询管理员自定义字段定义。" />
+  <LinkCard title="completion"    href="#shell-补全"    description="生成 shell 补全脚本。" />
+  <LinkCard title="update"        href="#自动更新"      description="自动更新二进制文件。" />
 </CardGrid>
 
 ## api
@@ -87,6 +88,20 @@ redmine statuses list
 ```
 
 列出所有工单状态。
+
+## custom-fields
+
+```bash
+redmine custom-fields list
+redmine custom-fields get "Severity"
+redmine custom-fields get 7 --output json
+```
+
+列出或查看自定义字段定义。列表视图会展示目标资源类型、字段格式以及是否必填、可筛选、可搜索、可多选等标志。`custom-fields get` 还会显示默认值、长度与正则约束、列表字段的可选值，以及该字段限定的跟踪类型与角色。
+
+<Aside type="caution">
+  底层的 `GET /custom_fields.json` 端点仅限管理员访问 — 使用非管理员 API key 时命令会返回 `403 Forbidden`。
+</Aside>
 
 ## Shell 补全
 

--- a/e2e/bootstrap-redmine.sh
+++ b/e2e/bootstrap-redmine.sh
@@ -43,6 +43,21 @@ docker compose -f "$compose_file" exec -T \
       seeded_query.save!
     end
 
+    # Seed an issue custom field so the custom-fields e2e suite has a stable
+    # fixture. Redmine has no REST endpoint for creating custom field
+    # definitions, so the bootstrap is the only place this can live.
+    custom_field_name = "E2E Severity"
+    seeded_custom_field = IssueCustomField.find_or_initialize_by(name: custom_field_name)
+    if seeded_custom_field.new_record?
+      seeded_custom_field.field_format = "list"
+      seeded_custom_field.possible_values = ["Low", "Medium", "High"]
+      seeded_custom_field.is_required = false
+      seeded_custom_field.is_filter = true
+      seeded_custom_field.searchable = false
+      seeded_custom_field.tracker_ids = Tracker.pluck(:id)
+      seeded_custom_field.save!
+    end
+
     puts({
       rest_api_enabled: Setting.rest_api_enabled?,
       admin_api_key_present: admin.api_key.to_s != "",
@@ -50,6 +65,8 @@ docker compose -f "$compose_file" exec -T \
       trackers: Tracker.count,
       statuses: IssueStatus.count,
       seeded_query_id: seeded_query.id,
-      seeded_query_name: seeded_query.name
+      seeded_query_name: seeded_query.name,
+      seeded_custom_field_id: seeded_custom_field.id,
+      seeded_custom_field_name: seeded_custom_field.name
     }.inspect)
   ' 2>/dev/null | tail -n 1

--- a/e2e/custom_fields_test.go
+++ b/e2e/custom_fields_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const seededCustomFieldName = "E2E Severity"
+
+type e2eCustomField struct {
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	CustomizedType string `json:"customized_type"`
+	FieldFormat    string `json:"field_format"`
+	PossibleValues []struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+	} `json:"possible_values"`
+}
+
+func TestCustomFields_ListAndGet(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	var fields []e2eCustomField
+	r.runJSON(t, &fields, "custom-fields", "list")
+
+	var seeded e2eCustomField
+	for _, f := range fields {
+		if f.Name == seededCustomFieldName {
+			seeded = f
+			break
+		}
+	}
+	if seeded.ID == 0 {
+		t.Fatalf("custom-fields list missing seeded fixture %q; got %+v", seededCustomFieldName, fields)
+	}
+	if seeded.CustomizedType != "issue" || seeded.FieldFormat != "list" {
+		t.Fatalf("seeded custom field metadata unexpected: %+v", seeded)
+	}
+	if len(seeded.PossibleValues) == 0 {
+		t.Fatalf("seeded custom field has no possible values: %+v", seeded)
+	}
+
+	var got e2eCustomField
+	r.runJSON(t, &got, "custom-fields", "get", strconv.Itoa(seeded.ID))
+	if got.ID != seeded.ID || got.Name != seeded.Name {
+		t.Fatalf("custom-fields get returned %+v, want id=%d name=%q", got, seeded.ID, seeded.Name)
+	}
+
+	stdout := r.run(t, "custom-fields", "get", seeded.Name, "--output", "table")
+	text := string(stdout)
+	for _, want := range []string{seeded.Name, "Format", "list", "Possible Values"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("custom-fields get table output missing %q\nstdout:\n%s", want, stdout)
+		}
+	}
+}

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "get_custom_field",
+    "description": "Fetch a single custom field definition by ID. Admin-only endpoint."
+  },
+  {
     "name": "get_group",
     "description": "Fetch a single Redmine group by ID."
   },
@@ -42,6 +46,10 @@
   {
     "name": "list_categories",
     "description": "List issue categories for a project."
+  },
+  {
+    "name": "list_custom_fields",
+    "description": "List custom field definitions configured in this Redmine instance. Admin-only endpoint."
   },
   {
     "name": "list_groups",

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -45,6 +45,7 @@ type Client struct {
 	Attachments  *AttachmentService
 	Wikis        *WikiService
 	Queries      *QueryService
+	CustomFields *CustomFieldService
 }
 
 // DebugLog returns the client's debug logger.
@@ -119,6 +120,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Attachments = &AttachmentService{client: c}
 	c.Wikis = &WikiService{client: c}
 	c.Queries = &QueryService{client: c}
+	c.CustomFields = &CustomFieldService{client: c}
 
 	return c, nil
 }

--- a/internal/api/custom_fields.go
+++ b/internal/api/custom_fields.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+// CustomFieldService handles custom field definition API calls. Redmine only
+// exposes the list endpoint (admin only), so Get resolves from the list.
+type CustomFieldService struct {
+	client *Client
+}
+
+// List retrieves all custom field definitions.
+func (s *CustomFieldService) List(ctx context.Context) ([]models.CustomField, error) {
+	var resp struct {
+		CustomFields []models.CustomField `json:"custom_fields"`
+	}
+	if err := s.client.Get(ctx, "/custom_fields.json", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.CustomFields, nil
+}
+
+// Get retrieves a single custom field definition by ID by resolving it from
+// the list endpoint, which is the only custom-field endpoint Redmine exposes.
+func (s *CustomFieldService) Get(ctx context.Context, id int) (*models.CustomField, error) {
+	fields, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range fields {
+		if fields[i].ID == id {
+			return &fields[i], nil
+		}
+	}
+	return nil, &APIError{
+		StatusCode: http.StatusNotFound,
+		Errors:     []string{fmt.Sprintf("custom field %d not found", id)},
+	}
+}

--- a/internal/api/custom_fields_test.go
+++ b/internal/api/custom_fields_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCustomFieldServiceGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/custom_fields.json" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"custom_fields":[
+			{"id":1,"name":"Severity","customized_type":"issue","field_format":"list","is_required":true,"possible_values":[{"value":"Low","label":"Low"},{"value":"High","label":"High"}],"trackers":[{"id":1,"name":"Bug"}]},
+			{"id":2,"name":"Department","customized_type":"user","field_format":"string"}
+		]}`))
+	}))
+	defer ts.Close()
+
+	client := newTestClient(ts)
+	client.CustomFields = &CustomFieldService{client: client}
+
+	field, err := client.CustomFields.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if field.Name != "Severity" {
+		t.Fatalf("name = %q, want Severity", field.Name)
+	}
+	if field.CustomizedType != "issue" || field.FieldFormat != "list" {
+		t.Fatalf("type/format = %q/%q", field.CustomizedType, field.FieldFormat)
+	}
+	if !field.IsRequired {
+		t.Fatal("is_required should be true")
+	}
+	if len(field.PossibleValues) != 2 || field.PossibleValues[0].Value != "Low" {
+		t.Fatalf("possible_values = %+v", field.PossibleValues)
+	}
+	if len(field.Trackers) != 1 || field.Trackers[0].Name != "Bug" {
+		t.Fatalf("trackers = %+v", field.Trackers)
+	}
+}
+
+func TestCustomFieldServiceGetNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"custom_fields":[{"id":1,"name":"Severity"}]}`))
+	}))
+	defer ts.Close()
+
+	client := newTestClient(ts)
+	client.CustomFields = &CustomFieldService{client: client}
+	_, err := client.CustomFields.Get(context.Background(), 99)
+	if err == nil {
+		t.Fatal("Get returned nil error, want not found")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("Get error type = %T, want *APIError", err)
+	}
+	if !apiErr.IsNotFound() {
+		t.Fatalf("Get error status = %d, want 404", apiErr.StatusCode)
+	}
+}
+
+func TestCustomFieldServiceListPropagatesForbidden(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":["You are not authorized to access this page."]}`))
+	}))
+	defer ts.Close()
+
+	client := newTestClient(ts)
+	client.CustomFields = &CustomFieldService{client: client}
+	_, err := client.CustomFields.List(context.Background())
+	if err == nil {
+		t.Fatal("List returned nil error, want forbidden")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("List error type = %T, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("List error status = %d, want 403", apiErr.StatusCode)
+	}
+}

--- a/internal/cmd/custom_field/custom_field.go
+++ b/internal/cmd/custom_field/custom_field.go
@@ -1,0 +1,60 @@
+package customfield
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+// NewCmdCustomFields creates the custom-fields command group.
+func NewCmdCustomFields(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "custom-fields",
+		Aliases: []string{"custom-field"},
+		Short:   "Discover custom field definitions",
+		Long: "List and inspect Redmine custom field definitions exposed by " +
+			"the admin-only /custom_fields.json endpoint.",
+	}
+
+	cmd.AddCommand(newCmdCustomFieldList(f))
+	cmd.AddCommand(newCmdCustomFieldGet(f))
+	return cmd
+}
+
+func boolLabel(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func formatPossibleValues(values []models.CustomFieldPossibleValue) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		label := v.Label
+		if label == "" || label == v.Value {
+			parts = append(parts, v.Value)
+			continue
+		}
+		parts = append(parts, v.Value+" ("+label+")")
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatIDNames(items []models.IDName) string {
+	if len(items) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, item.Name+" (ID: "+strconv.Itoa(item.ID)+")")
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/cmd/custom_field/custom_field_test.go
+++ b/internal/cmd/custom_field/custom_field_test.go
@@ -1,0 +1,59 @@
+package customfield
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+const listFixture = `{"custom_fields":[
+	{"id":1,"name":"Severity","customized_type":"issue","field_format":"list","is_required":true,"is_filter":true,"searchable":false,"multiple":false,"possible_values":[{"value":"Low","label":"Low"},{"value":"High","label":"High"}],"trackers":[{"id":1,"name":"Bug"}]},
+	{"id":2,"name":"Department","customized_type":"user","field_format":"string"}
+]}`
+
+func TestCustomFieldList_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listFixture))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdCustomFieldList(f)
+	cmd.SetArgs([]string{"--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{`"name": "Severity"`, `"customized_type": "issue"`, `"field_format": "list"`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("JSON output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestCustomFieldList_Table(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listFixture))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdCustomFieldList(f)
+	cmd.SetArgs([]string{"--output", "table"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Severity", "Department", "issue", "user", "Format", "Required"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("table output missing %q:\n%s", want, stdout)
+		}
+	}
+}

--- a/internal/cmd/custom_field/get.go
+++ b/internal/cmd/custom_field/get.go
@@ -1,0 +1,110 @@
+package customfield
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+	"github.com/aarondpn/redmine-cli/v2/internal/resolver"
+)
+
+func newCmdCustomFieldGet(f *cmdutil.Factory) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:               "get <id-or-name>",
+		Aliases:           []string{"show", "view"},
+		Short:             "Show custom field definition details",
+		Long:              "Show details for a custom field definition. Accepts a numeric ID or field name.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cmdutil.CompleteCustomFields(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			id, err := resolver.ResolveCustomField(ctx, client, args[0])
+			if err != nil {
+				return err
+			}
+
+			printer := f.Printer(format)
+			stop := printer.Spinner("Fetching custom field...")
+			field, err := ops.GetCustomField(ctx, client, ops.GetCustomFieldInput{ID: id})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			if printer.Format() == output.FormatJSON {
+				printer.JSON(field)
+				return nil
+			}
+			if printer.Format() == output.FormatCSV {
+				printer.CSV(
+					[]string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple", "Default", "Possible Values", "Trackers", "Roles"},
+					[][]string{{
+						fmt.Sprintf("%d", field.ID),
+						field.Name,
+						field.CustomizedType,
+						field.FieldFormat,
+						boolLabel(field.IsRequired),
+						boolLabel(field.IsFilter),
+						boolLabel(field.Searchable),
+						boolLabel(field.Multiple),
+						field.DefaultValue,
+						formatPossibleValues(field.PossibleValues),
+						formatIDNames(field.Trackers),
+						formatIDNames(field.Roles),
+					}},
+				)
+				return nil
+			}
+
+			details := []output.KeyValue{
+				{Key: "ID", Value: fmt.Sprintf("%d", field.ID)},
+				{Key: "Name", Value: field.Name},
+				{Key: "Type", Value: field.CustomizedType},
+				{Key: "Format", Value: field.FieldFormat},
+				{Key: "Required", Value: boolLabel(field.IsRequired)},
+				{Key: "Filter", Value: boolLabel(field.IsFilter)},
+				{Key: "Searchable", Value: boolLabel(field.Searchable)},
+				{Key: "Multiple", Value: boolLabel(field.Multiple)},
+				{Key: "Visible", Value: boolLabel(field.Visible)},
+			}
+			if field.DefaultValue != "" {
+				details = append(details, output.KeyValue{Key: "Default", Value: field.DefaultValue})
+			}
+			if field.Regexp != "" {
+				details = append(details, output.KeyValue{Key: "Regexp", Value: field.Regexp})
+			}
+			if field.MinLength != nil {
+				details = append(details, output.KeyValue{Key: "Min Length", Value: fmt.Sprintf("%d", *field.MinLength)})
+			}
+			if field.MaxLength != nil {
+				details = append(details, output.KeyValue{Key: "Max Length", Value: fmt.Sprintf("%d", *field.MaxLength)})
+			}
+			if value := formatPossibleValues(field.PossibleValues); value != "" {
+				details = append(details, output.KeyValue{Key: "Possible Values", Value: value})
+			}
+			if value := formatIDNames(field.Trackers); value != "" {
+				details = append(details, output.KeyValue{Key: "Trackers", Value: value})
+			}
+			if value := formatIDNames(field.Roles); value != "" {
+				details = append(details, output.KeyValue{Key: "Roles", Value: value})
+			}
+
+			printer.Detail(details)
+			return nil
+		},
+	}
+
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}

--- a/internal/cmd/custom_field/get_test.go
+++ b/internal/cmd/custom_field/get_test.go
@@ -95,6 +95,60 @@ func TestCustomFieldGet_CSV(t *testing.T) {
 	}
 }
 
+// TestCustomFieldGet_TableOptionalRows verifies that the detail renderer
+// surfaces Default/Regexp/MinLength/MaxLength when the API provides them and
+// omits the rows entirely when the values are absent. The two cases share a
+// fixture pair so a regression where one branch swallows the other shows up.
+func TestCustomFieldGet_TableOptionalRows(t *testing.T) {
+	t.Run("rows present when fields set", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"custom_fields":[
+				{"id":1,"name":"Ticket","customized_type":"issue","field_format":"string","default_value":"none","regexp":"^[A-Z]+$","min_length":3,"max_length":20}
+			]}`))
+		}))
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdCustomFieldGet(f)
+		cmd.SetArgs([]string{"1", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		stdout := testutil.Stdout(f)
+		for _, want := range []string{"Default", "none", "Regexp", "^[A-Z]+$", "Min Length", "3", "Max Length", "20"} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("detail output missing %q:\n%s", want, stdout)
+			}
+		}
+	})
+
+	t.Run("rows omitted when fields absent", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"custom_fields":[
+				{"id":1,"name":"Plain","customized_type":"issue","field_format":"string"}
+			]}`))
+		}))
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdCustomFieldGet(f)
+		cmd.SetArgs([]string{"1", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		stdout := testutil.Stdout(f)
+		for _, unwanted := range []string{"Default", "Regexp", "Min Length", "Max Length", "Possible Values", "Trackers", "Roles"} {
+			if strings.Contains(stdout, unwanted) {
+				t.Errorf("detail output unexpectedly contains %q for empty field:\n%s", unwanted, stdout)
+			}
+		}
+	})
+}
+
 func TestCustomFieldGet_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/custom_field/get_test.go
+++ b/internal/cmd/custom_field/get_test.go
@@ -1,0 +1,113 @@
+package customfield
+
+import (
+	"bytes"
+	"encoding/csv"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+const detailFixture = `{"custom_fields":[
+	{"id":1,"name":"Severity","customized_type":"issue","field_format":"list","is_required":true,"is_filter":true,"searchable":true,"multiple":false,"default_value":"Low","visible":true,"possible_values":[{"value":"Low","label":"Low"},{"value":"High","label":"High"}],"trackers":[{"id":1,"name":"Bug"}],"roles":[{"id":3,"name":"Manager"}]},
+	{"id":2,"name":"Department","customized_type":"user","field_format":"string"}
+]}`
+
+func TestCustomFieldGet_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(detailFixture))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdCustomFieldGet(f)
+	cmd.SetArgs([]string{"Severity", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{`"name": "Severity"`, `"possible_values": [`, `"trackers": [`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("JSON output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestCustomFieldGet_TableByID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(detailFixture))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdCustomFieldGet(f)
+	cmd.SetArgs([]string{"1", "--output", "table"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := testutil.Stdout(f)
+	for _, want := range []string{"Severity", "Format", "list", "Possible Values", "Low, High", "Bug (ID: 1)", "Manager (ID: 3)"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("detail output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestCustomFieldGet_CSV(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(detailFixture))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdCustomFieldGet(f)
+	cmd.SetArgs([]string{"1", "--output", "csv"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := csv.NewReader(bytes.NewBufferString(testutil.Stdout(f))).ReadAll()
+	if err != nil {
+		t.Fatalf("decode CSV: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("CSV rows = %d, want 2", len(rows))
+	}
+
+	wantHeaders := []string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple", "Default", "Possible Values", "Trackers", "Roles"}
+	if !slices.Equal(rows[0], wantHeaders) {
+		t.Fatalf("CSV header mismatch:\n got: %v\nwant: %v", rows[0], wantHeaders)
+	}
+
+	wantRow := []string{"1", "Severity", "issue", "list", "yes", "yes", "yes", "no", "Low", "Low, High", "Bug (ID: 1)", "Manager (ID: 3)"}
+	if !slices.Equal(rows[1], wantRow) {
+		t.Fatalf("CSV row mismatch:\n got: %v\nwant: %v", rows[1], wantRow)
+	}
+}
+
+func TestCustomFieldGet_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"custom_fields":[{"id":1,"name":"Severity"}]}`))
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := newCmdCustomFieldGet(f)
+	cmd.SetArgs([]string{"99"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want not-found error")
+	}
+}

--- a/internal/cmd/custom_field/list.go
+++ b/internal/cmd/custom_field/list.go
@@ -1,0 +1,65 @@
+package customfield
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+)
+
+func newCmdCustomFieldList(f *cmdutil.Factory) *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all custom field definitions",
+		Long: "List Redmine custom field definitions. Requires an administrator API " +
+			"key because the underlying /custom_fields.json endpoint is admin-only.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			stop := printer.Spinner("Fetching custom fields...")
+			result, err := ops.ListCustomFields(context.Background(), client, struct{}{})
+			stop()
+			if err != nil {
+				return err
+			}
+
+			cmdutil.RenderCollection(
+				printer,
+				result.CustomFields,
+				[]string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple"},
+				func(cf models.CustomField, styled bool) []string {
+					id := fmt.Sprintf("%d", cf.ID)
+					if styled {
+						id = output.StyleID.Render(id)
+					}
+					return []string{
+						id,
+						cf.Name,
+						cf.CustomizedType,
+						cf.FieldFormat,
+						boolLabel(cf.IsRequired),
+						boolLabel(cf.IsFilter),
+						boolLabel(cf.Searchable),
+						boolLabel(cf.Multiple),
+					}
+				},
+			)
+			return nil
+		},
+	}
+
+	cmdutil.AddOutputFlag(cmd, &format)
+	return cmd
+}

--- a/internal/cmd/output_contract_test.go
+++ b/internal/cmd/output_contract_test.go
@@ -37,6 +37,8 @@ var commandOutputContracts = map[string]commandContract{
 	"redmine categories list":    {Mode: outputContractStructured},
 	"redmine completion":         {Mode: outputContractRawPassthrough, Reason: "streams generated shell completion scripts"},
 	"redmine config":             {Mode: outputContractStructured},
+	"redmine custom-fields get":  {Mode: outputContractStructured},
+	"redmine custom-fields list": {Mode: outputContractStructured},
 	"redmine groups add-user":    {Mode: outputContractStructured},
 	"redmine groups create":      {Mode: outputContractStructured},
 	"redmine groups delete":      {Mode: outputContractStructured},

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/auth"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/category"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/completion"
+	customfield "github.com/aarondpn/redmine-cli/v2/internal/cmd/custom_field"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/group"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/installskill"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/issue"
@@ -99,6 +100,7 @@ func NewRootCmdWithFactory(version string) (*cobra.Command, *cmdutil.Factory) {
 	cmd.AddCommand(timecmd.NewCmdTime(f))
 	cmd.AddCommand(user.NewCmdUser(f))
 	cmd.AddCommand(tracker.NewCmdTrackers(f))
+	cmd.AddCommand(customfield.NewCmdCustomFields(f))
 	cmd.AddCommand(category.NewCmdCategories(f))
 	cmd.AddCommand(status.NewCmdStatuses(f))
 	cmd.AddCommand(versioncmd.NewCmdVersions(f))

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -149,6 +149,30 @@ func CompleteStatuses(f *Factory) func(cmd *cobra.Command, args []string, toComp
 	}
 }
 
+// CompleteCustomFields returns a completion function for the custom-fields
+// command argument. Hits the admin-only /custom_fields.json endpoint, so it
+// silently returns no candidates when the authenticated user lacks access.
+func CompleteCustomFields(f *Factory) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		client, ctx, cancel := completionClient(f)
+		if client == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		defer cancel()
+
+		fields, err := client.CustomFields.List(ctx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		items := make([]string, 0, len(fields))
+		for _, fld := range fields {
+			items = append(items, fmt.Sprintf("%s\t%s/%s", fld.Name, fld.CustomizedType, fld.FieldFormat))
+		}
+		return filterCompletions(items, toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 // CompleteRoles returns a completion function for role-related flags.
 func CompleteRoles(f *Factory) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/mcpserver/tools_custom_fields_test.go
+++ b/internal/mcpserver/tools_custom_fields_test.go
@@ -1,0 +1,69 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestListCustomFieldsTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/custom_fields.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"custom_fields":[{"id":1,"name":"Severity","customized_type":"issue","field_format":"list","is_required":true}]}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_custom_fields"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"name":"Severity"`, `"customized_type":"issue"`, `"field_format":"list"`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}
+
+func TestGetCustomFieldTool_RoundTrip(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/custom_fields.json" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"custom_fields":[
+			{"id":1,"name":"Severity","customized_type":"issue","field_format":"list","possible_values":[{"value":"High","label":"High"}]},
+			{"id":2,"name":"Department","customized_type":"user","field_format":"string"}
+		]}`))
+	}))
+	defer closeTS()
+
+	cs, cleanup := newConnectedSession(t, apiClient, Options{Version: "v0"})
+	defer cleanup()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "get_custom_field",
+		Arguments: map[string]any{"id": 2},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %+v", res.Content)
+	}
+	text := asText(t, res.Content[0])
+	if !containsText(text, `"id":2`, `"name":"Department"`, `"field_format":"string"`) {
+		t.Fatalf("unexpected tool payload: %s", text)
+	}
+}

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -158,6 +158,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Writes:      true,
 		Call:        ops.DeleteVersion,
 	})
+	registerToolSpec(s, client, opts, toolSpec[ops.GetCustomFieldInput, *models.CustomField]{
+		Name:        "get_custom_field",
+		Description: "Fetch a single custom field definition by ID. Admin-only endpoint.",
+		Category:    "meta",
+		Call:        ops.GetCustomField,
+	})
 	registerToolSpec(s, client, opts, toolSpec[ops.GetRoleInput, *models.Role]{
 		Name:        "get_role",
 		Description: "Fetch a single Redmine role by ID, including permissions when available.",
@@ -181,6 +187,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Description: "List issue categories for a project.",
 		Category:    "meta",
 		Call:        ops.ListCategories,
+	})
+	registerToolSpec(s, client, opts, toolSpec[struct{}, ops.CustomFieldsListResult]{
+		Name:        "list_custom_fields",
+		Description: "List custom field definitions configured in this Redmine instance. Admin-only endpoint.",
+		Category:    "meta",
+		Call:        ops.ListCustomFields,
 	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListQueriesInput, ops.QueriesListResult]{
 		Name:        "list_queries",
@@ -404,10 +416,12 @@ func generatedToolDescriptors() []ToolDescriptor {
 		{Name: "update_membership", Description: "Replace the roles on a project membership. Requires --enable-writes.", Group: "memberships", Writes: true},
 		{Name: "create_version", Description: "Create a project version (milestone). Requires --enable-writes.", Group: "meta", Writes: true},
 		{Name: "delete_version", Description: "Delete a version (milestone). Destructive. Requires --enable-writes.", Group: "meta", Writes: true},
+		{Name: "get_custom_field", Description: "Fetch a single custom field definition by ID. Admin-only endpoint.", Group: "meta", Writes: false},
 		{Name: "get_role", Description: "Fetch a single Redmine role by ID, including permissions when available.", Group: "meta", Writes: false},
 		{Name: "get_tracker", Description: "Fetch a single tracker by ID, including default status and enabled standard fields when available.", Group: "meta", Writes: false},
 		{Name: "get_version", Description: "Fetch a single version (milestone) by ID.", Group: "meta", Writes: false},
 		{Name: "list_categories", Description: "List issue categories for a project.", Group: "meta", Writes: false},
+		{Name: "list_custom_fields", Description: "List custom field definitions configured in this Redmine instance. Admin-only endpoint.", Group: "meta", Writes: false},
 		{Name: "list_queries", Description: "List saved queries (custom filters) visible to the authenticated user. Pass the returned id to list_issues as query_id to run the query.", Group: "meta", Writes: false},
 		{Name: "list_roles", Description: "List all Redmine roles configured in this instance.", Group: "meta", Writes: false},
 		{Name: "list_statuses", Description: "List all issue statuses configured in this Redmine instance.", Group: "meta", Writes: false},

--- a/internal/models/custom_field.go
+++ b/internal/models/custom_field.go
@@ -1,0 +1,31 @@
+package models
+
+// CustomFieldPossibleValue represents one entry of a list-format custom
+// field's possible values. Redmine returns the field as an array of
+// `{value,label}` objects, sometimes as bare strings on older versions; the
+// list-of-objects form is what /custom_fields.json emits in 4.x+.
+type CustomFieldPossibleValue struct {
+	Value string `json:"value"`
+	Label string `json:"label,omitempty"`
+}
+
+// CustomField represents a Redmine custom field definition as returned by
+// /custom_fields.json. The endpoint is admin-only.
+type CustomField struct {
+	ID             int                        `json:"id"`
+	Name           string                     `json:"name"`
+	CustomizedType string                     `json:"customized_type"`
+	FieldFormat    string                     `json:"field_format"`
+	Regexp         string                     `json:"regexp,omitempty"`
+	MinLength      *int                       `json:"min_length,omitempty"`
+	MaxLength      *int                       `json:"max_length,omitempty"`
+	IsRequired     bool                       `json:"is_required"`
+	IsFilter       bool                       `json:"is_filter"`
+	Searchable     bool                       `json:"searchable"`
+	Multiple       bool                       `json:"multiple"`
+	DefaultValue   string                     `json:"default_value,omitempty"`
+	Visible        bool                       `json:"visible"`
+	PossibleValues []CustomFieldPossibleValue `json:"possible_values,omitempty"`
+	Trackers       []IDName                   `json:"trackers,omitempty"`
+	Roles          []IDName                   `json:"roles,omitempty"`
+}

--- a/internal/ops/meta.go
+++ b/internal/ops/meta.go
@@ -81,6 +81,15 @@ type GetRoleInput struct {
 	ID int `json:"id" jsonschema:"Numeric role ID."`
 }
 
+type CustomFieldsListResult struct {
+	CustomFields []models.CustomField `json:"custom_fields"`
+	Count        int                  `json:"count"`
+}
+
+type GetCustomFieldInput struct {
+	ID int `json:"id" jsonschema:"Numeric custom field definition ID."`
+}
+
 //mcpgen:tool list_versions
 //mcpgen:description List versions (milestones) for a project.
 //mcpgen:category meta
@@ -204,4 +213,22 @@ func ListCategories(ctx context.Context, client *api.Client, input ListCategorie
 
 func GetVersionForResource(ctx context.Context, client *api.Client, id int) (*models.Version, error) {
 	return client.Versions.Get(ctx, id)
+}
+
+//mcpgen:tool list_custom_fields
+//mcpgen:description List custom field definitions configured in this Redmine instance. Admin-only endpoint.
+//mcpgen:category meta
+func ListCustomFields(ctx context.Context, client *api.Client, _ struct{}) (CustomFieldsListResult, error) {
+	fields, err := client.CustomFields.List(ctx)
+	if err != nil {
+		return CustomFieldsListResult{}, err
+	}
+	return CustomFieldsListResult{CustomFields: fields, Count: len(fields)}, nil
+}
+
+//mcpgen:tool get_custom_field
+//mcpgen:description Fetch a single custom field definition by ID. Admin-only endpoint.
+//mcpgen:category meta
+func GetCustomField(ctx context.Context, client *api.Client, input GetCustomFieldInput) (*models.CustomField, error) {
+	return client.CustomFields.Get(ctx, input.ID)
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -270,6 +270,21 @@ func ResolveRole(ctx context.Context, client *api.Client, input string) (int, er
 	})
 }
 
+// ResolveCustomField resolves a custom field by name or numeric ID.
+func ResolveCustomField(ctx context.Context, client *api.Client, input string) (int, error) {
+	return Resolve(input, "custom field", client, func() ([]Option, error) {
+		fields, err := client.CustomFields.List(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch custom fields: %w", err)
+		}
+		opts := make([]Option, len(fields))
+		for i, f := range fields {
+			opts[i] = Option{ID: f.ID, Name: f.Name}
+		}
+		return opts, nil
+	})
+}
+
 // ResolveQuery resolves a saved query by numeric ID or name. When the input
 // is numeric the underlying list is not fetched; the returned SavedQuery only
 // has its ID populated in that case. For name input every visible query is


### PR DESCRIPTION
## Summary
- Closes #84
- Adds a `custom-fields` command group (`list`, `get` with aliases `show`/`view`) backed by Redmine's admin-only `GET /custom_fields.json` endpoint. List view shows target resource type, format, and `required`/`filter`/`searchable`/`multiple` flags; `get` adds defaults, length/regexp constraints, possible values, and the trackers/roles the field is restricted to.
- Registers matching `list_custom_fields` and `get_custom_field` MCP tools in the `meta` group via the existing `//mcpgen:` directive pipeline.
- Wires shell completion and resolver helpers so `custom-fields get` accepts either a numeric ID or the field name.

## Test plan
- [x] `go test ./...` — full unit suites, including new `api`, `cmd/custom_field`, and `mcpserver` tests
- [x] `gofmt -l` clean and `golangci-lint run` reports 0 issues
- [x] `go test -tags=e2e -run NoSuchTest ./e2e/...` confirms the e2e build compiles
- [x] Full e2e: `make e2e-up && make e2e-test` against Redmine 6.1 (bootstrap now seeds an `E2E Severity` list custom field; the new e2e test verifies list + get by ID and by name)
- [x] Manual smoke: `redmine custom-fields list -o json` and `redmine custom-fields get "Severity" -o table` against an admin profile