### PR TITLE
feat(files): add project files commands for listing and uploading

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
 						{ label: 'Projects', translations: { 'zh-CN': '项目' }, slug: 'commands/projects' },
 						{ label: 'Memberships', translations: { 'zh-CN': '成员关系' }, slug: 'commands/memberships' },
 						{ label: 'Versions', translations: { 'zh-CN': '版本' }, slug: 'commands/versions' },
+						{ label: 'Files', translations: { 'zh-CN': '项目文件' }, slug: 'commands/files' },
 						{ label: 'Time Entries', translations: { 'zh-CN': '工时记录' }, slug: 'commands/time' },
 						{ label: 'Users', translations: { 'zh-CN': '用户' }, slug: 'commands/users' },
 						{ label: 'Groups', translations: { 'zh-CN': '用户组' }, slug: 'commands/groups' },

--- a/docs/src/content/docs/commands/files.mdx
+++ b/docs/src/content/docs/commands/files.mdx
@@ -1,0 +1,82 @@
+---
+title: Files
+description: List and upload project-level files (release artifacts and other project attachments).
+---
+
+import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starlight/components';
+
+The `files` command surfaces Redmine's [project Files API](https://www.redmine.org/projects/redmine/wiki/Rest_Files), which keeps files such as release artifacts attached to a project rather than to an individual issue or wiki page.
+
+Every subcommand needs a project. Pass `--project <identifier>`, or rely on the default project of the active profile (see [`auth`](/redmine-cli/commands/auth/)).
+
+<CardGrid>
+  <LinkCard title="list"   href="#list"   description="List the files attached to a project." />
+  <LinkCard title="upload" href="#upload" description="Upload a file from disk and attach it to a project." />
+</CardGrid>
+
+## list
+
+```bash
+redmine files list [flags]
+```
+
+Aliases: `ls`. Prints each file's ID, name, size in bytes, associated version (if any), uploader, and creation timestamp.
+
+| Flag | Description |
+|------|-------------|
+| `--project`     | Project identifier or numeric ID. Falls back to the default project of the active profile. |
+| `--limit`       | Maximum number of results (`0` for all) |
+| `--offset`      | Result offset for pagination |
+| `-o, --output`  | Output format: `table`, `json`, `csv` |
+
+<Tabs syncKey="files-list">
+  <TabItem label="Default">
+    ```bash
+    redmine files list --project myproject
+    ```
+  </TabItem>
+  <TabItem label="JSON">
+    ```bash
+    redmine files list --project myproject -o json
+    ```
+  </TabItem>
+  <TabItem label="Paginated">
+    ```bash
+    redmine files list --project myproject --limit 10 --offset 20
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside>
+  Redmine returns the project file list in a single response and ignores the server-side `limit`/`offset` parameters, so pagination is applied client-side. `--limit 0` is the default behaviour and is safe to use even on busy projects.
+</Aside>
+
+## upload
+
+```bash
+redmine files upload <path> [flags]
+```
+
+Aliases: `add`, `create`. Uploads a file from disk to Redmine's `/uploads.json` endpoint, then attaches the resulting token to the project. Pass `--version` to pin the file to a milestone so it shows up in version-scoped views.
+
+| Flag | Description |
+|------|-------------|
+| `--project`      | Project identifier or numeric ID |
+| `--filename`     | Override the displayed filename (defaults to the file's base name) |
+| `--version`      | Attach to a version: name or numeric ID |
+| `--description`  | Optional description |
+| `--content-type` | Override the detected MIME type |
+| `-o, --output`   | Output format |
+
+```bash
+redmine files upload ./release.tar.gz --project myproject
+
+redmine files upload ./changelog.md --project myproject \
+  --version 1.2.0 --description "Release notes"
+
+redmine files upload ./build.zip --project myproject --filename "build-1.2.0.zip"
+```
+
+<Aside type="tip">
+  Redmine returns no body on a successful upload. Run `redmine files list --project myproject` afterwards to confirm the new file landed and to capture its assigned ID and content URL.
+</Aside>

--- a/docs/src/content/docs/zh-cn/commands/files.mdx
+++ b/docs/src/content/docs/zh-cn/commands/files.mdx
@@ -1,0 +1,82 @@
+---
+title: 项目文件
+description: 列出并上传项目级文件（如发布产物及其他项目附件）。
+---
+
+import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starlight/components';
+
+`files` 命令对接 Redmine 的[项目文件 API](https://www.redmine.org/projects/redmine/wiki/Rest_Files)，可将发布产物等文件挂在项目而非具体的工单或 Wiki 页面下。
+
+每个子命令都需要指定项目，可通过 `--project <identifier>` 传入，或依赖当前认证配置的默认项目（参见 [`auth`](/redmine-cli/zh-cn/commands/auth/)）。
+
+<CardGrid>
+  <LinkCard title="list"   href="#list"   description="列出项目下挂载的所有文件。" />
+  <LinkCard title="upload" href="#upload" description="从本地上传文件并附加到项目。" />
+</CardGrid>
+
+## list
+
+```bash
+redmine files list [flags]
+```
+
+别名：`ls`。输出每个文件的 ID、名称、字节大小、关联版本（如有）、上传者及创建时间。
+
+| 标志 | 描述 |
+|------|------|
+| `--project`     | 项目标识符或数字 ID。未指定时回退到当前认证配置的默认项目。 |
+| `--limit`       | 最大返回数量（`0` 表示全部） |
+| `--offset`      | 分页偏移量 |
+| `-o, --output`  | 输出格式：`table`、`json`、`csv` |
+
+<Tabs syncKey="files-list">
+  <TabItem label="默认">
+    ```bash
+    redmine files list --project myproject
+    ```
+  </TabItem>
+  <TabItem label="JSON">
+    ```bash
+    redmine files list --project myproject -o json
+    ```
+  </TabItem>
+  <TabItem label="分页">
+    ```bash
+    redmine files list --project myproject --limit 10 --offset 20
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside>
+  Redmine 在一次请求中返回项目的全部文件列表，并忽略服务器端的 `limit`/`offset` 参数，因此分页在客户端进行。即使项目下文件较多，使用 `--limit 0`（默认值）也是安全的。
+</Aside>
+
+## upload
+
+```bash
+redmine files upload <path> [flags]
+```
+
+别名：`add`、`create`。先调用 Redmine 的 `/uploads.json` 上传文件，再用返回的 token 把文件挂在项目下。通过 `--version` 可将文件绑定到某个里程碑，使其出现在按版本筛选的视图中。
+
+| 标志 | 描述 |
+|------|------|
+| `--project`      | 项目标识符或数字 ID |
+| `--filename`     | 自定义显示文件名（默认为路径的基础名） |
+| `--version`      | 关联到指定版本：名称或数字 ID |
+| `--description`  | 可选描述 |
+| `--content-type` | 覆盖自动识别的 MIME 类型 |
+| `-o, --output`   | 输出格式 |
+
+```bash
+redmine files upload ./release.tar.gz --project myproject
+
+redmine files upload ./changelog.md --project myproject \
+  --version 1.2.0 --description "发布说明"
+
+redmine files upload ./build.zip --project myproject --filename "build-1.2.0.zip"
+```
+
+<Aside type="tip">
+  Redmine 上传成功后不会返回响应体。可在上传后执行 `redmine files list --project myproject` 以确认文件入库，并获取其 ID 与下载链接。
+</Aside>

--- a/e2e/files_test.go
+++ b/e2e/files_test.go
@@ -65,6 +65,75 @@ func TestFiles_Lifecycle(t *testing.T) {
 	}
 }
 
+// TestFiles_UploadWithVersionAndFilename exercises the milestone-attachment
+// path and the --filename display-name override. The lifecycle test
+// deliberately keeps the simple path simple; this test guards the optional
+// flags that would otherwise silently regress (resolver dropping --version,
+// or upload.go falling through to filepath.Base when --filename is set).
+func TestFiles_UploadWithVersionAndFilename(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	uniq := strconv.FormatInt(time.Now().UnixNano(), 36)
+	versionName := "files-e2e-" + uniq
+
+	var createdVersion struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	r.runJSON(t, &createdVersion, "versions", "create",
+		"--project", proj.Identifier,
+		"--name", versionName)
+	if createdVersion.Name != versionName {
+		t.Fatalf("version name = %q, want %q", createdVersion.Name, versionName)
+	}
+
+	originalName := "raw-" + uniq + ".bin"
+	displayName := "release-" + uniq + ".zip"
+	path := filepath.Join(t.TempDir(), originalName)
+	payload := []byte("release artifact for e2e " + uniq + "\n")
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var uploaded actionEnvelope
+	r.runJSON(t, &uploaded, "files", "upload", path,
+		"--project", proj.Identifier,
+		"--version", versionName,
+		"--filename", displayName)
+	if !uploaded.Ok || uploaded.Action != "uploaded" {
+		t.Fatalf("unexpected upload envelope: %+v", uploaded)
+	}
+
+	type versionRef struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	type fileEntry struct {
+		ID       int         `json:"id"`
+		Filename string      `json:"filename"`
+		Version  *versionRef `json:"version"`
+	}
+	var listed []fileEntry
+	r.runJSON(t, &listed, "files", "list", "--project", proj.Identifier)
+
+	var found *fileEntry
+	for i, f := range listed {
+		if f.Filename == displayName {
+			found = &listed[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("did not find uploaded file under override name %q (on-disk was %q): %+v",
+			displayName, originalName, listed)
+	}
+	if found.Version == nil || found.Version.ID != createdVersion.ID {
+		t.Errorf("file.Version = %+v, want id=%d", found.Version, createdVersion.ID)
+	}
+}
+
 // TestFiles_ListEmptyProject covers the empty-state path so a regression in
 // the no-results envelope or pagination handling does not slip past CI.
 func TestFiles_ListEmptyProject(t *testing.T) {

--- a/e2e/files_test.go
+++ b/e2e/files_test.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestFiles_Lifecycle exercises the project files command group end-to-end:
+// upload a file to a fresh project, then list it and verify the metadata
+// round-trips. The Redmine /projects/:id/files.json endpoint returns 204 on
+// upload and reveals the resource only via the list endpoint, so the lifecycle
+// must combine the two to be meaningful.
+func TestFiles_Lifecycle(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	tmp := t.TempDir()
+	uniq := strconv.FormatInt(time.Now().UnixNano(), 36)
+	filename := "release-" + uniq + ".txt"
+	path := filepath.Join(tmp, filename)
+	payload := []byte("file uploaded by redmine-cli e2e " + uniq + "\n")
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	var uploaded actionEnvelope
+	r.runJSON(t, &uploaded, "files", "upload", path,
+		"--project", proj.Identifier,
+		"--description", "e2e fixture")
+	if !uploaded.Ok || uploaded.Action != "uploaded" || uploaded.Resource != "project_file" {
+		t.Fatalf("unexpected upload envelope: %+v", uploaded)
+	}
+
+	type fileEntry struct {
+		ID          int    `json:"id"`
+		Filename    string `json:"filename"`
+		Filesize    int64  `json:"filesize"`
+		ContentType string `json:"content_type"`
+		Description string `json:"description"`
+	}
+	var listed []fileEntry
+	r.runJSON(t, &listed, "files", "list", "--project", proj.Identifier)
+
+	var found *fileEntry
+	for i, f := range listed {
+		if f.Filename == filename {
+			found = &listed[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("uploaded file %q not in list: %+v", filename, listed)
+	}
+	if found.Filesize != int64(len(payload)) {
+		t.Errorf("filesize = %d, want %d", found.Filesize, len(payload))
+	}
+	if found.Description != "e2e fixture" {
+		t.Errorf("description = %q, want %q", found.Description, "e2e fixture")
+	}
+}
+
+// TestFiles_ListEmptyProject covers the empty-state path so a regression in
+// the no-results envelope or pagination handling does not slip past CI.
+func TestFiles_ListEmptyProject(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	var listed []struct {
+		ID int `json:"id"`
+	}
+	r.runJSON(t, &listed, "files", "list", "--project", proj.Identifier)
+	if len(listed) != 0 {
+		t.Errorf("expected empty list for fresh project, got %+v", listed)
+	}
+}
+
+// TestFiles_UploadMissingFile checks that a clear error is surfaced when the
+// path does not exist, instead of a partial upload or an opaque API error.
+func TestFiles_UploadMissingFile(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	stdout, _ := r.runExpectError(t, "files", "upload",
+		filepath.Join(t.TempDir(), "does-not-exist.bin"),
+		"--project", proj.Identifier)
+	requireErrorEnvelopeMessage(t, stdout)
+}

--- a/e2e/testdata/mcp_tools_readonly.golden.json
+++ b/e2e/testdata/mcp_tools_readonly.golden.json
@@ -64,6 +64,10 @@
     "description": "List memberships for a project."
   },
   {
+    "name": "list_project_files",
+    "description": "List files attached to a project."
+  },
+  {
     "name": "list_project_members",
     "description": "List members for a Redmine project."
   },

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -46,6 +46,7 @@ type Client struct {
 	Wikis        *WikiService
 	Queries      *QueryService
 	CustomFields *CustomFieldService
+	Files        *FileService
 }
 
 // DebugLog returns the client's debug logger.
@@ -121,6 +122,7 @@ func NewClient(cfg *config.Config, log *debug.Logger) (*Client, error) {
 	c.Wikis = &WikiService{client: c}
 	c.Queries = &QueryService{client: c}
 	c.CustomFields = &CustomFieldService{client: c}
+	c.Files = &FileService{client: c}
 
 	return c, nil
 }

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/aarondpn/redmine-cli/v2/internal/models"
 )
@@ -19,7 +20,12 @@ type FileService struct {
 // FetchAll's fallback path.
 func (s *FileService) List(ctx context.Context, projectID string, limit, offset int) ([]models.ProjectFile, int, error) {
 	path := fmt.Sprintf("/projects/%s/files.json", url.PathEscape(projectID))
-	return FetchAll[models.ProjectFile](ctx, s.client, path, nil, "files", limit)
+	var params url.Values
+	if offset > 0 {
+		params = url.Values{}
+		params.Set("offset", strconv.Itoa(offset))
+	}
+	return FetchAll[models.ProjectFile](ctx, s.client, path, params, "files", limit)
 }
 
 // Create uploads a file to a project using a previously obtained upload

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+// FileService handles project file API calls.
+type FileService struct {
+	client *Client
+}
+
+// List retrieves the file list for a project. The Redmine endpoint does not
+// honour pagination parameters, so all files are returned in a single
+// response. limit/offset are still accepted for client-side trimming via
+// FetchAll's fallback path.
+func (s *FileService) List(ctx context.Context, projectID string, limit, offset int) ([]models.ProjectFile, int, error) {
+	path := fmt.Sprintf("/projects/%s/files.json", url.PathEscape(projectID))
+	return FetchAll[models.ProjectFile](ctx, s.client, path, nil, "files", limit)
+}
+
+// Create uploads a file to a project using a previously obtained upload
+// token. Redmine's POST /projects/:id/files.json returns 204 No Content on
+// success and does not echo the created resource.
+func (s *FileService) Create(ctx context.Context, projectID string, file models.ProjectFileCreate) error {
+	body := map[string]interface{}{"file": file}
+	path := fmt.Sprintf("/projects/%s/files.json", url.PathEscape(projectID))
+	return s.client.Post(ctx, path, body, nil)
+}

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -66,6 +66,39 @@ func TestFileService_List(t *testing.T) {
 	}
 }
 
+// TestFileService_List_OffsetIsTrimmedClientSide guards a regression where
+// offset was accepted but dropped before reaching FetchAll. The Redmine Files
+// endpoint ignores pagination params, so FetchAll's client-side trim must
+// observe the offset we set on the params.
+func TestFileService_List_OffsetIsTrimmedClientSide(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "files": [
+                {"id": 1, "filename": "a", "filesize": 1, "author": {"id": 1, "name": "A"}, "created_on": "2026-04-01T10:00:00Z"},
+                {"id": 2, "filename": "b", "filesize": 2, "author": {"id": 1, "name": "A"}, "created_on": "2026-04-01T10:00:00Z"},
+                {"id": 3, "filename": "c", "filesize": 3, "author": {"id": 1, "name": "A"}, "created_on": "2026-04-01T10:00:00Z"}
+            ],
+            "total_count": 3
+        }`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Files = &FileService{client: c}
+
+	files, _, err := c.Files.List(context.Background(), "proj", 0, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("files len = %d, want 1 (offset 2 of 3)", len(files))
+	}
+	if files[0].ID != 3 {
+		t.Errorf("files[0].ID = %d, want 3", files[0].ID)
+	}
+}
+
 func TestFileService_Create_Body(t *testing.T) {
 	var (
 		gotMethod string

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+func TestFileService_List(t *testing.T) {
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "files": [
+                {
+                    "id": 7,
+                    "filename": "release.tar.gz",
+                    "filesize": 12345,
+                    "content_type": "application/gzip",
+                    "description": "v1 release",
+                    "content_url": "https://example/attachments/download/7/release.tar.gz",
+                    "author": {"id": 1, "name": "Alice"},
+                    "created_on": "2026-04-01T10:00:00Z",
+                    "version": {"id": 4, "name": "1.0"},
+                    "digest": "abc123",
+                    "downloads": 2
+                }
+            ],
+            "total_count": 1
+        }`))
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Files = &FileService{client: c}
+
+	files, total, err := c.Files.List(context.Background(), "proj a", 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(files) != 1 {
+		t.Fatalf("files len = %d, want 1", len(files))
+	}
+	want := "/projects/proj%20a/files.json"
+	if gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	got := files[0]
+	if got.ID != 7 || got.Filename != "release.tar.gz" || got.Filesize != 12345 {
+		t.Errorf("file = %+v, unexpected core fields", got)
+	}
+	if got.Version == nil || got.Version.Name != "1.0" {
+		t.Errorf("version = %+v, want name=1.0", got.Version)
+	}
+	if got.Author.Name != "Alice" {
+		t.Errorf("author = %+v, want Alice", got.Author)
+	}
+}
+
+func TestFileService_Create_Body(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]interface{}
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Files = &FileService{client: c}
+
+	err := c.Files.Create(context.Background(), "proj", models.ProjectFileCreate{
+		Token:       "tok-1",
+		Filename:    "build.zip",
+		VersionID:   42,
+		Description: "release artifact",
+		ContentType: "application/zip",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/projects/proj/files.json" {
+		t.Errorf("path = %q, want /projects/proj/files.json", gotPath)
+	}
+	file, ok := gotBody["file"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing file key")
+	}
+	if file["token"] != "tok-1" {
+		t.Errorf("token = %v, want tok-1", file["token"])
+	}
+	if file["filename"] != "build.zip" {
+		t.Errorf("filename = %v, want build.zip", file["filename"])
+	}
+	if file["version_id"] != float64(42) {
+		t.Errorf("version_id = %v, want 42", file["version_id"])
+	}
+	if file["description"] != "release artifact" {
+		t.Errorf("description = %v, want release artifact", file["description"])
+	}
+	if file["content_type"] != "application/zip" {
+		t.Errorf("content_type = %v, want application/zip", file["content_type"])
+	}
+}
+
+func TestFileService_Create_OmitsZeroValueFields(t *testing.T) {
+	var gotBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	c.Files = &FileService{client: c}
+
+	if err := c.Files.Create(context.Background(), "proj", models.ProjectFileCreate{Token: "tok"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	file, ok := gotBody["file"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing file key")
+	}
+	for _, key := range []string{"filename", "version_id", "description", "content_type"} {
+		if _, present := file[key]; present {
+			t.Errorf("%s should be omitted when empty, got %v", key, file[key])
+		}
+	}
+}

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -17,5 +17,6 @@ func NewTestClient(httpClient *http.Client, baseURL string, log *debug.Logger) *
 	}
 	c.Attachments = &AttachmentService{client: c}
 	c.Issues = &IssueService{client: c}
+	c.Files = &FileService{client: c}
 	return c
 }

--- a/internal/cmd/files/files.go
+++ b/internal/cmd/files/files.go
@@ -12,9 +12,10 @@ import (
 // NewCmdFiles creates the parent files command.
 func NewCmdFiles(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "files",
-		Short: "Manage Redmine project files",
-		Long:  "List and upload Redmine project files (release artifacts and other attachments scoped to a project).",
+		Use:     "files",
+		Aliases: []string{"f"},
+		Short:   "Manage Redmine project files",
+		Long:    "List and upload Redmine project files (release artifacts and other attachments scoped to a project).",
 	}
 
 	cmd.AddCommand(newCmdList(f))

--- a/internal/cmd/files/files.go
+++ b/internal/cmd/files/files.go
@@ -1,0 +1,24 @@
+// Package files implements the `redmine files` command group, which surfaces
+// the Redmine REST Files API so users can list and upload project-level
+// artifacts without dropping down to `redmine api`.
+package files
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+)
+
+// NewCmdFiles creates the parent files command.
+func NewCmdFiles(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "files",
+		Short: "Manage Redmine project files",
+		Long:  "List and upload Redmine project files (release artifacts and other attachments scoped to a project).",
+	}
+
+	cmd.AddCommand(newCmdList(f))
+	cmd.AddCommand(newCmdUpload(f))
+
+	return cmd
+}

--- a/internal/cmd/files/list.go
+++ b/internal/cmd/files/list.go
@@ -1,0 +1,105 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+)
+
+func newCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project string
+		limit   int
+		offset  int
+		format  string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List project files",
+		Long:    "List files attached to a Redmine project.",
+		Example: `  # List files in a project
+  redmine files list --project myproject
+
+  # JSON output
+  redmine files list --project myproject -o json
+
+  # Paginate
+  redmine files list --project myproject --limit 10 --offset 20`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
+			if err != nil {
+				return err
+			}
+
+			stop := printer.Spinner("Fetching project files...")
+			result, err := ops.ListProjectFiles(ctx, client, ops.ListProjectFilesInput{
+				ProjectID: projectID,
+				Limit:     cmdutil.OpsLimit(limit),
+				Offset:    offset,
+			})
+			stop()
+			if err != nil {
+				return fmt.Errorf("failed to list project files: %w", err)
+			}
+			fileList, total := result.Files, result.TotalCount
+
+			if cmdutil.HandleEmpty(printer, fileList, "files") {
+				return nil
+			}
+
+			cmdutil.RenderCollection(
+				printer, fileList,
+				[]string{"ID", "Filename", "Size", "Version", "Author", "Created"},
+				func(file models.ProjectFile, styled bool) []string {
+					id := strconv.Itoa(file.ID)
+					if styled {
+						id = output.StyleID.Render(id)
+					}
+					version := ""
+					if file.Version != nil {
+						version = file.Version.Name
+					}
+					return []string{
+						id,
+						file.Filename,
+						strconv.FormatInt(file.Filesize, 10),
+						version,
+						file.Author.Name,
+						file.CreatedOn,
+					}
+				},
+			)
+
+			cmdutil.WarnPagination(printer, cmdutil.PaginationResult{
+				Shown: len(fileList), Total: total, Limit: limit, Offset: offset, Noun: "files",
+			})
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
+	cmdutil.AddPaginationFlags(cmd, &limit, &offset)
+	cmdutil.AddOutputFlag(cmd, &format)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+
+	return cmd
+}

--- a/internal/cmd/files/list.go
+++ b/internal/cmd/files/list.go
@@ -25,7 +25,9 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List project files",
-		Long:    "List files attached to a Redmine project.",
+		Long: "List files attached to a Redmine project.\n\n" +
+			"The Redmine endpoint returns the full file list in a single response and " +
+			"ignores server-side pagination, so --limit and --offset are applied client-side.",
 		Example: `  # List files in a project
   redmine files list --project myproject
 

--- a/internal/cmd/files/upload.go
+++ b/internal/cmd/files/upload.go
@@ -1,0 +1,143 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/cmdutil"
+	"github.com/aarondpn/redmine-cli/v2/internal/ops"
+	"github.com/aarondpn/redmine-cli/v2/internal/output"
+	"github.com/aarondpn/redmine-cli/v2/internal/resolver"
+)
+
+func newCmdUpload(f *cmdutil.Factory) *cobra.Command {
+	var (
+		project     string
+		filename    string
+		version     string
+		description string
+		contentType string
+		format      string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "upload <path>",
+		Aliases: []string{"add", "create"},
+		Short:   "Upload a file to a project",
+		Long:    "Upload a file from disk and attach it to a Redmine project. Optionally pin it to a version (milestone).",
+		Example: `  # Upload a release artifact
+  redmine files upload ./release.tar.gz --project myproject
+
+  # Attach the upload to a version (milestone) and add a description
+  redmine files upload ./changelog.md --project myproject \
+    --version 1.2.0 --description "Release notes"
+
+  # Override the displayed filename
+  redmine files upload ./build.zip --project myproject --filename "build-1.2.0.zip"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			printer := f.Printer(format)
+
+			projectID, err := cmdutil.RequireProjectIdentifier(ctx, f, project)
+			if err != nil {
+				return err
+			}
+
+			path := args[0]
+			file, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("opening %s: %w", path, err)
+			}
+			defer file.Close()
+
+			info, err := file.Stat()
+			if err != nil {
+				return fmt.Errorf("stat %s: %w", path, err)
+			}
+
+			displayName := filename
+			if displayName == "" {
+				displayName = filepath.Base(path)
+			}
+
+			ct := contentType
+			if ct == "" {
+				ct = detectContentType(file, path)
+				if _, err := file.Seek(0, 0); err != nil {
+					return fmt.Errorf("rewinding %s: %w", path, err)
+				}
+			}
+
+			var versionID int
+			if version != "" {
+				versionID, err = resolver.ResolveVersion(ctx, client, version, projectID)
+				if err != nil {
+					return err
+				}
+			}
+
+			stop := printer.Spinner("Uploading file...")
+			token, err := client.Attachments.Upload(ctx, displayName, file, info.Size())
+			if err != nil {
+				stop()
+				return fmt.Errorf("failed to upload %s: %w", path, err)
+			}
+
+			if _, err := ops.UploadProjectFile(ctx, client, ops.UploadProjectFileInput{
+				ProjectID:   projectID,
+				Token:       token,
+				Filename:    displayName,
+				VersionID:   versionID,
+				Description: description,
+				ContentType: ct,
+			}); err != nil {
+				stop()
+				return fmt.Errorf("failed to attach %s to project: %w", displayName, err)
+			}
+			stop()
+
+			printer.Action(output.ActionUploaded, "project_file", displayName,
+				fmt.Sprintf("Uploaded %s to project %s", displayName, projectID))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Project identifier or ID (required if no default)")
+	cmd.Flags().StringVar(&filename, "filename", "", "Override the displayed filename (defaults to the file's base name)")
+	cmd.Flags().StringVar(&version, "version", "", "Attach to a version: name or numeric ID")
+	cmd.Flags().StringVar(&description, "description", "", "Optional description")
+	cmd.Flags().StringVar(&contentType, "content-type", "", "Override the detected MIME type")
+	cmdutil.AddOutputFlag(cmd, &format)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjects(f))
+	_ = cmd.RegisterFlagCompletionFunc("version", cmdutil.CompleteVersions(f))
+
+	return cmd
+}
+
+// detectContentType resolves a MIME type from the file extension, falling back
+// to sniffing the first 512 bytes. The file position is left unspecified; the
+// caller must seek before reading the file for upload.
+func detectContentType(f *os.File, path string) string {
+	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
+		return ct
+	}
+	var sniff [512]byte
+	n, _ := f.Read(sniff[:])
+	if n == 0 {
+		return ""
+	}
+	return http.DetectContentType(sniff[:n])
+}

--- a/internal/cmd/files/upload.go
+++ b/internal/cmd/files/upload.go
@@ -3,8 +3,6 @@ package files
 import (
 	"context"
 	"fmt"
-	"mime"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -74,7 +72,7 @@ func newCmdUpload(f *cmdutil.Factory) *cobra.Command {
 
 			ct := contentType
 			if ct == "" {
-				ct = detectContentType(file, path)
+				ct = cmdutil.DetectContentType(file, path)
 				if _, err := file.Seek(0, 0); err != nil {
 					return fmt.Errorf("rewinding %s: %w", path, err)
 				}
@@ -125,19 +123,4 @@ func newCmdUpload(f *cmdutil.Factory) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("version", cmdutil.CompleteVersions(f))
 
 	return cmd
-}
-
-// detectContentType resolves a MIME type from the file extension, falling back
-// to sniffing the first 512 bytes. The file position is left unspecified; the
-// caller must seek before reading the file for upload.
-func detectContentType(f *os.File, path string) string {
-	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
-		return ct
-	}
-	var sniff [512]byte
-	n, _ := f.Read(sniff[:])
-	if n == 0 {
-		return ""
-	}
-	return http.DetectContentType(sniff[:n])
 }

--- a/internal/cmd/files/upload.go
+++ b/internal/cmd/files/upload.go
@@ -28,7 +28,7 @@ func newCmdUpload(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "upload <path>",
-		Aliases: []string{"add", "create"},
+		Aliases: []string{"add"},
 		Short:   "Upload a file to a project",
 		Long:    "Upload a file from disk and attach it to a Redmine project. Optionally pin it to a version (milestone).",
 		Example: `  # Upload a release artifact

--- a/internal/cmd/output_contract_test.go
+++ b/internal/cmd/output_contract_test.go
@@ -39,6 +39,8 @@ var commandOutputContracts = map[string]commandContract{
 	"redmine config":             {Mode: outputContractStructured},
 	"redmine custom-fields get":  {Mode: outputContractStructured},
 	"redmine custom-fields list": {Mode: outputContractStructured},
+	"redmine files list":         {Mode: outputContractStructured},
+	"redmine files upload":       {Mode: outputContractStructured},
 	"redmine groups add-user":    {Mode: outputContractStructured},
 	"redmine groups create":      {Mode: outputContractStructured},
 	"redmine groups delete":      {Mode: outputContractStructured},

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/category"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/completion"
 	customfield "github.com/aarondpn/redmine-cli/v2/internal/cmd/custom_field"
+	"github.com/aarondpn/redmine-cli/v2/internal/cmd/files"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/group"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/installskill"
 	"github.com/aarondpn/redmine-cli/v2/internal/cmd/issue"
@@ -104,6 +105,7 @@ func NewRootCmdWithFactory(version string) (*cobra.Command, *cmdutil.Factory) {
 	cmd.AddCommand(category.NewCmdCategories(f))
 	cmd.AddCommand(status.NewCmdStatuses(f))
 	cmd.AddCommand(versioncmd.NewCmdVersions(f))
+	cmd.AddCommand(files.NewCmdFiles(f))
 	cmd.AddCommand(search.NewCmdSearch(f))
 	cmd.AddCommand(wiki.NewCmdWiki(f))
 	cmd.AddCommand(mcpcmd.NewCmdMCP(f))

--- a/internal/cmdutil/uploads.go
+++ b/internal/cmdutil/uploads.go
@@ -41,7 +41,7 @@ func uploadOne(ctx context.Context, client *api.Client, path string) (models.Upl
 		return models.Upload{}, err
 	}
 
-	ct := detectContentType(f, path)
+	ct := DetectContentType(f, path)
 	if _, err := f.Seek(0, 0); err != nil {
 		return models.Upload{}, err
 	}
@@ -59,10 +59,10 @@ func uploadOne(ctx context.Context, client *api.Client, path string) (models.Upl
 	}, nil
 }
 
-// detectContentType resolves a MIME type from the file extension, falling back
+// DetectContentType resolves a MIME type from the file extension, falling back
 // to sniffing the first 512 bytes. The file position is left unspecified; the
 // caller must seek before reading the file for upload.
-func detectContentType(f *os.File, path string) string {
+func DetectContentType(f *os.File, path string) string {
 	if ct := mime.TypeByExtension(filepath.Ext(path)); ct != "" {
 		return ct
 	}

--- a/internal/mcpserver/zz_generated_tools.go
+++ b/internal/mcpserver/zz_generated_tools.go
@@ -251,6 +251,12 @@ func registerGeneratedTools(s *mcp.Server, client *api.Client, opts Options) {
 		Category:    "projects",
 		Call:        ops.GetProject,
 	})
+	registerToolSpec(s, client, opts, toolSpec[ops.ListProjectFilesInput, ops.ProjectFilesListResult]{
+		Name:        "list_project_files",
+		Description: "List files attached to a project.",
+		Category:    "projects",
+		Call:        ops.ListProjectFiles,
+	})
 	registerToolSpec(s, client, opts, toolSpec[ops.ListProjectMembersInput, ops.ProjectMembersListResult]{
 		Name:        "list_project_members",
 		Description: "List members for a Redmine project.",
@@ -431,6 +437,7 @@ func generatedToolDescriptors() []ToolDescriptor {
 		{Name: "create_project", Description: "Create a new Redmine project. Requires --enable-writes.", Group: "projects", Writes: true},
 		{Name: "delete_project", Description: "Delete a Redmine project. Destructive. Requires --enable-writes.", Group: "projects", Writes: true},
 		{Name: "get_project", Description: "Fetch a single Redmine project by identifier or ID.", Group: "projects", Writes: false},
+		{Name: "list_project_files", Description: "List files attached to a project.", Group: "projects", Writes: false},
 		{Name: "list_project_members", Description: "List members for a Redmine project.", Group: "projects", Writes: false},
 		{Name: "list_projects", Description: "List Redmine projects.", Group: "projects", Writes: false},
 		{Name: "update_project", Description: "Update an existing Redmine project. Requires --enable-writes.", Group: "projects", Writes: true},

--- a/internal/models/file.go
+++ b/internal/models/file.go
@@ -1,0 +1,27 @@
+package models
+
+// ProjectFile represents a project-level file as returned by the Redmine
+// /projects/:id/files.json endpoint.
+type ProjectFile struct {
+	ID          int     `json:"id"`
+	Filename    string  `json:"filename"`
+	Filesize    int64   `json:"filesize"`
+	ContentType string  `json:"content_type,omitempty"`
+	Description string  `json:"description,omitempty"`
+	ContentURL  string  `json:"content_url,omitempty"`
+	Author      IDName  `json:"author"`
+	CreatedOn   string  `json:"created_on"`
+	Version     *IDName `json:"version,omitempty"`
+	Digest      string  `json:"digest,omitempty"`
+	Downloads   int     `json:"downloads,omitempty"`
+}
+
+// ProjectFileCreate defines fields for uploading a file to a project. The
+// Token is obtained from the /uploads.json endpoint.
+type ProjectFileCreate struct {
+	Token       string `json:"token"`
+	Filename    string `json:"filename,omitempty"`
+	VersionID   int    `json:"version_id,omitempty"`
+	Description string `json:"description,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+}

--- a/internal/ops/files.go
+++ b/internal/ops/files.go
@@ -43,6 +43,10 @@ func ListProjectFiles(ctx context.Context, client *api.Client, input ListProject
 // UploadProjectFile attaches a previously uploaded file (via the /uploads.json
 // flow) to a project. The Redmine API returns no body on success; callers can
 // re-list the project's files to surface the resulting record.
+//
+// Deliberately not exposed as an MCP tool: the function requires an upload
+// token obtained by streaming bytes to /uploads.json, and MCP has no tool that
+// produces such a token, so exposing it alone would be unusable.
 func UploadProjectFile(ctx context.Context, client *api.Client, input UploadProjectFileInput) (MessageResult, error) {
 	if input.Token == "" {
 		return MessageResult{}, fmt.Errorf("token is required")

--- a/internal/ops/files.go
+++ b/internal/ops/files.go
@@ -1,0 +1,64 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+	"github.com/aarondpn/redmine-cli/v2/internal/models"
+)
+
+type ListProjectFilesInput struct {
+	ProjectID string `json:"project_id" jsonschema:"Project identifier or numeric ID."`
+	Limit     int    `json:"limit,omitempty" jsonschema:"Max results to return. Defaults to 50 when omitted."`
+	Offset    int    `json:"offset,omitempty" jsonschema:"Number of leading results to skip."`
+}
+
+type ProjectFilesListResult struct {
+	Files      []models.ProjectFile `json:"files"`
+	Count      int                  `json:"count"`
+	TotalCount int                  `json:"total_count"`
+}
+
+type UploadProjectFileInput struct {
+	ProjectID   string `json:"project_id" jsonschema:"Project identifier or numeric ID."`
+	Token       string `json:"token" jsonschema:"Upload token returned by the /uploads.json endpoint."`
+	Filename    string `json:"filename,omitempty" jsonschema:"File name shown in Redmine. Defaults to the uploaded file's name."`
+	VersionID   int    `json:"version_id,omitempty" jsonschema:"Optional version (milestone) to attach the file to."`
+	Description string `json:"description,omitempty" jsonschema:"Optional human-readable description."`
+	ContentType string `json:"content_type,omitempty" jsonschema:"Optional MIME type override."`
+}
+
+//mcpgen:tool list_project_files
+//mcpgen:description List files attached to a project.
+//mcpgen:category projects
+func ListProjectFiles(ctx context.Context, client *api.Client, input ListProjectFilesInput) (ProjectFilesListResult, error) {
+	files, total, err := client.Files.List(ctx, input.ProjectID, ListLimit(input.Limit), input.Offset)
+	if err != nil {
+		return ProjectFilesListResult{}, err
+	}
+	return ProjectFilesListResult{Files: files, Count: len(files), TotalCount: total}, nil
+}
+
+// UploadProjectFile attaches a previously uploaded file (via the /uploads.json
+// flow) to a project. The Redmine API returns no body on success; callers can
+// re-list the project's files to surface the resulting record.
+func UploadProjectFile(ctx context.Context, client *api.Client, input UploadProjectFileInput) (MessageResult, error) {
+	if input.Token == "" {
+		return MessageResult{}, fmt.Errorf("token is required")
+	}
+	if err := client.Files.Create(ctx, input.ProjectID, models.ProjectFileCreate{
+		Token:       input.Token,
+		Filename:    input.Filename,
+		VersionID:   input.VersionID,
+		Description: input.Description,
+		ContentType: input.ContentType,
+	}); err != nil {
+		return MessageResult{}, err
+	}
+	name := input.Filename
+	if name == "" {
+		name = "file"
+	}
+	return MessageResult{Message: fmt.Sprintf("Uploaded %s to project %s", name, input.ProjectID)}, nil
+}

--- a/internal/ops/files_test.go
+++ b/internal/ops/files_test.go
@@ -1,0 +1,98 @@
+package ops
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/api"
+	"github.com/aarondpn/redmine-cli/v2/internal/debug"
+)
+
+// TestUploadProjectFile_RequiresToken guards the ops-layer boundary: the CLI
+// always calls /uploads.json first, but MCP or other programmatic callers
+// reach UploadProjectFile directly. Without this check an empty token would
+// round-trip to Redmine and surface as an opaque 422.
+func TestUploadProjectFile_RequiresToken(t *testing.T) {
+	_, err := UploadProjectFile(context.Background(), nil, UploadProjectFileInput{
+		ProjectID: "proj",
+		Filename:  "x.txt",
+	})
+	if err == nil {
+		t.Fatal("expected error when token is empty")
+	}
+	if !strings.Contains(err.Error(), "token") {
+		t.Errorf("error = %q, want it to mention the token requirement", err.Error())
+	}
+}
+
+func TestUploadProjectFile_PassesThroughToAPI(t *testing.T) {
+	var gotBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client := api.NewTestClient(ts.Client(), ts.URL, debug.New(nil))
+
+	result, err := UploadProjectFile(context.Background(), client, UploadProjectFileInput{
+		ProjectID:   "proj",
+		Token:       "tok",
+		Filename:    "build.zip",
+		VersionID:   3,
+		Description: "release",
+		ContentType: "application/zip",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Message == "" {
+		t.Error("expected non-empty success message")
+	}
+	file, ok := gotBody["file"].(map[string]interface{})
+	if !ok {
+		t.Fatal("body missing file key")
+	}
+	if file["token"] != "tok" {
+		t.Errorf("token = %v, want tok", file["token"])
+	}
+	if file["filename"] != "build.zip" {
+		t.Errorf("filename = %v, want build.zip", file["filename"])
+	}
+	if file["version_id"] != float64(3) {
+		t.Errorf("version_id = %v, want 3", file["version_id"])
+	}
+}
+
+func TestListProjectFiles_DecodesResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "files": [
+                {"id": 1, "filename": "a.txt", "filesize": 10, "author": {"id": 5, "name": "Bob"}, "created_on": "2026-04-02T10:00:00Z"},
+                {"id": 2, "filename": "b.zip", "filesize": 200, "author": {"id": 5, "name": "Bob"}, "created_on": "2026-04-03T10:00:00Z", "version": {"id": 9, "name": "1.1"}}
+            ],
+            "total_count": 2
+        }`))
+	}))
+	defer ts.Close()
+
+	client := api.NewTestClient(ts.Client(), ts.URL, debug.New(nil))
+
+	got, err := ListProjectFiles(context.Background(), client, ListProjectFilesInput{ProjectID: "proj"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TotalCount != 2 || got.Count != 2 {
+		t.Errorf("counts = (count=%d, total=%d), want both 2", got.Count, got.TotalCount)
+	}
+	if got.Files[1].Version == nil || got.Files[1].Version.Name != "1.1" {
+		t.Errorf("version = %+v, want name=1.1", got.Files[1].Version)
+	}
+}

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -55,6 +55,7 @@ const (
 	ActionSwitched    = "switched"
 	ActionInstalled   = "installed"
 	ActionOpened      = "opened"
+	ActionUploaded    = "uploaded"
 )
 
 // RenderActionJSON writes an action envelope as pretty-printed JSON.

--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -18,6 +18,7 @@ Only these top-level commands exist. Do NOT invent subcommands that aren't liste
 | `projects` | List, get, create, update, delete projects; list project members |
 | `time` | Log, list, get, update, delete, summarize time entries |
 | `versions` | Create, list, get, update, delete project versions (milestones) |
+| `files` | List and upload project-level files (release artifacts) |
 | `memberships` | List, get, create, update, delete project memberships |
 | `users` | List, get, create, update, delete users |
 | `groups` | List, get, create, update, delete groups; add/remove users |


### PR DESCRIPTION
## Summary

Closes #81.

Adds a first-class `redmine files` command group so release-artifact workflows no longer need `redmine api` or the web UI:

- `files list [--project <id>]` — table/json/csv view of a project's file list with size, version (if any), uploader, and timestamps.
- `files upload <path> [--project <id>] [--version <name|id>] [--filename <name>] [--description <text>] [--content-type <mime>]` — streams the file through the existing `/uploads.json` plumbing, then attaches the returned token to the project. Optional `--version` resolves milestone names to IDs.

Under the hood:

- New `models.ProjectFile` / `models.ProjectFileCreate` and an `api.FileService` (`List`, `Create`).
- Ops layer: `ListProjectFiles` (exposed as MCP `list_project_files` under the `projects` group, read-only) and `UploadProjectFile` (CLI-only; MCP would need an upload token from a real file on disk).
- Re-generated MCP tool catalog (`zz_generated_tools.go`) and updated MCP read-only golden.
- New `output.ActionUploaded` constant so the upload envelope emits `{"action":"uploaded","resource":"project_file"}`.
- Docs: full English + Chinese pages and sidebar entry.
- Skill: `files` row added to the command table.

## Test plan

- [x] `go test ./...` — unit tests pass (new tests cover URL escaping, body shape, omitempty for the API service, plus token-required guard and list decoding for the ops layer).
- [x] `golangci-lint run` — clean.
- [x] `go vet -tags=e2e ./...` — clean.
- [x] `make e2e-up && make e2e-test` — new e2e file covers upload→list lifecycle, empty-project list, and the missing-file error envelope. Needs a live Redmine in CI.
- [x] `redmine files --help`, `redmine files list --help`, `redmine files upload --help` — sane output.