### PR TITLE
docs(time): remove unimplemented interactive form mentions

### DIFF
--- a/docs/src/content/docs/commands/time.mdx
+++ b/docs/src/content/docs/commands/time.mdx
@@ -8,7 +8,7 @@ import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starli
 The `time` command (alias `t`) manages time entries.
 
 <CardGrid>
-  <LinkCard title="log"     href="#log"     description="Log time interactively or via flags." />
+  <LinkCard title="log"     href="#log"     description="Log time via flags." />
   <LinkCard title="list"    href="#list"    description="Filter and page through time entries." />
   <LinkCard title="get"     href="#get"     description="View a single entry." />
   <LinkCard title="update"  href="#update"  description="Change hours, activity, comment, or date." />
@@ -22,8 +22,6 @@ The `time` command (alias `t`) manages time entries.
 redmine time log [flags]
 ```
 
-Without flags, opens an interactive form.
-
 | Flag | Description |
 |------|-------------|
 | `--issue`    | Issue ID |
@@ -35,12 +33,7 @@ Without flags, opens an interactive form.
 | `--user`     | Log on behalf of another user (`me`, login, name, or ID) |
 
 <Tabs syncKey="time-log">
-  <TabItem label="Interactive">
-    ```bash
-    redmine time log
-    ```
-  </TabItem>
-  <TabItem label="One-shot">
+  <TabItem label="Basic">
     ```bash
     redmine time log --issue 123 --hours 1.5 --activity Development --comment "Bug fix"
     ```

--- a/docs/src/content/docs/zh-cn/commands/time.mdx
+++ b/docs/src/content/docs/zh-cn/commands/time.mdx
@@ -8,7 +8,7 @@ import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starli
 `time` 命令（别名 `t`）用于管理工时记录。
 
 <CardGrid>
-  <LinkCard title="log"     href="#log"     description="通过交互式表单或标志记录工时。" />
+  <LinkCard title="log"     href="#log"     description="通过标志记录工时。" />
   <LinkCard title="list"    href="#list"    description="过滤并分页浏览工时记录。" />
   <LinkCard title="get"     href="#get"     description="查看单条工时记录。" />
   <LinkCard title="update"  href="#update"  description="修改工时、活动类型、评论或日期。" />
@@ -22,8 +22,6 @@ import { CardGrid, LinkCard, Tabs, TabItem, Aside, Badge } from '@astrojs/starli
 redmine time log [flags]
 ```
 
-不带标志时，打开交互式填写表单。
-
 | 标志 | 描述 |
 |------|------|
 | `--issue`    | 工单 ID |
@@ -35,12 +33,7 @@ redmine time log [flags]
 | `--user`     | 代他人记录工时（`me`、登录名、姓名或 ID） |
 
 <Tabs syncKey="time-log">
-  <TabItem label="交互式">
-    ```bash
-    redmine time log
-    ```
-  </TabItem>
-  <TabItem label="一次性">
+  <TabItem label="基础">
     ```bash
     redmine time log --issue 123 --hours 1.5 --activity Development --comment "Bug fix"
     ```


### PR DESCRIPTION
The `redmine time log` docs claimed "Without flags, opens an interactive form" since the initial release, but this was never implemented. `--hours` is always required.

Since the interactive form is not planned for now (see #112), this drops the references entirely rather than documenting a feature that does not exist. Applied to both the English and zh-cn docs.