### PR TITLE
ci(docs): add wrangler config for static-asset deploy

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,6 +2,8 @@
 dist/
 # generated types
 .astro/
+# wrangler local cache
+.wrangler/
 
 # dependencies
 node_modules/

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "redmine-cli",
+	"compatibility_date": "2026-06-13",
+	"assets": {
+		"directory": "./dist",
+		"not_found_handling": "404-page"
+	}
+}


### PR DESCRIPTION
Follow-up to #115. That PR was squash-merged before this commit landed, so the wrangler config is missing from `main` and the Cloudflare deploy fails.

`wrangler deploy` finds no config and auto-runs `astro add cloudflare`, which injects the SSR adapter and breaks the static build (`No such module ".../path"`). This declares the site as static assets so wrangler uploads `dist` directly.

Validated with `wrangler deploy --dry-run`: reads the static files from `dist`, no auto-config.