### PR TITLE
docs: update google-site-verification token

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -9,4 +9,4 @@ const xDefault = new URL(enPath, Astro.site).href;
 
 <Default />
 <link rel="alternate" hreflang="x-default" href={xDefault} />
-<meta name="google-site-verification" content="NtmxXszJbpRXC9KM9h2QGK9oaT4YsEGmQF9Xz2uxgV0" />
+<meta name="google-site-verification" content="3GN_SussYBJTIeb0i2fHLiuJs3JbSRosE0_kVZN7DZ8" />


### PR DESCRIPTION
Swap in the new Google Search Console verification token for the Cloudflare Workers docs domain.