### PR TITLE
docs: set canonical site URL to redmine-cli.dev

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,7 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://redmine-cli.aaron-doeppner.workers.dev',
+	site: 'https://redmine-cli.dev',
 	integrations: [
 		starlight({
 			title: 'redmine-cli',

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow:
 
-Sitemap: https://redmine-cli.aaron-doeppner.workers.dev/sitemap-index.xml
+Sitemap: https://redmine-cli.dev/sitemap-index.xml


### PR DESCRIPTION
Point the canonical `site` and sitemap at the new custom domain `redmine-cli.dev` (sitemap/hreflang/SEO).