### PR TITLE
fix(time): don't inject default project on issue-scoped time list/log (#123)

### DIFF
--- a/e2e/runner_test.go
+++ b/e2e/runner_test.go
@@ -85,6 +85,17 @@ func (r *cliRunner) runJSON(t *testing.T, dest any, args ...string) {
 	}
 }
 
+// runJSONWithEnv is like runJSON but appends extra env vars to the child
+// process. Tests that need to drive config via REDMINE_* env (e.g. a default
+// project) and still decode JSON output use this.
+func (r *cliRunner) runJSONWithEnv(t *testing.T, extraEnv []string, dest any, args ...string) {
+	t.Helper()
+	stdout := r.runWithEnv(t, extraEnv, args...)
+	if err := json.Unmarshal(stdout, dest); err != nil {
+		t.Fatalf("decode JSON for %q: %v\nstdout:\n%s", strings.Join(args, " "), err, stdout)
+	}
+}
+
 // runExpectError runs the CLI and requires a non-zero exit. It returns
 // stdout and stderr so tests can inspect the error envelope.
 func (r *cliRunner) runExpectError(t *testing.T, args ...string) (stdout, stderr []byte) {

--- a/e2e/time_entries_test.go
+++ b/e2e/time_entries_test.go
@@ -84,6 +84,67 @@ func TestTimeEntries_CRUD(t *testing.T) {
 	}
 }
 
+// TestTimeEntries_DefaultProjectIgnoredForIssueScope is a regression test for
+// issue #123. When a default project is configured that differs from the
+// issue's project, issue-scoped `time log` and `time list` must NOT inject the
+// default project's project_id. Before the fix the injected project_id made
+// Redmine reject the create (issue/project mismatch) and scoped the list query
+// to the wrong project, so the entry was invisible.
+func TestTimeEntries_DefaultProjectIgnoredForIssueScope(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	// projB owns the issue; projA is the configured default project.
+	projA := createTestProject(t, r)
+	projB := createTestProject(t, r)
+	issue := createTestIssue(t, r, projB.Identifier)
+	activity := firstActivityName(t, r)
+
+	defaultProjectEnv := []string{"REDMINE_DEFAULT_PROJECT=" + projA.Identifier}
+
+	// `time log --issue` must attach to the issue's project (projB), not the
+	// configured default (projA).
+	var created struct {
+		ID      int `json:"id"`
+		Project struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"project"`
+	}
+	r.runJSONWithEnv(t, defaultProjectEnv, &created, "time", "log",
+		"--issue", strconv.Itoa(issue.ID),
+		"--hours", "0.75",
+		"--activity", activity,
+		"--date", "2026-04-18",
+		"--comment", "issue-scoped despite default project")
+	if created.ID == 0 {
+		t.Fatalf("time log returned no ID: %+v", created)
+	}
+	if created.Project.ID != projB.ID {
+		t.Fatalf("time entry project = %d (%s), want issue's project %d (%s); default project leaked in",
+			created.Project.ID, created.Project.Name, projB.ID, projB.Name)
+	}
+
+	t.Cleanup(func() {
+		var deleted actionEnvelope
+		r.runJSON(t, &deleted, "time", "delete", strconv.Itoa(created.ID), "--force")
+		if !deleted.Ok {
+			t.Errorf("time delete envelope not ok: %+v", deleted)
+		}
+	})
+
+	// `time list --issue` must return the entry even though the configured
+	// default project is a different project.
+	var entries []struct {
+		ID int `json:"id"`
+	}
+	r.runJSONWithEnv(t, defaultProjectEnv, &entries, "time", "list", "--issue", strconv.Itoa(issue.ID))
+	if len(entries) != 1 || entries[0].ID != created.ID {
+		t.Fatalf("time list --issue %d with default project %s = %+v, want single entry %d",
+			issue.ID, projA.Identifier, entries, created.ID)
+	}
+}
+
 // TestTimeEntries_LogOnBehalfOf verifies admin can log time for another user
 // via `time log --user`. Resolves the target user by login and confirms the
 // returned entry's user.id matches the fixture, not the API caller.

--- a/internal/cmd/time/list.go
+++ b/internal/cmd/time/list.go
@@ -41,7 +41,17 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 			from = cmdutil.ResolveDateKeyword(from)
 			to = cmdutil.ResolveDateKeyword(to)
 
-			project, err = cmdutil.DefaultProjectID(ctx, f, project)
+			// When filtering by a specific issue, the issue already determines
+			// the scope. Applying the configured default project would inject an
+			// unrelated project_id, which Redmine authorizes against that project
+			// (often a 403 when its time-tracking module is disabled or the issue
+			// lives elsewhere). Only fall back to the default project for
+			// project-scoped listings; an explicit --project is still honored.
+			if issue > 0 {
+				project, err = cmdutil.ResolveProjectID(ctx, f, project)
+			} else {
+				project, err = cmdutil.DefaultProjectID(ctx, f, project)
+			}
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/time/log.go
+++ b/internal/cmd/time/log.go
@@ -37,7 +37,16 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 
 			ctx := context.Background()
 
-			project, err = cmdutil.DefaultProjectID(ctx, f, project)
+			// When logging against a specific issue, Redmine derives the project
+			// from the issue. Applying the configured default project would inject
+			// a conflicting project_id that Redmine can reject. Only fall back to
+			// the default project when no issue is given; an explicit --project is
+			// still honored.
+			if issue > 0 {
+				project, err = cmdutil.ResolveProjectID(ctx, f, project)
+			} else {
+				project, err = cmdutil.DefaultProjectID(ctx, f, project)
+			}
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/time/time_test.go
+++ b/internal/cmd/time/time_test.go
@@ -175,6 +175,119 @@ func TestTimeList_EmptyCSVPrintsHeaders(t *testing.T) {
 	}
 }
 
+// TestTimeList_IssueScopeIgnoresDefaultProject pins that filtering by --issue
+// does not inject the configured default project's project_id, which would
+// change Redmine's authorization scope and can surface as a 403. See issue #123.
+func TestTimeList_IssueScopeIgnoresDefaultProject(t *testing.T) {
+	var capturedQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/projects/demo.json":
+			// Default-project resolution would hit this if (wrongly) attempted.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":7,"identifier":"demo","name":"Demo"}}`))
+		case "/time_entries.json":
+			capturedQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time_entries":[],"total_count":0}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactoryWithConfig(t, srv.URL, "default_project: demo\n")
+	cmd := newCmdTimeList(f)
+	cmd.SetArgs([]string{"--issue", "42", "--limit", "0", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := capturedQuery.Get("issue_id"); got != "42" {
+		t.Errorf("issue_id query = %q, want 42", got)
+	}
+	if got, ok := capturedQuery["project_id"]; ok {
+		t.Errorf("project_id must be absent when filtering by issue, got %q", got)
+	}
+}
+
+// TestTimeLog_IssueScopeIgnoresDefaultProject pins that logging against --issue
+// does not inject the configured default project into the request body. See
+// issue #123.
+func TestTimeLog_IssueScopeIgnoresDefaultProject(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/projects/demo.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":7,"identifier":"demo","name":"Demo"}}`))
+		case "/time_entries.json":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &capturedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time_entry":{"id":99,"hours":1,"spent_on":"2025-06-15","project":{"id":1,"name":"Demo"},"user":{"id":2,"name":"Alice"},"activity":{"id":9,"name":"Development"}}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactoryWithConfig(t, srv.URL, "default_project: demo\n")
+	cmd := newCmdTimeLog(f)
+	cmd.SetArgs([]string{"--hours", "1", "--issue", "42", "--date", "2025-06-15"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	te, _ := capturedBody["time_entry"].(map[string]interface{})
+	if te == nil {
+		t.Fatal("request body missing time_entry wrapper")
+	}
+	if te["issue_id"] != float64(42) {
+		t.Errorf("payload issue_id = %v, want 42", te["issue_id"])
+	}
+	if v, ok := te["project_id"]; ok {
+		t.Errorf("project_id must be absent when logging against an issue, got %v", v)
+	}
+}
+
+// TestTimeSummary_HonorsDefaultProject pins a deliberate decision from the
+// issue #123 audit: `time summary` has no issue scope, so applying the
+// configured default project is intended behavior (the same fallback the fix
+// keeps in the no-issue branch of list/log). It must NOT be "fixed" to drop the
+// default project, which would regress project-scoped summaries.
+func TestTimeSummary_HonorsDefaultProject(t *testing.T) {
+	var capturedQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/projects/demo.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":7,"identifier":"demo","name":"Demo"}}`))
+		case "/time_entries.json":
+			capturedQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"time_entries":[],"total_count":0}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	f := testutil.NewFactoryWithConfig(t, srv.URL, "default_project: demo\n")
+	cmd := newCmdTimeSummary(f)
+	cmd.SetArgs([]string{"--from", "2025-06-01", "--to", "2025-06-30", "--output", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := capturedQuery.Get("project_id"); got != "7" {
+		t.Errorf("project_id query = %q, want 7 (summary should honor the default project)", got)
+	}
+}
+
 // --- get ---
 
 func TestTimeGet_Detail(t *testing.T) {


### PR DESCRIPTION
## Summary

`redmine time list --issue <id>` and `redmine time log --issue <id>` returned `Permission denied` (HTTP 403) while the equivalent raw call `redmine api /time_entries.json -f issue_id=<id> ...` worked with the same API key. Closes #123.

## Root cause

Both commands applied the configured **default project** unconditionally before building the request, injecting an unrelated `project_id` that the raw API call never sends:

| Command | Request actually sent |
|---|---|
| `api /time_entries.json -f issue_id=42 -f limit=100` (works) | `GET …?issue_id=42&limit=100` |
| `time list --issue 42` (default project set) | `GET …?issue_id=42&limit=100&offset=0&`**`project_id=7`** |
| `time log --issue 42` (default project set) | `POST` body `{"issue_id":42,`**`"project_id":"7"`**`,…}` |

Reproduced against a logging mock server, and the 403 was confirmed against Redmine's own source:

- **List** (`TimelogController#index` -> `find_optional_project`): authorization keys on `project_id`, not `issue_id`. `User#allowed_to?(action, project)` runs `return false unless context.allows_to?(action)` (module-enabled check) **before** `return true if admin?`, so a `project_id` whose project has time tracking disabled returns 403 even for an admin. With only `issue_id`, the `:global` branch grants admins immediately.
- **Log** (`TimelogController#create`): `TimeEntry#safe_attributes=` only corrects the project to the issue's project when `project_id` is **blank**. A non-blank injected `project_id` keeps the wrong project, then `create` does `render_403` on the `log_time` check (or fails validation with an issue/project mismatch).

The reported "activity inactive at project level" detail is a red herring: that would surface as a 422, and `time list` never touches activities.

## Fix

Gate the default-project fallback on `issue == 0`. When an issue scopes the request, the issue determines the project, so no `project_id` is injected; an explicit `--project` is still resolved and honored. Commands without an issue scope keep the default-project fallback.

## Scope check

A multi-agent audit of every default-project callsite plus the ops/MCP layers confirmed `time list` and `time log` are the only members of this bug class. `time summary` was considered and deliberately left unchanged: it has no issue scope, so honoring the configured default project is intended (matching the no-issue branch of list/log); changing it would regress project-scoped summaries. The ops/MCP layers never inject a default project, so they are unaffected.

## Tests

- Unit (`internal/cmd/time/time_test.go`):
  - `TestTimeList_IssueScopeIgnoresDefaultProject` and `TestTimeLog_IssueScopeIgnoresDefaultProject` assert no `project_id` leaks when scoping by issue with a default project configured.
  - `TestTimeSummary_HonorsDefaultProject` pins the deliberate decision that summary still honors the default project.
- E2E (`e2e/time_entries_test.go`): `TestTimeEntries_DefaultProjectIgnoredForIssueScope` configures a default project that differs from the issue's project and verifies `time log` attaches to the issue's project and `time list --issue` returns the entry.

## Verification

- `gofmt`, `go vet ./...` (and `-tags e2e`), `golangci-lint run ./...` (0 issues)
- Full unit suite passes; e2e compiles under the `e2e` tag.