### PR TITLE
docs(skill): list roles, custom-fields, my-account commands

### DIFF
--- a/skills/redmine-cli/SKILL.md
+++ b/skills/redmine-cli/SKILL.md
@@ -22,10 +22,13 @@ Only these top-level commands exist. Do NOT invent subcommands that aren't liste
 | `files` | List and upload project-level files (release artifacts) |
 | `memberships` | List, get, create, update, delete project memberships |
 | `users` | List, get, create, update, delete users |
+| `my-account` | Get and update your own Redmine account (works without admin) |
 | `groups` | List, get, create, update, delete groups; add/remove users |
+| `roles` | List and get roles, including their permissions |
 | `categories` | List issue categories |
-| `trackers` | List trackers |
+| `trackers` | List and get trackers |
 | `statuses` | List issue statuses |
+| `custom-fields` | List and get custom field definitions (admin-only endpoint) |
 | `search` | Search issues, wiki, news, messages, or browse results |
 | `auth` | Login, logout, list, switch, and check status of authentication profiles |
 | `wiki` | List, get, create, update, delete wiki pages |


### PR DESCRIPTION
## Summary

While verifying the AI integrations, I found the agent skill's command table (`skills/redmine-cli/SKILL.md`) was missing three top-level commands that already ship in the CLI:

- `roles` (added in #92)
- `custom-fields` (added in #97)
- `my-account` (added in #104)

All three predate the skill's last edit (#121), so they were simply overlooked.

## Why it matters

The skill explicitly tells agents: *"Only these top-level commands exist. Do NOT invent... commands not listed here."* So a Claude/Cursor agent following the skill would have **refused to use** these commands, even though the MCP server already exposes them (`list_roles`, `get_custom_field`, `get_my_account`, etc.).

## Change

Adds the three missing rows. The table now matches `redmine --help` 1:1 (verified by diff). No code changes.