### PR TITLE
fix(config): write credential file with 0o600 permissions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,11 @@ func LoadProfiles(configPath string, log *debug.Logger) (*ProfileConfig, error) 
 		return nil, err
 	}
 
+	// Best-effort tighten of credential files written 0o644 by older versions.
+	if info, statErr := os.Stat(configPath); statErr == nil && info.Mode().Perm()&0o077 != 0 {
+		_ = os.Chmod(configPath, 0o600)
+	}
+
 	// Try to detect format by checking for "profiles" key
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
@@ -198,7 +203,13 @@ func SaveProfiles(pc *ProfileConfig, path string) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	return os.WriteFile(path, data, 0o644)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+
+	// Chmod because WriteFile keeps an existing file's mode (older versions wrote 0o644).
+	_ = os.Chmod(path, 0o600)
+	return nil
 }
 
 // Save writes a single profile's configuration (used by auth login).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -542,5 +543,82 @@ func TestApplyEnvOverrides_MCPAuthToken(t *testing.T) {
 	}
 	if cfg.MCP.AuthToken != "from-env" {
 		t.Errorf("AuthToken = %q, want from-env (env should override file)", cfg.MCP.AuthToken)
+	}
+}
+
+func fileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}
+
+func TestSaveProfilesWritesOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	pc := &ProfileConfig{
+		ActiveProfile: "example-com",
+		Profiles: map[string]Config{
+			"example-com": {Server: "https://example.com", APIKey: "secret"},
+		},
+	}
+	if err := SaveProfiles(pc, cfgPath); err != nil {
+		t.Fatalf("SaveProfiles: %v", err)
+	}
+
+	if got := fileMode(t, cfgPath); got != 0o600 {
+		t.Errorf("new config mode = %o, want 600", got)
+	}
+}
+
+func TestSaveProfilesTightensLegacyWorldReadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("profiles:\n  example-com:\n    server: https://example.com\n    api_key: old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := fileMode(t, cfgPath); got != 0o644 {
+		t.Fatalf("precondition mode = %o, want 644", got)
+	}
+
+	pc := &ProfileConfig{
+		ActiveProfile: "example-com",
+		Profiles: map[string]Config{
+			"example-com": {Server: "https://example.com", APIKey: "new"},
+		},
+	}
+	if err := SaveProfiles(pc, cfgPath); err != nil {
+		t.Fatalf("SaveProfiles: %v", err)
+	}
+
+	if got := fileMode(t, cfgPath); got != 0o600 {
+		t.Errorf("overwritten legacy config mode = %o, want 600 (should be tightened)", got)
+	}
+}
+
+func TestLoadProfilesTightensLegacyWorldReadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("profiles:\n  example-com:\n    server: https://example.com\n    api_key: k\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadProfiles(cfgPath, debug.New(nil)); err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+
+	if got := fileMode(t, cfgPath); got != 0o600 {
+		t.Errorf("config mode after load = %o, want 600 (should be tightened on read)", got)
 	}
 }


### PR DESCRIPTION
## Problem

The profile config file (`~/.redmine-cli.yaml`) stores plaintext credentials (API keys, basic-auth passwords, MCP auth tokens) but was written world-readable (`0o644`). On a shared or multi-user host, any local user could read another user's credentials and impersonate them against Redmine. Because `os.WriteFile` only applies the mode on file creation, files kept their old permissions even after being rewritten.

## Fix

- `SaveProfiles` now writes `0o600`, and `Chmod`s after writing so files created by older versions (`0o644`) are tightened on their next write.
- `LoadProfiles` best-effort tightens the file on load, so existing installs are remediated even when the user never triggers a write.
- Both `Chmod` calls are best-effort (a read-only mount or exotic FS never breaks save/load).
- `os.WriteFile` is kept over an atomic temp+rename so symlinked configs (dotfiles repos) are preserved. The parent directory is left at `0o755` since for the default path it is the user's home directory.

## Compatibility

- No config content changes; existing files keep working and are tightened automatically.
- Independent of install method (brew / `go install` / curl) since all read the same file.
- On Windows, `Chmod(0o600)` keeps the file writable and is effectively a no-op.

## Tests

Added coverage (skipped on Windows) for: new files written `0o600`, an existing `0o644` file tightened on overwrite, and a `0o644` file tightened on load.