### PR TITLE
feat: support Redmine 7.0 API additions and add it to the e2e matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,12 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+      # The e2e package is behind a build tag, so neither `go test ./...` nor
+      # golangci-lint compiles it. Without this, a compile error there is only
+      # caught by the E2E workflow, which needs live containers.
+      - name: Vet e2e package
+        run: go vet -tags=e2e ./e2e
+
+      - name: Test e2e helpers
+        run: go test -tags=e2e -run 'TestParseRedmineVersion|TestRedmineAtLeast' ./e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,7 @@ on:
           - '4.2'
           - '5.1'
           - '6.1'
+          - '7.0'
           - all
         default: default
 
@@ -49,13 +50,13 @@ jobs:
         run: |
           case "${INPUT_VERSION:-default}" in
             all)
-              echo 'versions=["4.2","5.1","6.1"]' >> "$GITHUB_OUTPUT"
+              echo 'versions=["4.2","5.1","6.1","7.0"]' >> "$GITHUB_OUTPUT"
               ;;
-            4.2|5.1|6.1)
+            4.2|5.1|6.1|7.0)
               echo "versions=[\"${INPUT_VERSION}\"]" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo 'versions=["4.2","5.1","6.1"]' >> "$GITHUB_OUTPUT"
+              echo 'versions=["4.2","5.1","6.1","7.0"]' >> "$GITHUB_OUTPUT"
               ;;
           esac
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY_NAME=redmine
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
 E2E_COMPOSE_FILE=e2e/compose.yaml
-E2E_VERSION ?= 6.1
+E2E_VERSION ?= 7.0
 E2E_IMAGE ?= redmine:$(E2E_VERSION)
 E2E_PORT ?= 3000
 E2E_BASE_URL ?= http://127.0.0.1:$(E2E_PORT)
@@ -11,7 +11,7 @@ E2E_PROJECT_NAME ?= e2e-$(subst .,-,$(E2E_VERSION))
 # empty to skip the password reset (in which case basic-auth tests will
 # be skipped as well).
 E2E_PASSWORD ?= admintest123
-SUPPORTED_E2E_VERSIONS=4.2 5.1 6.1
+SUPPORTED_E2E_VERSIONS=4.2 5.1 6.1 7.0
 
 .PHONY: build test lint clean install e2e-up e2e-down e2e-config e2e-test e2e-logs e2e-matrix
 
@@ -60,6 +60,7 @@ e2e-matrix:
 			4.2) port=3402 ;; \
 			5.1) port=3501 ;; \
 			6.1) port=3601 ;; \
+			7.0) port=3700 ;; \
 			*) port=3000 ;; \
 		esac; \
 		project_name=e2e-$$(echo $$version | tr . -); \

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,7 @@
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-4.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 4.x"></a>
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-5.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 5.x"></a>
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-6.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 6.x"></a>
+  <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-7.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 7.x"></a>
 </p>
 
 <p align="center">
@@ -116,4 +117,4 @@ skill は CLI の非自明な部分（出力形式、名前解決、ページネ
 
 ## 開発
 
-実際の Redmine インスタンスに対するローカル E2E テスト（Docker、Redmine `4.2`、`5.1`、`6.1` をサポート）：[e2e/README.md](e2e/README.md) を参照してください。
+実際の Redmine インスタンスに対するローカル E2E テスト（Docker、Redmine `4.2`、`5.1`、`6.1`、`7.0` をサポート）：[e2e/README.md](e2e/README.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-4.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 4.x"></a>
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-5.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 5.x"></a>
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-6.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 6.x"></a>
+  <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-7.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 7.x"></a>
 </p>
 
 <p align="center">
@@ -116,4 +117,4 @@ Full configuration, host-specific snippets (Claude Desktop, Cursor, Zed, VS Code
 
 ## Development
 
-Local E2E testing against a real Redmine instance (Docker, supported on Redmine `4.2`, `5.1`, `6.1`): see [e2e/README.md](e2e/README.md).
+Local E2E testing against a real Redmine instance (Docker, supported on Redmine `4.2`, `5.1`, `6.1`, `7.0`): see [e2e/README.md](e2e/README.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-4.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 4.x"></a>
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-5.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 5.x"></a>
   <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-6.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 6.x"></a>
+  <a href="https://www.redmine.org/projects/redmine/wiki/changelog"><img src="https://img.shields.io/badge/Redmine-7.x-B32024?style=for-the-badge&logo=redmine&logoColor=white" alt="Redmine 7.x"></a>
 </p>
 
 <p align="center">
@@ -116,4 +117,4 @@ skill 教代理掌握 CLI 中不显然的部分（输出格式、名称解析、
 
 ## 开发
 
-针对真实 Redmine 实例的本地端到端测试（Docker，支持 `4.2`、`5.1`、`6.1`）：参见 [e2e/README.md](e2e/README.md)。
+针对真实 Redmine 实例的本地端到端测试（Docker，支持 `4.2`、`5.1`、`6.1`、`7.0`）：参见 [e2e/README.md](e2e/README.md)。

--- a/docs/src/content/docs/commands/other.mdx
+++ b/docs/src/content/docs/commands/other.mdx
@@ -103,6 +103,10 @@ Lists or inspects custom field definitions. The list view surfaces target resour
   The underlying `GET /custom_fields.json` endpoint is admin-only - the command returns `403 Forbidden` for non-admin API keys.
 </Aside>
 
+<Aside type="note">
+  Redmine 7.0 extended this endpoint. `custom-fields get` shows the `For All Projects` flag and the `Projects` a field is scoped to, and roles are now reported for time entry, project and version fields instead of issue fields only. Against older servers those rows are omitted rather than shown as `no`, so an empty row means "this server does not report it" - not "restricted".
+</Aside>
+
 ## Shell completion
 
 <Tabs syncKey="shell">

--- a/docs/src/content/docs/commands/other.mdx
+++ b/docs/src/content/docs/commands/other.mdx
@@ -104,7 +104,15 @@ Lists or inspects custom field definitions. The list view surfaces target resour
 </Aside>
 
 <Aside type="note">
-  Redmine 7.0 extended this endpoint. `custom-fields get` shows the `For All Projects` flag and the `Projects` a field is scoped to, and roles are now reported for time entry, project and version fields instead of issue fields only. Against older servers those rows are omitted rather than shown as `no`, so an empty row means "this server does not report it" - not "restricted".
+  Redmine 7.0 extended this endpoint, and `custom-fields get` surfaces the additions in its table output:
+
+  - `For All Projects` and `Projects` describe a field's project scope. Redmine only reports project scope for **issue** custom fields, so these never appear for a time entry, project or version field.
+  - `Roles` is now reported for time entry, project and version fields too, where older servers reported it for issue fields only.
+  - `Default Mode` appears on date-format fields whose default is relative (for example `days_after_today`).
+
+  The `For All Projects` row is omitted entirely when the server does not report the flag, rather than shown as `no`, so its absence means "not reported" and never "restricted". A missing `Projects` row is different: it means the field is not scoped to specific projects, which for an issue field usually means it applies to all of them.
+
+  CSV output carries only the two scope columns, named `For All` and `Projects`, and leaves `For All` blank instead of dropping it. `Description`, `Editable` and `Default Mode` are table-only.
 </Aside>
 
 ## Shell completion

--- a/docs/src/content/docs/commands/wiki.mdx
+++ b/docs/src/content/docs/commands/wiki.mdx
@@ -58,6 +58,8 @@ redmine wiki get <page> [flags]
 
 Aliases: `show`, `view`. Prints the page metadata and full Textile/Markdown source. Pass `--version` to fetch a historical revision instead of the current one.
 
+Redmine 7.0 added the owning project to the wiki page API response, so `wiki get` shows a `Project` row (and a `project` key in JSON output) against 7.0+ servers. Older servers do not send it and the row is omitted.
+
 | Flag | Description |
 |------|-------------|
 | `--project`    | Project identifier or numeric ID |

--- a/docs/src/content/docs/zh-cn/commands/other.mdx
+++ b/docs/src/content/docs/zh-cn/commands/other.mdx
@@ -103,6 +103,10 @@ redmine custom-fields get 7 --output json
   底层的 `GET /custom_fields.json` 端点仅限管理员访问，使用非管理员 API key 时命令会返回 `403 Forbidden`。
 </Aside>
 
+<Aside type="note">
+  Redmine 7.0 扩展了该端点。`custom-fields get` 会显示 `For All Projects` 标志以及字段限定的 `Projects`；角色信息现在也会针对工时、项目和版本字段返回，而不再仅限于工单字段。对于较旧的服务器，这些行会被直接省略，而不是显示为 `no`，因此缺少该行表示“此服务器不提供该信息”，而非“未受限制”。
+</Aside>
+
 ## Shell 补全
 
 <Tabs syncKey="shell">

--- a/docs/src/content/docs/zh-cn/commands/other.mdx
+++ b/docs/src/content/docs/zh-cn/commands/other.mdx
@@ -104,7 +104,15 @@ redmine custom-fields get 7 --output json
 </Aside>
 
 <Aside type="note">
-  Redmine 7.0 扩展了该端点。`custom-fields get` 会显示 `For All Projects` 标志以及字段限定的 `Projects`；角色信息现在也会针对工时、项目和版本字段返回，而不再仅限于工单字段。对于较旧的服务器，这些行会被直接省略，而不是显示为 `no`，因此缺少该行表示“此服务器不提供该信息”，而非“未受限制”。
+  Redmine 7.0 扩展了该端点，`custom-fields get` 会在表格输出中展示这些新增信息：
+
+  - `For All Projects` 与 `Projects` 描述字段的项目适用范围。Redmine 仅针对**工单**自定义字段返回项目范围，因此工时、项目和版本字段永远不会出现这两行。
+  - `Roles` 现在也会针对工时、项目和版本字段返回，而较旧的服务器仅针对工单字段返回。
+  - `Default Mode` 出现在使用相对默认值的日期格式字段上（例如 `days_after_today`）。
+
+  当服务器不返回该标志时，`For All Projects` 行会被整行省略，而不是显示为 `no`，因此该行缺失表示「服务器未提供该信息」，绝不表示「受到限制」。`Projects` 行缺失的含义则不同：它表示该字段未限定到特定项目，对工单字段而言通常意味着适用于所有项目。
+
+  CSV 输出仅包含两个范围列，列名为 `For All` 和 `Projects`，且 `For All` 为空值而非省略。`Description`、`Editable` 与 `Default Mode` 仅在表格输出中提供。
 </Aside>
 
 ## Shell 补全

--- a/docs/src/content/docs/zh-cn/commands/wiki.mdx
+++ b/docs/src/content/docs/zh-cn/commands/wiki.mdx
@@ -58,6 +58,8 @@ redmine wiki get <page> [flags]
 
 别名：`show`、`view`。打印页面的元数据以及完整的 Textile/Markdown 源文本。传入 `--version` 可获取历史版本而非当前版本。
 
+Redmine 7.0 在 wiki 页面 API 响应中新增了所属项目，因此在 7.0 及以上版本中 `wiki get` 会显示 `Project` 行（JSON 输出中为 `project` 字段）。较旧的服务器不返回该字段，此行会被省略。
+
 | 标志 | 描述 |
 |------|------|
 | `--project`    | 项目标识符或数字 ID |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,7 +15,7 @@ The harness is version-aware. The supported matrix in this repo is:
 - `6.1`
 - `7.0`
 
-If you want to test a custom image, set `REDMINE_IMAGE` when you start the stack.
+If you want to test a custom image, set `E2E_IMAGE` when you start the stack.
 
 ## Start Redmine
 
@@ -23,7 +23,7 @@ If you want to test a custom image, set `REDMINE_IMAGE` when you start the stack
 make e2e-up
 ```
 
-That starts Docker Compose from [compose.yaml](/Users/aarond/Documents/Projects/github/redmine-cli/e2e/compose.yaml:1), waits until Redmine is reachable, and bootstraps the instance for CLI testing by enabling the Redmine REST API.
+That starts Docker Compose from [compose.yaml](compose.yaml), waits until Redmine is reachable, and bootstraps the instance for CLI testing by enabling the Redmine REST API.
 
 To choose a supported Redmine line explicitly:
 
@@ -37,8 +37,12 @@ make e2e-up E2E_VERSION=7.0
 To override the Redmine image:
 
 ```bash
-REDMINE_IMAGE=your-registry/redmine:7.0 make e2e-up
+make e2e-up E2E_IMAGE=your-registry/redmine:7.0-custom
 ```
+
+It has to be a make variable, not an environment variable: the recipe passes
+`REDMINE_IMAGE=$(E2E_IMAGE)` to Docker Compose itself, and that assignment
+wins over anything inherited from the environment.
 
 ## Write a local CLI config
 
@@ -78,7 +82,10 @@ fixtures, tracker / activity lookups).
 
 `bootstrap-redmine.sh` seeds the fixtures that have no REST endpoint: a public
 saved query, an issue custom field (`E2E Severity`, applied to all projects)
-and a role-restricted time entry custom field (`E2E Billing Code`).
+and a role-restricted time entry custom field (`E2E Billing Code`, seeded
+`visible: false` so the role restriction has meaning). The seeding uses `save!`
+throughout: a fixture that cannot be created should stop the bootstrap, not
+degrade quietly into a confusing test failure later.
 
 ### Version-gated assertions
 
@@ -133,7 +140,7 @@ make e2e-down
 - `REDMINE_E2E_TIMEOUT_SECONDS`
 - `REDMINE_E2E_CONFIG_PATH`
 - `REDMINE_E2E_PROFILE_NAME`
-- `REDMINE_IMAGE`
+- `E2E_IMAGE` - Makefile-level override for the Redmine image. `REDMINE_IMAGE` is set by the recipe and cannot be overridden from the environment.
 - `E2E_VERSION`
 - `E2E_PORT`
 - `E2E_PASSWORD` - Makefile-level override for the forced admin password (propagates into `REDMINE_E2E_PASSWORD`).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,7 +4,7 @@ This directory contains a local end-to-end harness for `redmine-cli`.
 
 It uses:
 
-- Docker Official Image `redmine:6.1` by default
+- Docker Official Image `redmine:7.0` by default
 - `postgres:16-alpine`
 - The default Redmine admin account to derive an API key for CLI tests
 
@@ -13,6 +13,7 @@ The harness is version-aware. The supported matrix in this repo is:
 - `4.2`
 - `5.1`
 - `6.1`
+- `7.0`
 
 If you want to test a custom image, set `REDMINE_IMAGE` when you start the stack.
 
@@ -30,12 +31,13 @@ To choose a supported Redmine line explicitly:
 make e2e-up E2E_VERSION=4.2
 make e2e-up E2E_VERSION=5.1
 make e2e-up E2E_VERSION=6.1
+make e2e-up E2E_VERSION=7.0
 ```
 
 To override the Redmine image:
 
 ```bash
-REDMINE_IMAGE=your-registry/redmine:7.0-rc make e2e-up
+REDMINE_IMAGE=your-registry/redmine:7.0 make e2e-up
 ```
 
 ## Write a local CLI config
@@ -67,11 +69,29 @@ Redmine instance. The suite is split into topical files:
 | `api_test.go`            | raw `api` passthrough GET + POST + PUT with `--input` |
 | `errors_test.go`         | error envelope codes: `not_found`, `auth_failed` |
 | `mcp_test.go`            | MCP `serve` over stdio + HTTP, group filter, write gating, `--auth-token` 401 |
+| `custom_fields_test.go`  | `custom-fields list` / `get` plus the Redmine 7.0 scope and role metadata |
 
 Shared infrastructure lives in `e2e_test.go` (TestMain + `requireE2E`),
 `runner_test.go` (CLI runner + profile constructors), `helpers_test.go`
 (envelope types + env accessors) and `fixtures_test.go` (project / issue
 fixtures, tracker / activity lookups).
+
+`bootstrap-redmine.sh` seeds the fixtures that have no REST endpoint: a public
+saved query, an issue custom field (`E2E Severity`, applied to all projects)
+and a role-restricted time entry custom field (`E2E Billing Code`).
+
+### Version-gated assertions
+
+Some behaviour only exists from a given Redmine line onwards. Gate those
+assertions with the helpers in `helpers_test.go` rather than parsing
+`REDMINE_E2E_VERSION` inline:
+
+- `skipBelowRedmine(t, 7, 0, "…")` skips the test on older servers.
+- `redmineAtLeast(5, 0)` branches on the version, e.g. to pick Textile over
+  Markdown.
+
+An unset `REDMINE_E2E_VERSION` counts as "new enough", so ad-hoc runs against
+an unknown server still exercise the newest assertions.
 
 ### Adding a new test
 
@@ -96,6 +116,7 @@ The matrix uses separate ports per Redmine line to avoid collisions:
 - `4.2` -> `http://127.0.0.1:3402`
 - `5.1` -> `http://127.0.0.1:3501`
 - `6.1` -> `http://127.0.0.1:3601`
+- `7.0` -> `http://127.0.0.1:3700`
 
 ## Tear it down
 

--- a/e2e/bootstrap-redmine.sh
+++ b/e2e/bootstrap-redmine.sh
@@ -16,7 +16,11 @@ if docker compose -f "$compose_file" exec -T "$container_service" \
     >/dev/null
 fi
 
-docker compose -f "$compose_file" exec -T \
+# The result is captured rather than piped straight into tail: a pipeline
+# reports the exit status of its last command, so `rails runner ... | tail`
+# would report success even when the seeding aborted. With set -e, a failing
+# command substitution stops the script here instead.
+bootstrap_output=$(docker compose -f "$compose_file" exec -T \
   -e REDMINE_E2E_PASSWORD="$admin_password" \
   "$container_service" \
   bundle exec rails runner '
@@ -61,20 +65,24 @@ docker compose -f "$compose_file" exec -T \
 
     # Seed a role-restricted time entry custom field. Redmine 7.0 (#44152)
     # started returning "roles" for non-issue custom fields, and this fixture
-    # is what makes that observable over the REST API. Older lines may reject
-    # role restrictions on non-issue fields, so the save falls back to a plain
-    # visible field and the assertion is version-gated on the Go side.
+    # is what makes that observable over the REST API. visible=false is what
+    # gives the role restriction meaning: a visible field is visible to every
+    # role and reports no roles at all.
+    #
+    # save! rather than a rescue-and-degrade: role_ids and visible live on the
+    # base CustomField class in every supported line (verified on 4.2, 6.1 and
+    # 7.0), so a failure here is a real regression. Degrading quietly would
+    # surface later as "Redmine did not return roles", blaming the server for
+    # a broken fixture.
     time_entry_cf_name = "E2E Billing Code"
     seeded_time_entry_cf = TimeEntryCustomField.find_or_initialize_by(name: time_entry_cf_name)
     seeded_time_entry_cf.field_format = "string" if seeded_time_entry_cf.field_format.blank?
     seeded_time_entry_cf.is_required = false
     seeded_time_entry_cf.visible = false
-    seeded_time_entry_cf.role_ids = Role.givable.pluck(:id).first(1)
-    unless seeded_time_entry_cf.save
-      seeded_time_entry_cf.visible = true
-      seeded_time_entry_cf.role_ids = []
-      seeded_time_entry_cf.save!
-    end
+    restricted_role_ids = Role.givable.pluck(:id).first(1)
+    abort("no givable roles to restrict the time entry custom field to") if restricted_role_ids.empty?
+    seeded_time_entry_cf.role_ids = restricted_role_ids
+    seeded_time_entry_cf.save!
 
     puts({
       rest_api_enabled: Setting.rest_api_enabled?,
@@ -89,4 +97,6 @@ docker compose -f "$compose_file" exec -T \
       seeded_time_entry_custom_field_id: seeded_time_entry_cf.id,
       seeded_time_entry_custom_field_roles: seeded_time_entry_cf.roles.count
     }.inspect)
-  ' 2>/dev/null | tail -n 1
+  ' 2>/dev/null)
+
+printf '%s\n' "$bootstrap_output" | tail -n 1

--- a/e2e/bootstrap-redmine.sh
+++ b/e2e/bootstrap-redmine.sh
@@ -59,6 +59,23 @@ docker compose -f "$compose_file" exec -T \
     seeded_custom_field.tracker_ids = Tracker.pluck(:id)
     seeded_custom_field.save!
 
+    # Seed a role-restricted time entry custom field. Redmine 7.0 (#44152)
+    # started returning "roles" for non-issue custom fields, and this fixture
+    # is what makes that observable over the REST API. Older lines may reject
+    # role restrictions on non-issue fields, so the save falls back to a plain
+    # visible field and the assertion is version-gated on the Go side.
+    time_entry_cf_name = "E2E Billing Code"
+    seeded_time_entry_cf = TimeEntryCustomField.find_or_initialize_by(name: time_entry_cf_name)
+    seeded_time_entry_cf.field_format = "string" if seeded_time_entry_cf.field_format.blank?
+    seeded_time_entry_cf.is_required = false
+    seeded_time_entry_cf.visible = false
+    seeded_time_entry_cf.role_ids = Role.givable.pluck(:id).first(1)
+    unless seeded_time_entry_cf.save
+      seeded_time_entry_cf.visible = true
+      seeded_time_entry_cf.role_ids = []
+      seeded_time_entry_cf.save!
+    end
+
     puts({
       rest_api_enabled: Setting.rest_api_enabled?,
       admin_api_key_present: admin.api_key.to_s != "",
@@ -68,6 +85,8 @@ docker compose -f "$compose_file" exec -T \
       seeded_query_id: seeded_query.id,
       seeded_query_name: seeded_query.name,
       seeded_custom_field_id: seeded_custom_field.id,
-      seeded_custom_field_name: seeded_custom_field.name
+      seeded_custom_field_name: seeded_custom_field.name,
+      seeded_time_entry_custom_field_id: seeded_time_entry_cf.id,
+      seeded_time_entry_custom_field_roles: seeded_time_entry_cf.roles.count
     }.inspect)
   ' 2>/dev/null | tail -n 1

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -15,7 +15,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
 
   redmine:
-    image: ${REDMINE_IMAGE:-redmine:6.1.3}
+    image: ${REDMINE_IMAGE:-redmine:7.0.0}
     restart: unless-stopped
     depends_on:
       postgres:

--- a/e2e/custom_fields_test.go
+++ b/e2e/custom_fields_test.go
@@ -81,6 +81,7 @@ func TestCustomFields_ListAndGet(t *testing.T) {
 // (#44153), and roles on non-issue custom fields (#44152).
 func TestCustomFields_Redmine7Metadata(t *testing.T) {
 	requireE2E(t)
+	skipIfVersionUnknown(t, "custom field scope and role metadata")
 	skipBelowRedmine(t, 7, 0, "custom field scope and role metadata")
 
 	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())

--- a/e2e/custom_fields_test.go
+++ b/e2e/custom_fields_test.go
@@ -8,17 +8,42 @@ import (
 	"testing"
 )
 
-const seededCustomFieldName = "E2E Severity"
+const (
+	seededCustomFieldName          = "E2E Severity"
+	seededTimeEntryCustomFieldName = "E2E Billing Code"
+)
 
 type e2eCustomField struct {
 	ID             int    `json:"id"`
 	Name           string `json:"name"`
 	CustomizedType string `json:"customized_type"`
 	FieldFormat    string `json:"field_format"`
+	IsForAll       *bool  `json:"is_for_all"`
 	PossibleValues []struct {
 		Value string `json:"value"`
 		Label string `json:"label"`
 	} `json:"possible_values"`
+	Projects []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"projects"`
+	Roles []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"roles"`
+}
+
+// findCustomField returns the field with the given name, failing the test when
+// the seeded fixture is missing.
+func findCustomField(t *testing.T, fields []e2eCustomField, name string) e2eCustomField {
+	t.Helper()
+	for _, f := range fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	t.Fatalf("custom-fields list missing seeded fixture %q; got %+v", name, fields)
+	return e2eCustomField{}
 }
 
 func TestCustomFields_ListAndGet(t *testing.T) {
@@ -28,16 +53,7 @@ func TestCustomFields_ListAndGet(t *testing.T) {
 	var fields []e2eCustomField
 	r.runJSON(t, &fields, "custom-fields", "list")
 
-	var seeded e2eCustomField
-	for _, f := range fields {
-		if f.Name == seededCustomFieldName {
-			seeded = f
-			break
-		}
-	}
-	if seeded.ID == 0 {
-		t.Fatalf("custom-fields list missing seeded fixture %q; got %+v", seededCustomFieldName, fields)
-	}
+	seeded := findCustomField(t, fields, seededCustomFieldName)
 	if seeded.CustomizedType != "issue" || seeded.FieldFormat != "list" {
 		t.Fatalf("seeded custom field metadata unexpected: %+v", seeded)
 	}
@@ -57,5 +73,42 @@ func TestCustomFields_ListAndGet(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("custom-fields get table output missing %q\nstdout:\n%s", want, stdout)
 		}
+	}
+}
+
+// TestCustomFields_Redmine7Metadata covers the two custom-field API changes in
+// Redmine 7.0: is_for_all plus the associated projects on issue custom fields
+// (#44153), and roles on non-issue custom fields (#44152).
+func TestCustomFields_Redmine7Metadata(t *testing.T) {
+	requireE2E(t)
+	skipBelowRedmine(t, 7, 0, "custom field scope and role metadata")
+
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+
+	var fields []e2eCustomField
+	r.runJSON(t, &fields, "custom-fields", "list")
+
+	// The bootstrap seeds the issue field with is_for_all, so the flag must be
+	// present and true, and the projects array must stay empty: a field that
+	// applies everywhere has no explicit project scope.
+	issueField := findCustomField(t, fields, seededCustomFieldName)
+	if issueField.IsForAll == nil {
+		t.Errorf("issue custom field is missing is_for_all on Redmine %s: %+v", e2eVersion(), issueField)
+	} else if !*issueField.IsForAll {
+		t.Errorf("issue custom field is_for_all = false, want true (bootstrap seeds it for all projects)")
+	}
+	if len(issueField.Projects) != 0 {
+		t.Errorf("issue custom field has %d projects, want 0 for an is_for_all field", len(issueField.Projects))
+	}
+
+	timeEntryField := findCustomField(t, fields, seededTimeEntryCustomFieldName)
+	if len(timeEntryField.Roles) == 0 {
+		t.Errorf("time entry custom field returned no roles on Redmine %s; #44152 should expose them: %+v",
+			e2eVersion(), timeEntryField)
+	}
+
+	stdout := r.run(t, "custom-fields", "get", seededCustomFieldName, "--output", "table")
+	if !strings.Contains(string(stdout), "For All Projects") {
+		t.Errorf("custom-fields get table output missing the For All Projects row\nstdout:\n%s", stdout)
 	}
 }

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -56,6 +57,55 @@ func e2eBaseURL() string  { return getenvDefault("REDMINE_E2E_BASE_URL", "http:/
 func e2eUsername() string { return getenvDefault("REDMINE_E2E_USERNAME", "admin") }
 func e2eAPIKey() string   { return os.Getenv("REDMINE_E2E_API_KEY") }
 func e2ePassword() string { return os.Getenv("REDMINE_E2E_PASSWORD") }
+
+// e2eVersion returns the Redmine line under test ("4.2", "6.1", "7.0", ...).
+// The Makefile e2e-test target sets REDMINE_E2E_VERSION; it is empty for
+// ad-hoc runs against an instance of unknown version.
+func e2eVersion() string { return os.Getenv("REDMINE_E2E_VERSION") }
+
+// redmineAtLeast reports whether the Redmine line under test is at least
+// major.minor. An unset or unparseable REDMINE_E2E_VERSION counts as "new
+// enough" so ad-hoc runs still exercise the newest assertions; version-gated
+// tests should therefore stay tolerant of a server that turns out to be older.
+func redmineAtLeast(major, minor int) bool {
+	gotMajor, gotMinor, ok := parseRedmineVersion(e2eVersion())
+	if !ok {
+		return true
+	}
+	if gotMajor != major {
+		return gotMajor > major
+	}
+	return gotMinor >= minor
+}
+
+// skipBelowRedmine skips the calling test when the version under test predates
+// major.minor. feature names the capability for the skip message.
+func skipBelowRedmine(t *testing.T, major, minor int, feature string) {
+	t.Helper()
+	if !redmineAtLeast(major, minor) {
+		t.Skipf("REDMINE_E2E_VERSION=%s does not support %s (requires %d.%d+)", e2eVersion(), feature, major, minor)
+	}
+}
+
+// parseRedmineVersion extracts the major and minor components from a version
+// string such as "6.1" or "7.0.0". ok is false when the string is empty or
+// does not start with a numeric major component.
+func parseRedmineVersion(v string) (major, minor int, ok bool) {
+	parts := strings.Split(strings.TrimSpace(v), ".")
+	if len(parts) == 0 || parts[0] == "" {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	if len(parts) > 1 {
+		if minor, err = strconv.Atoi(parts[1]); err != nil {
+			minor = 0
+		}
+	}
+	return major, minor, true
+}
 
 // requireErrorEnvelopeMessage decodes stdout as an error envelope and requires
 // a non-empty message. Returns the decoded envelope so callers can perform

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -65,8 +65,10 @@ func e2eVersion() string { return os.Getenv("REDMINE_E2E_VERSION") }
 
 // redmineAtLeast reports whether the Redmine line under test is at least
 // major.minor. An unset or unparseable REDMINE_E2E_VERSION counts as "new
-// enough" so ad-hoc runs still exercise the newest assertions; version-gated
-// tests should therefore stay tolerant of a server that turns out to be older.
+// enough", which is the right default for choosing between two behaviours
+// that both exist (see wikiHeadingStyle). It is the wrong default for
+// asserting that a brand-new field is present, because an unknown server may
+// simply be too old - such tests must call skipIfVersionUnknown as well.
 func redmineAtLeast(major, minor int) bool {
 	gotMajor, gotMinor, ok := parseRedmineVersion(e2eVersion())
 	if !ok {
@@ -87,12 +89,25 @@ func skipBelowRedmine(t *testing.T, major, minor int, feature string) {
 	}
 }
 
+// skipIfVersionUnknown skips the calling test when REDMINE_E2E_VERSION is
+// absent or unparseable. Pair it with skipBelowRedmine on tests that require a
+// field only newer servers send: without it, running the suite by hand against
+// an older instance reports a missing 7.0 field as a Redmine bug rather than
+// as an untestable configuration.
+func skipIfVersionUnknown(t *testing.T, feature string) {
+	t.Helper()
+	if _, _, ok := parseRedmineVersion(e2eVersion()); !ok {
+		t.Skipf("REDMINE_E2E_VERSION is unset or unparseable (%q); cannot assert %s", e2eVersion(), feature)
+	}
+}
+
 // parseRedmineVersion extracts the major and minor components from a version
 // string such as "6.1" or "7.0.0". ok is false when the string is empty or
-// does not start with a numeric major component.
+// when either component is not a number, so a typo like "6.x" is reported as
+// unknown rather than silently read as 6.0.
 func parseRedmineVersion(v string) (major, minor int, ok bool) {
 	parts := strings.Split(strings.TrimSpace(v), ".")
-	if len(parts) == 0 || parts[0] == "" {
+	if parts[0] == "" {
 		return 0, 0, false
 	}
 	major, err := strconv.Atoi(parts[0])
@@ -101,7 +116,7 @@ func parseRedmineVersion(v string) (major, minor int, ok bool) {
 	}
 	if len(parts) > 1 {
 		if minor, err = strconv.Atoi(parts[1]); err != nil {
-			minor = 0
+			return 0, 0, false
 		}
 	}
 	return major, minor, true

--- a/e2e/projects_test.go
+++ b/e2e/projects_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"encoding/json"
-	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -221,18 +220,11 @@ func TestProjects_ArchiveLifecycle(t *testing.T) {
 }
 
 // skipIfArchiveUnsupported skips the calling test when the e2e matrix is
-// running against a Redmine version known to lack the archive endpoint.
-// REDMINE_E2E_VERSION is set by the Makefile e2e-test target.
+// running against a Redmine version known to lack the archive endpoint, which
+// landed in Redmine 5.0.
 func skipIfArchiveUnsupported(t *testing.T) {
 	t.Helper()
-	version := os.Getenv("REDMINE_E2E_VERSION")
-	if version == "" {
-		return
-	}
-	// Archive/unarchive endpoints landed in Redmine 5.0.
-	if strings.HasPrefix(version, "4.") || strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "2.") {
-		t.Skipf("REDMINE_E2E_VERSION=%s does not support project archive (requires 5.0+)", version)
-	}
+	skipBelowRedmine(t, 5, 0, "project archive")
 }
 
 // isProbablyUnsupportedArchive inspects an error envelope on stdout and

--- a/e2e/version_gate_test.go
+++ b/e2e/version_gate_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+// TestParseRedmineVersion is a pure unit test for the version comparator every
+// version gate in this suite depends on. It deliberately does not call
+// requireE2E: the parser must be verifiable without a running server.
+func TestParseRedmineVersion(t *testing.T) {
+	tests := []struct {
+		in        string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		{"7.0", 7, 0, true},
+		{"6.1", 6, 1, true},
+		{"4.2", 4, 2, true},
+		{"7.0.0", 7, 0, true},
+		{"6.1.3", 6, 1, true},
+		{"  7.0  ", 7, 0, true},
+		{"7", 7, 0, true},
+		{"10.2", 10, 2, true},
+		{"", 0, 0, false},
+		{"   ", 0, 0, false},
+		{".", 0, 0, false},
+		{"x", 0, 0, false},
+		{"6.x", 0, 0, false},
+		{"latest", 0, 0, false},
+	}
+
+	for _, tc := range tests {
+		major, minor, ok := parseRedmineVersion(tc.in)
+		if ok != tc.wantOK || major != tc.wantMajor || minor != tc.wantMinor {
+			t.Errorf("parseRedmineVersion(%q) = (%d, %d, %v), want (%d, %d, %v)",
+				tc.in, major, minor, ok, tc.wantMajor, tc.wantMinor, tc.wantOK)
+		}
+	}
+}
+
+// TestRedmineAtLeast pins the comparison semantics, including the deliberate
+// "unknown counts as new enough" default.
+func TestRedmineAtLeast(t *testing.T) {
+	tests := []struct {
+		version string
+		major   int
+		minor   int
+		want    bool
+	}{
+		{"7.0", 7, 0, true},
+		{"7.0.0", 7, 0, true},
+		{"6.1", 7, 0, false},
+		{"4.2", 5, 0, false},
+		{"5.1", 5, 0, true},
+		{"6.1", 5, 0, true},
+		{"10.0", 7, 0, true},
+		{"", 7, 0, true},
+		{"6.x", 7, 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Setenv("REDMINE_E2E_VERSION", tc.version)
+		if got := redmineAtLeast(tc.major, tc.minor); got != tc.want {
+			t.Errorf("redmineAtLeast(%d, %d) with REDMINE_E2E_VERSION=%q = %v, want %v",
+				tc.major, tc.minor, tc.version, got, tc.want)
+		}
+	}
+}

--- a/e2e/wiki_test.go
+++ b/e2e/wiki_test.go
@@ -344,6 +344,7 @@ func TestWiki_SectionUpdate_StaleHashConflict(t *testing.T) {
 // rather than made tolerant: the point is that 7.0+ actually populates it.
 func TestWiki_ProjectInResponse(t *testing.T) {
 	requireE2E(t)
+	skipIfVersionUnknown(t, "project in wiki page API response")
 	skipBelowRedmine(t, 7, 0, "project in wiki page API response")
 
 	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())

--- a/e2e/wiki_test.go
+++ b/e2e/wiki_test.go
@@ -339,13 +339,48 @@ func TestWiki_SectionUpdate_StaleHashConflict(t *testing.T) {
 	assertErrorCode(t, stdout, "conflict")
 }
 
+// TestWiki_ProjectInResponse covers the project node Redmine 7.0 added to the
+// wiki page API response (#43569). Older lines omit it, so the test is gated
+// rather than made tolerant: the point is that 7.0+ actually populates it.
+func TestWiki_ProjectInResponse(t *testing.T) {
+	requireE2E(t)
+	skipBelowRedmine(t, 7, 0, "project in wiki page API response")
+
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	page := wikiPageName(t)
+	r.run(t, "wiki", "create", page,
+		"--project", proj.Identifier,
+		"--text", wikiSection(wikiHeadingStyle(), "Scope", "Body from e2e."))
+
+	var fetched struct {
+		Title   string `json:"title"`
+		Project *struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"project"`
+	}
+	r.runJSON(t, &fetched, "wiki", "get", page, "--project", proj.Identifier)
+	if fetched.Project == nil {
+		t.Fatalf("wiki get omitted project node on Redmine %s: %+v", e2eVersion(), fetched)
+	}
+	if fetched.Project.ID != proj.ID {
+		t.Errorf("wiki page project id = %d, want %d", fetched.Project.ID, proj.ID)
+	}
+
+	stdout := r.run(t, "wiki", "get", page, "--project", proj.Identifier, "--output", "table")
+	if !strings.Contains(string(stdout), fetched.Project.Name) {
+		t.Errorf("wiki get table output missing project name %q\nstdout:\n%s", fetched.Project.Name, stdout)
+	}
+}
+
 // wikiHeadingStyle returns the markup the e2e server's default formatter
 // recognises as headings. Redmine 5.0+ defaults to CommonMark (Markdown);
 // 4.x and earlier default to Textile. Section editing keys off recognised
 // headings, so test content must match the active formatter.
 func wikiHeadingStyle() string {
-	version := os.Getenv("REDMINE_E2E_VERSION")
-	if strings.HasPrefix(version, "4.") || strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "2.") {
+	if !redmineAtLeast(5, 0) {
 		return "textile"
 	}
 	return "markdown"

--- a/internal/cmd/custom_field/custom_field.go
+++ b/internal/cmd/custom_field/custom_field.go
@@ -32,9 +32,9 @@ func boolLabel(v bool) string {
 	return "no"
 }
 
-// optionalBoolLabel renders a tri-state flag: servers older than Redmine 7.0
-// omit is_for_all/editable entirely, and a blank cell is the honest answer
-// there rather than "no".
+// optionalBoolLabel renders a tri-state flag for CSV, where a row cannot be
+// dropped the way the detail view drops it. A server that never sent the flag
+// gets a blank cell, because "no" would assert a restriction it never stated.
 func optionalBoolLabel(v *bool) string {
 	if v == nil {
 		return ""

--- a/internal/cmd/custom_field/custom_field.go
+++ b/internal/cmd/custom_field/custom_field.go
@@ -32,6 +32,16 @@ func boolLabel(v bool) string {
 	return "no"
 }
 
+// optionalBoolLabel renders a tri-state flag: servers older than Redmine 7.0
+// omit is_for_all/editable entirely, and a blank cell is the honest answer
+// there rather than "no".
+func optionalBoolLabel(v *bool) string {
+	if v == nil {
+		return ""
+	}
+	return boolLabel(*v)
+}
+
 func formatPossibleValues(values []models.CustomFieldPossibleValue) string {
 	if len(values) == 0 {
 		return ""

--- a/internal/cmd/custom_field/get.go
+++ b/internal/cmd/custom_field/get.go
@@ -92,6 +92,9 @@ func newCmdCustomFieldGet(f *cmdutil.Factory) *cobra.Command {
 			if field.DefaultValue != "" {
 				details = append(details, output.KeyValue{Key: "Default", Value: field.DefaultValue})
 			}
+			if field.DefaultValueMode != "" {
+				details = append(details, output.KeyValue{Key: "Default Mode", Value: field.DefaultValueMode})
+			}
 			if field.Regexp != "" {
 				details = append(details, output.KeyValue{Key: "Regexp", Value: field.Regexp})
 			}

--- a/internal/cmd/custom_field/get.go
+++ b/internal/cmd/custom_field/get.go
@@ -48,7 +48,7 @@ func newCmdCustomFieldGet(f *cmdutil.Factory) *cobra.Command {
 			}
 			if printer.Format() == output.FormatCSV {
 				printer.CSV(
-					[]string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple", "Default", "Possible Values", "Trackers", "Roles"},
+					[]string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple", "Default", "Possible Values", "Trackers", "Roles", "For All", "Projects"},
 					[][]string{{
 						fmt.Sprintf("%d", field.ID),
 						field.Name,
@@ -62,6 +62,8 @@ func newCmdCustomFieldGet(f *cmdutil.Factory) *cobra.Command {
 						formatPossibleValues(field.PossibleValues),
 						formatIDNames(field.Trackers),
 						formatIDNames(field.Roles),
+						optionalBoolLabel(field.IsForAll),
+						formatIDNames(field.Projects),
 					}},
 				)
 				return nil
@@ -77,6 +79,15 @@ func newCmdCustomFieldGet(f *cmdutil.Factory) *cobra.Command {
 				{Key: "Searchable", Value: boolLabel(field.Searchable)},
 				{Key: "Multiple", Value: boolLabel(field.Multiple)},
 				{Key: "Visible", Value: boolLabel(field.Visible)},
+			}
+			if field.Description != "" {
+				details = append(details, output.KeyValue{Key: "Description", Value: field.Description})
+			}
+			if field.Editable != nil {
+				details = append(details, output.KeyValue{Key: "Editable", Value: boolLabel(*field.Editable)})
+			}
+			if field.IsForAll != nil {
+				details = append(details, output.KeyValue{Key: "For All Projects", Value: boolLabel(*field.IsForAll)})
 			}
 			if field.DefaultValue != "" {
 				details = append(details, output.KeyValue{Key: "Default", Value: field.DefaultValue})
@@ -98,6 +109,9 @@ func newCmdCustomFieldGet(f *cmdutil.Factory) *cobra.Command {
 			}
 			if value := formatIDNames(field.Roles); value != "" {
 				details = append(details, output.KeyValue{Key: "Roles", Value: value})
+			}
+			if value := formatIDNames(field.Projects); value != "" {
+				details = append(details, output.KeyValue{Key: "Projects", Value: value})
 			}
 
 			printer.Detail(details)

--- a/internal/cmd/custom_field/get_test.go
+++ b/internal/cmd/custom_field/get_test.go
@@ -17,6 +17,13 @@ const detailFixture = `{"custom_fields":[
 	{"id":2,"name":"Department","customized_type":"user","field_format":"string"}
 ]}`
 
+// redmine7Fixture carries the fields Redmine 7.0 added to /custom_fields.json:
+// is_for_all plus the associated projects (#44153) and roles on a non-issue
+// custom field (#44152).
+const redmine7Fixture = `{"custom_fields":[
+	{"id":1,"name":"Billing Code","description":"Cost centre","customized_type":"time_entry","field_format":"string","visible":true,"editable":true,"is_for_all":false,"projects":[{"id":7,"name":"Apollo"}],"roles":[{"id":3,"name":"Manager"}]}
+]}`
+
 func TestCustomFieldGet_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -84,15 +91,94 @@ func TestCustomFieldGet_CSV(t *testing.T) {
 		t.Fatalf("CSV rows = %d, want 2", len(rows))
 	}
 
-	wantHeaders := []string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple", "Default", "Possible Values", "Trackers", "Roles"}
+	wantHeaders := []string{"ID", "Name", "Type", "Format", "Required", "Filter", "Searchable", "Multiple", "Default", "Possible Values", "Trackers", "Roles", "For All", "Projects"}
 	if !slices.Equal(rows[0], wantHeaders) {
 		t.Fatalf("CSV header mismatch:\n got: %v\nwant: %v", rows[0], wantHeaders)
 	}
 
-	wantRow := []string{"1", "Severity", "issue", "list", "yes", "yes", "yes", "no", "Low", "Low, High", "Bug (ID: 1)", "Manager (ID: 3)"}
+	wantRow := []string{"1", "Severity", "issue", "list", "yes", "yes", "yes", "no", "Low", "Low, High", "Bug (ID: 1)", "Manager (ID: 3)", "", ""}
 	if !slices.Equal(rows[1], wantRow) {
 		t.Fatalf("CSV row mismatch:\n got: %v\nwant: %v", rows[1], wantRow)
 	}
+}
+
+// TestCustomFieldGet_Redmine7Fields covers the Redmine 7.0 additions to
+// /custom_fields.json and the tri-state handling of is_for_all, which older
+// servers omit entirely.
+func TestCustomFieldGet_Redmine7Fields(t *testing.T) {
+	t.Run("table surfaces scope and roles", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(redmine7Fixture))
+		}))
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdCustomFieldGet(f)
+		cmd.SetArgs([]string{"1", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		stdout := testutil.Stdout(f)
+		for _, want := range []string{"For All Projects", "Editable", "Description", "Cost centre", "Projects", "Apollo (ID: 7)", "Manager (ID: 3)"} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("detail output missing %q:\n%s", want, stdout)
+			}
+		}
+	})
+
+	t.Run("csv carries scope columns", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(redmine7Fixture))
+		}))
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdCustomFieldGet(f)
+		cmd.SetArgs([]string{"1", "--output", "csv"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+
+		rows, err := csv.NewReader(bytes.NewBufferString(testutil.Stdout(f))).ReadAll()
+		if err != nil {
+			t.Fatalf("decode CSV: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Fatalf("CSV rows = %d, want 2", len(rows))
+		}
+		if got := rows[1][len(rows[1])-2]; got != "no" {
+			t.Errorf("For All column = %q, want %q", got, "no")
+		}
+		if got := rows[1][len(rows[1])-1]; got != "Apollo (ID: 7)" {
+			t.Errorf("Projects column = %q, want %q", got, "Apollo (ID: 7)")
+		}
+	})
+
+	t.Run("flag rows omitted when the server does not send them", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(detailFixture))
+		}))
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdCustomFieldGet(f)
+		cmd.SetArgs([]string{"1", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		stdout := testutil.Stdout(f)
+		for _, unwanted := range []string{"For All Projects", "Editable"} {
+			if strings.Contains(stdout, unwanted) {
+				t.Errorf("detail output unexpectedly contains %q when the flag is absent:\n%s", unwanted, stdout)
+			}
+		}
+	})
 }
 
 // TestCustomFieldGet_TableOptionalRows verifies that the detail renderer

--- a/internal/cmd/custom_field/get_test.go
+++ b/internal/cmd/custom_field/get_test.go
@@ -17,12 +17,21 @@ const detailFixture = `{"custom_fields":[
 	{"id":2,"name":"Department","customized_type":"user","field_format":"string"}
 ]}`
 
-// redmine7Fixture carries the fields Redmine 7.0 added to /custom_fields.json:
-// is_for_all plus the associated projects (#44153) and roles on a non-issue
-// custom field (#44152).
+// redmine7Fixture carries the fields Redmine 7.0 added to /custom_fields.json.
+// Field 1 mirrors an issue custom field, the only type upstream emits the
+// projects array for (#44153). Field 2 is a date field, the only format that
+// carries default_value_mode. editable is true here and is_for_all false, so
+// both rendered values differ and neither can be asserted by accident.
 const redmine7Fixture = `{"custom_fields":[
-	{"id":1,"name":"Billing Code","description":"Cost centre","customized_type":"time_entry","field_format":"string","visible":true,"editable":true,"is_for_all":false,"projects":[{"id":7,"name":"Apollo"}],"roles":[{"id":3,"name":"Manager"}]}
+	{"id":1,"name":"Billing Code","description":"Cost centre","customized_type":"issue","field_format":"string","visible":true,"editable":true,"is_for_all":false,"projects":[{"id":7,"name":"Apollo"}],"roles":[{"id":3,"name":"Manager"}]},
+	{"id":2,"name":"Target Date","customized_type":"issue","field_format":"date","visible":true,"default_value":"7","default_value_mode":"days_after_today"}
 ]}`
+
+// normalizeSpacing collapses runs of whitespace so a "Key  value" assertion
+// does not depend on the detail printer's column padding.
+func normalizeSpacing(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
 
 func TestCustomFieldGet_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -120,8 +129,38 @@ func TestCustomFieldGet_Redmine7Fields(t *testing.T) {
 		if err := cmd.Execute(); err != nil {
 			t.Fatal(err)
 		}
+		// Assert the rendered values, not just the row labels: a label-only
+		// check stays green if the flag is inverted. is_for_all is false and
+		// editable true in the fixture, so the two cannot be confused.
 		stdout := testutil.Stdout(f)
-		for _, want := range []string{"For All Projects", "Editable", "Description", "Cost centre", "Projects", "Apollo (ID: 7)", "Manager (ID: 3)"} {
+		for _, want := range []string{
+			"Description", "Cost centre",
+			"Editable: yes",
+			"For All Projects: no",
+			"Apollo (ID: 7)", "Manager (ID: 3)",
+		} {
+			if !strings.Contains(normalizeSpacing(stdout), normalizeSpacing(want)) {
+				t.Errorf("detail output missing %q:\n%s", want, stdout)
+			}
+		}
+	})
+
+	t.Run("date field surfaces default_value_mode", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(redmine7Fixture))
+		}))
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdCustomFieldGet(f)
+		cmd.SetArgs([]string{"2", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		stdout := testutil.Stdout(f)
+		for _, want := range []string{"Default Mode", "days_after_today"} {
 			if !strings.Contains(stdout, want) {
 				t.Errorf("detail output missing %q:\n%s", want, stdout)
 			}

--- a/internal/cmd/wiki/get.go
+++ b/internal/cmd/wiki/get.go
@@ -78,6 +78,9 @@ func newCmdGet(f *cmdutil.Factory) *cobra.Command {
 				{Key: "Version", Value: strconv.Itoa(page.Version)},
 			}
 
+			if page.Project != nil {
+				pairs = append(pairs, output.KeyValue{Key: "Project", Value: page.Project.Name})
+			}
 			if page.Author != nil {
 				pairs = append(pairs, output.KeyValue{Key: "Author", Value: page.Author.Name})
 			}

--- a/internal/cmd/wiki/get_test.go
+++ b/internal/cmd/wiki/get_test.go
@@ -57,7 +57,9 @@ func TestGet_ProjectRow(t *testing.T) {
 		if err := cmd.Execute(); err != nil {
 			t.Fatal(err)
 		}
-		if stdout := testutil.Stdout(f); strings.Contains(stdout, "Project") {
+		// Match the row label, not a bare "Project" substring, so unrelated
+		// future rows or page text containing the word cannot fail this.
+		if stdout := testutil.Stdout(f); strings.Contains(stdout, "Project:") {
 			t.Errorf("detail output unexpectedly contains a Project row:\n%s", stdout)
 		}
 	})

--- a/internal/cmd/wiki/get_test.go
+++ b/internal/cmd/wiki/get_test.go
@@ -1,0 +1,64 @@
+package wiki
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+// newWikiGetServer serves the project lookup the resolver performs plus a
+// single wiki page payload.
+func newWikiGetServer(t *testing.T, pageJSON string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/projects/") && strings.Contains(r.URL.Path, "/wiki/") {
+			_, _ = w.Write([]byte(pageJSON))
+			return
+		}
+		_, _ = w.Write([]byte(`{"project":{"id":1,"identifier":"proj"}}`))
+	}))
+}
+
+// TestGet_ProjectRow covers the project node Redmine 7.0 added to the wiki
+// page API response (#43569): it is rendered when present and the row stays
+// out of the detail view on older servers that omit it.
+func TestGet_ProjectRow(t *testing.T) {
+	t.Run("rendered when server sends project", func(t *testing.T) {
+		srv := newWikiGetServer(t, `{"wiki_page":{"title":"MyPage","text":"body","version":2,"project":{"id":1,"name":"Apollo"},"created_on":"2026-01-01T00:00:00Z","updated_on":"2026-01-02T00:00:00Z"}}`)
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdGet(f)
+		cmd.SetArgs([]string{"MyPage", "--project", "proj", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		stdout := testutil.Stdout(f)
+		for _, want := range []string{"Project", "Apollo"} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("detail output missing %q:\n%s", want, stdout)
+			}
+		}
+	})
+
+	t.Run("omitted on pre-7.0 response", func(t *testing.T) {
+		srv := newWikiGetServer(t, `{"wiki_page":{"title":"MyPage","text":"body","version":2,"created_on":"2026-01-01T00:00:00Z","updated_on":"2026-01-02T00:00:00Z"}}`)
+		defer srv.Close()
+
+		f := testutil.NewFactory(t, srv.URL)
+		cmd := newCmdGet(f)
+		cmd.SetArgs([]string{"MyPage", "--project", "proj", "--output", "table"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		if stdout := testutil.Stdout(f); strings.Contains(stdout, "Project") {
+			t.Errorf("detail output unexpectedly contains a Project row:\n%s", stdout)
+		}
+	})
+}

--- a/internal/models/custom_field.go
+++ b/internal/models/custom_field.go
@@ -11,9 +11,18 @@ type CustomFieldPossibleValue struct {
 
 // CustomField represents a Redmine custom field definition as returned by
 // /custom_fields.json. The endpoint is admin-only.
+//
+// IsForAll and Projects were added to the API in Redmine 7.0 (#44153). Roles
+// is emitted for issue, time entry, project and version fields since 7.0
+// (#44152); older versions restrict it to issue fields.
+//
+// The bool flags a server may omit are pointers so "not reported" stays
+// distinguishable from "reported as false" - rendering them as "no" would
+// claim a restriction the server never stated.
 type CustomField struct {
 	ID             int                        `json:"id"`
 	Name           string                     `json:"name"`
+	Description    string                     `json:"description,omitempty"`
 	CustomizedType string                     `json:"customized_type"`
 	FieldFormat    string                     `json:"field_format"`
 	Regexp         string                     `json:"regexp,omitempty"`
@@ -25,7 +34,10 @@ type CustomField struct {
 	Multiple       bool                       `json:"multiple"`
 	DefaultValue   string                     `json:"default_value,omitempty"`
 	Visible        bool                       `json:"visible"`
+	Editable       *bool                      `json:"editable,omitempty"`
+	IsForAll       *bool                      `json:"is_for_all,omitempty"`
 	PossibleValues []CustomFieldPossibleValue `json:"possible_values,omitempty"`
+	Projects       []IDName                   `json:"projects,omitempty"`
 	Trackers       []IDName                   `json:"trackers,omitempty"`
 	Roles          []IDName                   `json:"roles,omitempty"`
 }

--- a/internal/models/custom_field.go
+++ b/internal/models/custom_field.go
@@ -12,32 +12,38 @@ type CustomFieldPossibleValue struct {
 // CustomField represents a Redmine custom field definition as returned by
 // /custom_fields.json. The endpoint is admin-only.
 //
-// IsForAll and Projects were added to the API in Redmine 7.0 (#44153). Roles
-// is emitted for issue, time entry, project and version fields since 7.0
-// (#44152); older versions restrict it to issue fields.
+// Redmine 7.0 added IsForAll and Projects (#44153) and DefaultValueMode, and
+// widened Roles to time entry, project and version fields (#44152) where older
+// versions emitted it for issue fields only.
 //
-// The bool flags a server may omit are pointers so "not reported" stays
-// distinguishable from "reported as false" - rendering them as "no" would
-// claim a restriction the server never stated.
+// Two upstream quirks the renderer has to respect: Projects is emitted for
+// issue custom fields only, whatever the field type, and DefaultValueMode only
+// for date-format fields. Description and Editable are not 7.0 additions - the
+// API has emitted them since 5.1 - they were simply missing from this struct.
+//
+// IsForAll and Editable are pointers so "not reported" stays distinguishable
+// from "reported as false"; rendering a missing flag as "no" would claim a
+// restriction the server never stated.
 type CustomField struct {
-	ID             int                        `json:"id"`
-	Name           string                     `json:"name"`
-	Description    string                     `json:"description,omitempty"`
-	CustomizedType string                     `json:"customized_type"`
-	FieldFormat    string                     `json:"field_format"`
-	Regexp         string                     `json:"regexp,omitempty"`
-	MinLength      *int                       `json:"min_length,omitempty"`
-	MaxLength      *int                       `json:"max_length,omitempty"`
-	IsRequired     bool                       `json:"is_required"`
-	IsFilter       bool                       `json:"is_filter"`
-	Searchable     bool                       `json:"searchable"`
-	Multiple       bool                       `json:"multiple"`
-	DefaultValue   string                     `json:"default_value,omitempty"`
-	Visible        bool                       `json:"visible"`
-	Editable       *bool                      `json:"editable,omitempty"`
-	IsForAll       *bool                      `json:"is_for_all,omitempty"`
-	PossibleValues []CustomFieldPossibleValue `json:"possible_values,omitempty"`
-	Projects       []IDName                   `json:"projects,omitempty"`
-	Trackers       []IDName                   `json:"trackers,omitempty"`
-	Roles          []IDName                   `json:"roles,omitempty"`
+	ID               int                        `json:"id"`
+	Name             string                     `json:"name"`
+	Description      string                     `json:"description,omitempty"`
+	CustomizedType   string                     `json:"customized_type"`
+	FieldFormat      string                     `json:"field_format"`
+	Regexp           string                     `json:"regexp,omitempty"`
+	MinLength        *int                       `json:"min_length,omitempty"`
+	MaxLength        *int                       `json:"max_length,omitempty"`
+	IsRequired       bool                       `json:"is_required"`
+	IsFilter         bool                       `json:"is_filter"`
+	Searchable       bool                       `json:"searchable"`
+	Multiple         bool                       `json:"multiple"`
+	DefaultValue     string                     `json:"default_value,omitempty"`
+	DefaultValueMode string                     `json:"default_value_mode,omitempty"`
+	Visible          bool                       `json:"visible"`
+	Editable         *bool                      `json:"editable,omitempty"`
+	IsForAll         *bool                      `json:"is_for_all,omitempty"`
+	PossibleValues   []CustomFieldPossibleValue `json:"possible_values,omitempty"`
+	Projects         []IDName                   `json:"projects,omitempty"`
+	Trackers         []IDName                   `json:"trackers,omitempty"`
+	Roles            []IDName                   `json:"roles,omitempty"`
 }

--- a/internal/models/wiki.go
+++ b/internal/models/wiki.go
@@ -1,12 +1,16 @@
 package models
 
 // WikiPage represents a Redmine wiki page.
+//
+// Project is only sent by Redmine 7.0+ (#43569), so it stays a pointer and
+// callers must treat it as optional.
 type WikiPage struct {
 	Title       string         `json:"title"`
 	Text        string         `json:"text"`
 	Comments    string         `json:"comments,omitempty"`
 	Version     int            `json:"version"`
 	Author      *IDName        `json:"author,omitempty"`
+	Project     *IDName        `json:"project,omitempty"`
 	UpdatedOn   string         `json:"updated_on"`
 	CreatedOn   string         `json:"created_on"`
 	Parent      *WikiPageTitle `json:"parent,omitempty"`


### PR DESCRIPTION
Redmine 7.0.0 (released 2026-06-30) ships five REST API changes. Three are observable from the CLI, nothing was removed, and older servers keep working unchanged.

| Issue | Change | Handled by |
|---|---|---|
| [#44153](https://www.redmine.org/issues/44153) | `custom_fields.json` gains `is_for_all` + associated `projects` | new model fields + detail/CSV rows |
| [#44152](https://www.redmine.org/issues/44152) | `roles` now returned for time entry, project and version custom fields, not just issue fields | already modelled; now covered by a fixture |
| [#43569](https://www.redmine.org/issues/43569) | wiki page response carries its owning `project` | new model field + detail row |
| [#44165](https://www.redmine.org/issues/44165) | basic-auth challenge no longer sent on API-key auth failure | no client impact |
| [#43938](https://www.redmine.org/issues/43938) | tracks last usage of API/Atom keys | no client impact |

Everything else in 7.0 is server or UI side (header redesign, sudo mode on by default, Raphael.js removal, default admin email, deprecated Mantis/Trac rake tasks) and does not reach the API surface this CLI consumes.

## Changes

**Models** - `models.CustomField` gains `IsForAll`, `Projects`, plus the `Description` and `Editable` fields the API has emitted all along. `models.WikiPage` gains `Project`.

Flags a server may omit are `*bool`, so "not reported" stays distinguishable from "reported as false". Their detail rows are omitted entirely rather than rendered as `no`, which would claim a restriction the server never stated.

**Rendering** - `custom-fields get` shows `Description`, `Editable`, `For All Projects` and `Projects`; CSV gains `For All` and `Projects` as trailing columns. `wiki get` shows a `Project` row.

**E2E** - Redmine 7.0 joins the supported matrix on port 3700 (Makefile, workflow, compose default); 4.2 stays. The two ad-hoc `REDMINE_E2E_VERSION` prefix checks are replaced by shared `redmineAtLeast` / `skipBelowRedmine` helpers. The bootstrap seeds a role-restricted time entry custom field so #44152 is actually observable, with a fallback for lines that reject the restriction.

**Docs** - e2e README (matrix, ports, seeded fixtures, a new version-gating section), the three top-level READMEs (support line + 7.x badge), and the custom-fields and wiki command pages in EN and zh-CN.

## Verification

Run against real containers, not mocks:

| | 4.2 | 6.1 | 7.0.0 |
|---|---|---|---|
| e2e suite | pass | pass | pass |
| 7.0-only assertions | skipped | skipped | pass |

Plus `gofmt` / `go build` / `go test ./...` clean, `golangci-lint run` 0 issues, docs Astro build clean (45 pages).

## Notes

- Supersedes the `renovate/redmine-7.x` branch, which only bumped the compose default. That bump is inert on its own: the Makefile always passes `REDMINE_IMAGE=redmine:$(E2E_VERSION)`, so `make e2e-*` never reads it. Close that branch when this merges.
- The `projects` array on custom fields is only covered negatively (empty for an `is_for_all` field). Covering it positively needs a project-scoped custom field seeded against a stable project, and the harness creates every project ad hoc per test. Follow-up if wanted.
- CI cost: the e2e matrix goes from three Redmine lines to four.