### PR TITLE
feat(mcp): serve the HTTP transport statelessly

### DIFF
--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -63,6 +63,8 @@ redmine mcp serve --http 0.0.0.0:8080 --auth-token "$(openssl rand -hex 32)"
 
 When a non-loopback bind is detected without `--auth-token`, the CLI prints a warning to stderr but still starts. The server applies `ReadHeaderTimeout=10s`, `ReadTimeout=30s`, and `IdleTimeout=120s`; `WriteTimeout` is left unbounded so slow Redmine instances don't terminate in-flight tool calls.
 
+The HTTP transport is stateless, so it speaks MCP revision `2026-07-28` (sessionless, `server/discover` instead of the `initialize` handshake). Every tool call is a self-contained Redmine API request, so there is no session to keep. Practical consequences: only `POST` is served (`GET` and `DELETE` answer `405`), and stream resumption via `Last-Event-ID` is not available. Older clients negotiate down to `2025-11-25` and keep working unchanged.
+
 Clients must send the bearer token on every request:
 
 ```http

--- a/docs/src/content/docs/zh-cn/guides/ai-agents.mdx
+++ b/docs/src/content/docs/zh-cn/guides/ai-agents.mdx
@@ -63,6 +63,8 @@ redmine mcp serve --http 0.0.0.0:8080 --auth-token "$(openssl rand -hex 32)"
 
 当检测到非回环绑定但未设置 `--auth-token` 时，CLI 会向 stderr 输出警告，但仍然启动。服务器会应用 `ReadHeaderTimeout=10s`、`ReadTimeout=30s`、`IdleTimeout=120s`；为避免缓慢的 Redmine 实例中断进行中的工具调用，`WriteTimeout` 保持不限。
 
+HTTP 传输是无状态的，因此使用 MCP `2026-07-28` 版本（无会话，用 `server/discover` 取代 `initialize` 握手）。每次工具调用都是一次自包含的 Redmine API 请求，无需维护会话。实际影响：仅提供 `POST`（`GET` 和 `DELETE` 返回 `405`），并且不支持通过 `Last-Event-ID` 恢复流。较旧的客户端会协商降级到 `2025-11-25`，行为保持不变。
+
 客户端必须在每个请求上发送 Bearer 令牌：
 
 ```http

--- a/internal/mcpserver/http.go
+++ b/internal/mcpserver/http.go
@@ -51,6 +51,12 @@ func BuildHTTPHandler(client *api.Client, opts Options) http.Handler {
 		return srv
 	}, &mcp.StreamableHTTPOptions{
 		JSONResponse: true,
+		// The MCP revision 2026-07-28 is only offered over HTTP when the
+		// handler is stateless. Every tool here is a self-contained Redmine
+		// API call, so there is no session state worth keeping: GET/DELETE
+		// answer 405 and resumability is dropped, but older clients still
+		// negotiate down to 2025-11-25 and keep working.
+		Stateless: true,
 	})
 }
 

--- a/internal/mcpserver/http_test.go
+++ b/internal/mcpserver/http_test.go
@@ -39,3 +39,35 @@ func TestBuildHTTPHandler_InitializeAndListPrompts(t *testing.T) {
 		t.Fatal("expected prompts over HTTP")
 	}
 }
+
+func TestBuildHTTPHandler_NegotiatesStatelessProtocol(t *testing.T) {
+	apiClient, closeTS := newTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer closeTS()
+
+	server := httptest.NewServer(BuildHTTPHandler(apiClient, Options{Version: "v0"}))
+	defer server.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+		Endpoint:   server.URL,
+		MaxRetries: -1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer session.Close()
+
+	if got := session.InitializeResult().ProtocolVersion; got != "2026-07-28" {
+		t.Fatalf("negotiated protocol version = %q, want 2026-07-28", got)
+	}
+
+	tools, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools over HTTP: %v", err)
+	}
+	if len(tools.Tools) == 0 {
+		t.Fatal("expected tools over HTTP")
+	}
+}


### PR DESCRIPTION
## Was

`BuildHTTPHandler` sets `StreamableHTTPOptions.Stateless = true`.

## Warum

go-sdk v1.7.0 offers MCP revision `2026-07-28` (sessionless, `server/discover` instead of the `initialize` handshake) over streamable HTTP **only** when the handler is stateless. Without it the HTTP transport is capped at `2025-11-25` while the stdio transport already speaks `2026-07-28`.

Every tool is a self-contained Redmine API call, so there is no session state worth keeping.

## Auswirkung

- `GET` and `DELETE` now answer `405`
- Stream resumption via `Last-Event-ID` is gone
- Older clients negotiate down to `2025-11-25` and keep working unchanged

Verified against the built binary: `server/discover` + `tools/list` at `2026-07-28` return 200, legacy `initialize` still answers `2025-11-25`, `GET` returns 405.