### PR TITLE
ci: publish SBOMs and release provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -19,6 +21,11 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "1.26"
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.50.0
 
       - name: Verify module path matches tag major version
         run: |
@@ -47,3 +54,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Locate release checksums
+        id: checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find dist -maxdepth 1 -type f -name 'redmine-cli_*_checksums.txt' -print)
+          if [ "${#files[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one release checksum file, found ${#files[@]}"
+            exit 1
+          fi
+          echo "path=${files[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest release artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: ${{ steps.checksums.outputs.path }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,12 @@ archives:
     files:
       - completions/*
 
+# Publish an SPDX JSON software bill of materials for every release archive.
+# GoReleaser invokes Syft for this step; the release workflow installs a pinned
+# Syft version before running GoReleaser.
+sboms:
+  - artifacts: archive
+
 changelog:
   use: github
   sort: asc


### PR DESCRIPTION
## Summary

- generate an SPDX JSON SBOM for every release archive with pinned Syft
- include release archives and SBOMs in GoReleaser's checksum manifest
- create keyless Sigstore-backed GitHub build provenance for every checksummed artifact

The existing checksum filename remains unchanged, so the installer and self-updater continue to work. Separate Cosign checksum signatures are intentionally omitted: GitHub attestations authenticate every digest in the checksum manifest without introducing a long-lived signing key.

## Validation

- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish --parallelism=1` with Syft v1.50.0
- validated all 5 generated SBOMs as SPDX JSON
- confirmed all 5 archives and all 5 SBOMs are present in the checksum manifest

After the next tagged release, users can verify a downloaded artifact with:

```sh
gh attestation verify <artifact> -R aarondpn/redmine-cli
```