### PR TITLE
fix: reject unexpected positional arguments on flag-only commands

### DIFF
--- a/docs/src/content/docs/commands/issues.mdx
+++ b/docs/src/content/docs/commands/issues.mdx
@@ -154,6 +154,11 @@ redmine issues create --project myproject --subject "Bug report" \
   --watcher me --watcher "QA Bot" \
   --custom-field Severity=High \
   --attach /path/to/screenshot.png --attach /path/to/log.txt
+
+# Values with spaces: quote the whole pair and repeat the flag per field
+redmine issues create --project myproject --subject "Bug" \
+  --custom-field "2=Value for field 2" \
+  --custom-field "61=Value for 61"
 ```
 
 ## update

--- a/docs/src/content/docs/zh-cn/commands/issues.mdx
+++ b/docs/src/content/docs/zh-cn/commands/issues.mdx
@@ -154,6 +154,11 @@ redmine issues create --project myproject --subject "Bug report" \
   --watcher me --watcher "QA Bot" \
   --custom-field Severity=High \
   --attach /path/to/screenshot.png --attach /path/to/log.txt
+
+# 值包含空格时：用引号包住整个键值对，并为每个字段重复使用该标志
+redmine issues create --project myproject --subject "Bug" \
+  --custom-field "2=Value for field 2" \
+  --custom-field "61=Value for 61"
 ```
 
 ## update

--- a/e2e/bootstrap-redmine.sh
+++ b/e2e/bootstrap-redmine.sh
@@ -63,6 +63,19 @@ bootstrap_output=$(docker compose -f "$compose_file" exec -T \
     seeded_custom_field.tracker_ids = Tracker.pluck(:id)
     seeded_custom_field.save!
 
+    # Seed a free-text issue custom field alongside the list-format one.
+    # The list field can only carry its fixed possible_values, so it cannot
+    # exercise values containing spaces (issue #155); a string field can.
+    notes_field_name = "E2E Notes"
+    seeded_notes_field = IssueCustomField.find_or_initialize_by(name: notes_field_name)
+    seeded_notes_field.field_format = "string" if seeded_notes_field.field_format.blank?
+    seeded_notes_field.is_required = false
+    seeded_notes_field.is_filter = false
+    seeded_notes_field.searchable = false
+    seeded_notes_field.is_for_all = true
+    seeded_notes_field.tracker_ids = Tracker.pluck(:id)
+    seeded_notes_field.save!
+
     # Seed a role-restricted time entry custom field. Redmine 7.0 (#44152)
     # started returning "roles" for non-issue custom fields, and this fixture
     # is what makes that observable over the REST API. visible=false is what
@@ -94,6 +107,7 @@ bootstrap_output=$(docker compose -f "$compose_file" exec -T \
       seeded_query_name: seeded_query.name,
       seeded_custom_field_id: seeded_custom_field.id,
       seeded_custom_field_name: seeded_custom_field.name,
+      seeded_notes_custom_field_id: seeded_notes_field.id,
       seeded_time_entry_custom_field_id: seeded_time_entry_cf.id,
       seeded_time_entry_custom_field_roles: seeded_time_entry_cf.roles.count
     }.inspect)

--- a/e2e/issues_extended_test.go
+++ b/e2e/issues_extended_test.go
@@ -134,6 +134,65 @@ func TestIssues_CustomFieldOnCreate(t *testing.T) {
 	}
 }
 
+// TestIssues_CustomFieldValueWithSpaces pins the fix for issue #155: a
+// repeated --custom-field flag whose value contains spaces must round-trip
+// unchanged. Uses the seeded string-format "E2E Notes" fixture because the
+// list-format "E2E Severity" field only accepts its fixed possible values.
+func TestIssues_CustomFieldValueWithSpaces(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	const notesValue = "Value with several words"
+
+	var created struct {
+		ID           int `json:"id"`
+		CustomFields []struct {
+			Name  string `json:"name"`
+			Value any    `json:"value"`
+		} `json:"custom_fields"`
+	}
+	r.runJSON(t, &created, "issues", "create",
+		"--project", proj.Identifier,
+		"--tracker", firstTrackerName(t, r),
+		"--subject", "E2E custom field with spaces",
+		"--custom-field", "E2E Severity=High",
+		"--custom-field", "E2E Notes="+notesValue)
+
+	got := map[string]any{}
+	for _, cf := range created.CustomFields {
+		got[cf.Name] = cf.Value
+	}
+	if got["E2E Severity"] != "High" {
+		t.Fatalf("E2E Severity = %v, want High (all: %+v)", got["E2E Severity"], created.CustomFields)
+	}
+	if got["E2E Notes"] != notesValue {
+		t.Fatalf("E2E Notes = %v, want %q (all: %+v)", got["E2E Notes"], notesValue, created.CustomFields)
+	}
+}
+
+// TestIssues_CreateRejectsStrayPositionalArgs pins the other half of issue
+// #155: a key=value pair not attached to a --custom-field flag must fail
+// loudly instead of being silently dropped (the command previously accepted
+// arbitrary positionals and ignored them, creating the issue without the
+// second field).
+func TestIssues_CreateRejectsStrayPositionalArgs(t *testing.T) {
+	requireE2E(t)
+	r := newCLIRunner(t, e2eBaseURL(), e2eAPIKey())
+	proj := createTestProject(t, r)
+
+	stdout, stderr := r.runExpectError(t, "issues", "create",
+		"--project", proj.Identifier,
+		"--subject", "E2E stray positional",
+		"--custom-field", "E2E Notes=Value for notes",
+		"61=Value for 61")
+
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "unknown command") && !strings.Contains(combined, "arg") {
+		t.Fatalf("expected the stray positional to be reported, got stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
 // TestIssues_RelationPrecedesWithDelay verifies the precedes relation type
 // accepts the --delay flag and Redmine returns the delay on subsequent GET.
 func TestIssues_RelationPrecedesWithDelay(t *testing.T) {

--- a/internal/cmd/args_contract_test.go
+++ b/internal/cmd/args_contract_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRunnableCommandsDeclarePositionalArgsPolicy pins that every runnable
+// command declares an explicit cobra Args validator. Without one, cobra
+// defaults to ArbitraryArgs and silently swallows stray positional
+// arguments — e.g. `issues create --custom-field 2="a b" 61="c d"` used to
+// drop the second pair without any error (issue #155). Commands that take
+// no positionals must set cobra.NoArgs so users get a loud error instead.
+func TestRunnableCommandsDeclarePositionalArgsPolicy(t *testing.T) {
+	root := NewRootCmd("test")
+
+	var offenders []string
+	walk(root, func(c *cobra.Command) {
+		if c.Runnable() && c.Args == nil {
+			offenders = append(offenders, c.CommandPath())
+		}
+	})
+
+	if len(offenders) > 0 {
+		slices.Sort(offenders)
+		t.Fatalf("runnable commands without an explicit Args validator (set cobra.NoArgs unless positionals are expected):\n%s", strings.Join(offenders, "\n"))
+	}
+}

--- a/internal/cmd/auth/list.go
+++ b/internal/cmd/auth/list.go
@@ -16,6 +16,7 @@ import (
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Args:  cobra.NoArgs,
 		Short: "List authentication profiles",
 		Long:  "Show all configured profiles with their server URLs.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -21,6 +21,7 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login",
+		Args:  cobra.NoArgs,
 		Short: "Log in to a Redmine instance",
 		Long:  "Interactive setup to authenticate with a Redmine server and save the profile.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -17,6 +17,7 @@ import (
 func NewCmdStatus(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
+		Args:  cobra.NoArgs,
 		Short: "Show current authentication status",
 		Long:  "Display the active profile, server, and authenticated user.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/category/list.go
+++ b/internal/cmd/category/list.go
@@ -32,6 +32,7 @@ func newCmdCategoryList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Short:   "List issue categories for a project",
 		Aliases: []string{"ls"},
 		Example: `  # List categories for a project

--- a/internal/cmd/custom_field/list.go
+++ b/internal/cmd/custom_field/list.go
@@ -17,6 +17,7 @@ func newCmdCustomFieldList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List all custom field definitions",
 		Long: "List Redmine custom field definitions. Requires an administrator API " +

--- a/internal/cmd/files/list.go
+++ b/internal/cmd/files/list.go
@@ -23,6 +23,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List project files",
 		Long: "List files attached to a Redmine project.\n\n" +

--- a/internal/cmd/group/create.go
+++ b/internal/cmd/group/create.go
@@ -18,6 +18,7 @@ func newCmdGroupCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create",
+		Args:    cobra.NoArgs,
 		Short:   "Create a new group",
 		Aliases: []string{"new"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/group/list.go
+++ b/internal/cmd/group/list.go
@@ -20,6 +20,7 @@ func newCmdGroupList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Short:   "List groups",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/installskill/installskill.go
+++ b/internal/cmd/installskill/installskill.go
@@ -16,6 +16,7 @@ func NewCmdInstallSkill(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install-skill",
+		Args:  cobra.NoArgs,
 		Short: "Install the AI agent skill for redmine-cli",
 		Long:  "Installs a skill that teaches AI coding agents (Claude Code, Cursor, etc.) how to use redmine-cli effectively.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/issue/browse.go
+++ b/internal/cmd/issue/browse.go
@@ -20,6 +20,7 @@ func NewCmdBrowse(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "browse",
+		Args:  cobra.NoArgs,
 		Short: "Interactive issue browser (TUI)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.PrepareInteractiveCommand(cmd, f); err != nil {

--- a/internal/cmd/issue/create.go
+++ b/internal/cmd/issue/create.go
@@ -37,6 +37,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"new"},
 		Short:   "Create a new issue",
 		Long:    "Create a new issue in the specified project.",
@@ -55,6 +56,10 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
   # Set custom field values (by name or numeric ID, repeatable)
   redmine issues create --project myproject --subject "Bug" \
     --custom-field Severity=High --custom-field 7=urgent
+
+  # Values with spaces: quote the whole pair and repeat the flag per field
+  redmine issues create --project myproject --subject "Bug" \
+    --custom-field "2=Value for field 2" --custom-field "61=Value for 61"
 
   # Numeric IDs still work
   redmine issues create --project 1 --tracker 1 --priority 2 --subject "Test"`,

--- a/internal/cmd/issue/create_test.go
+++ b/internal/cmd/issue/create_test.go
@@ -1,0 +1,97 @@
+package issue
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aarondpn/redmine-cli/v2/internal/testutil"
+)
+
+func newCreateIssueServer(t *testing.T, posted *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/projects/17.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":17,"identifier":"demo","name":"Demo"}}`))
+		case "/issues.json":
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, posted)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issue":{"id":1,"subject":"test","project":{"id":17,"name":"Demo"},"tracker":{"id":1,"name":"Bug"},"status":{"id":1,"name":"New"},"priority":{"id":2,"name":"Normal"}}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
+// TestCmdIssueCreate_CustomFieldValuesWithSpaces pins that repeated
+// --custom-field flags carry values containing spaces through to the API
+// payload unchanged (issue #155).
+func TestCmdIssueCreate_CustomFieldValuesWithSpaces(t *testing.T) {
+	var posted map[string]any
+	srv := newCreateIssueServer(t, &posted)
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdCreate(f)
+	cmd.SetArgs([]string{
+		"--project", "17", "--subject", "test",
+		"--custom-field", "2=Value for field 2",
+		"--custom-field", "61=Value for 61",
+		"--output", "json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	issue, ok := posted["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("posted body missing issue wrapper: %v", posted)
+	}
+	cfvs, ok := issue["custom_field_values"].(map[string]any)
+	if !ok {
+		t.Fatalf("posted body missing custom_field_values: %v", issue)
+	}
+	if cfvs["2"] != "Value for field 2" {
+		t.Errorf("custom_field_values[2] = %q, want %q", cfvs["2"], "Value for field 2")
+	}
+	if cfvs["61"] != "Value for 61" {
+		t.Errorf("custom_field_values[61] = %q, want %q", cfvs["61"], "Value for 61")
+	}
+}
+
+// TestCmdIssueCreate_RejectsStrayPositionalArgs pins that a key=value pair
+// not attached to a --custom-field flag fails loudly instead of being
+// silently dropped. This was the actual failure mode behind issue #155:
+// `--custom-field 2="a b" 61="c d"` created the issue with only field 2 set.
+func TestCmdIssueCreate_RejectsStrayPositionalArgs(t *testing.T) {
+	var posted map[string]any
+	srv := newCreateIssueServer(t, &posted)
+	defer srv.Close()
+
+	f := testutil.NewFactory(t, srv.URL)
+	cmd := NewCmdCreate(f)
+	cmd.SetArgs([]string{
+		"--project", "17", "--subject", "test",
+		"--custom-field", "2=Value for field 2",
+		"61=Value for 61",
+		"--output", "json",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for stray positional arg, got nil (posted: %v)", posted)
+	}
+	if !strings.Contains(err.Error(), "unknown command") && !strings.Contains(err.Error(), "arg") {
+		t.Errorf("error should mention the rejected argument, got: %v", err)
+	}
+	if posted != nil {
+		t.Errorf("no issue should have been created, but API received: %v", posted)
+	}
+}

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -42,6 +42,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List issues",
 		Long:    "List issues with filters. Combine flags for narrow searches.",

--- a/internal/cmd/issue/list_test.go
+++ b/internal/cmd/issue/list_test.go
@@ -324,7 +324,7 @@ func TestCmdIssueList_PassesNewFilters(t *testing.T) {
 		"--priority", "High",
 		"--author", "me",
 		"--parent", "42",
-		"--is-private", "true",
+		"--is-private=true",
 		"--output", "json",
 	})
 

--- a/internal/cmd/membership/create.go
+++ b/internal/cmd/membership/create.go
@@ -22,6 +22,7 @@ func newCmdMembershipCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"add", "new"},
 		Short:   "Add a member to a project",
 		Long:    "Create a new membership, adding a user or group to a project with specified roles.",

--- a/internal/cmd/membership/list.go
+++ b/internal/cmd/membership/list.go
@@ -24,6 +24,7 @@ func newCmdMembershipList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List project memberships",
 		Long:    "List all memberships for a project.",

--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -30,6 +30,7 @@ func newCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"new"},
 		Short:   "Create a new project",
 		Long:    "Create a new Redmine project.",

--- a/internal/cmd/project/list.go
+++ b/internal/cmd/project/list.go
@@ -22,6 +22,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List projects",
 		Long:    "List all accessible Redmine projects.",

--- a/internal/cmd/query/list.go
+++ b/internal/cmd/query/list.go
@@ -21,6 +21,7 @@ func newCmdQueryList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List saved queries",
 		Long:    "List saved queries (custom filters) visible to the authenticated user. The list includes both global queries and queries scoped to a project.",

--- a/internal/cmd/role/list.go
+++ b/internal/cmd/role/list.go
@@ -17,6 +17,7 @@ func newCmdRoleList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List all roles",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -130,6 +130,7 @@ func NewRootCmdWithFactory(version string) (*cobra.Command, *cmdutil.Factory) {
 func newCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
+		Args:  cobra.NoArgs,
 		Short: "Display current configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()

--- a/internal/cmd/status/list.go
+++ b/internal/cmd/status/list.go
@@ -27,6 +27,7 @@ func newCmdStatusList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Short:   "List all issue statuses",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/time/list.go
+++ b/internal/cmd/time/list.go
@@ -28,6 +28,7 @@ func newCmdTimeList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List time entries",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/time/log.go
+++ b/internal/cmd/time/log.go
@@ -27,6 +27,7 @@ func newCmdTimeLog(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "log",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"add", "create"},
 		Short:   "Log a time entry",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/time/summary.go
+++ b/internal/cmd/time/summary.go
@@ -27,6 +27,7 @@ func newCmdTimeSummary(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "summary",
+		Args:  cobra.NoArgs,
 		Short: "Summarize time entries",
 		Long:  "Aggregate time entries by day, project, or activity.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/tracker/list.go
+++ b/internal/cmd/tracker/list.go
@@ -32,6 +32,7 @@ func newCmdTrackerList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Short:   "List all trackers",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -50,6 +50,7 @@ func NewCmdUpdate(f *cmdutil.Factory, version string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
+		Args:  cobra.NoArgs,
 		Short: "Update redmine CLI to the latest version",
 		Long:  "Check GitHub releases for a newer version and replace the current binary.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/user/create.go
+++ b/internal/cmd/user/create.go
@@ -27,6 +27,7 @@ func newCmdUserCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create",
+		Args:    cobra.NoArgs,
 		Short:   "Create a new user",
 		Aliases: []string{"new"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/user/list.go
+++ b/internal/cmd/user/list.go
@@ -24,6 +24,7 @@ func newCmdUserList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Short:   "List users",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/user/me.go
+++ b/internal/cmd/user/me.go
@@ -17,6 +17,7 @@ func newCmdUserMe(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "me",
+		Args:  cobra.NoArgs,
 		Short: "Show current authenticated user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateUserIncludes(includes); err != nil {

--- a/internal/cmd/version/create.go
+++ b/internal/cmd/version/create.go
@@ -24,6 +24,7 @@ func newCmdVersionCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"new"},
 		Short:   "Create a project version",
 		Long:    "Create a Redmine project version (milestone).",

--- a/internal/cmd/version/list.go
+++ b/internal/cmd/version/list.go
@@ -43,6 +43,7 @@ func newCmdVersionList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List project versions",
 		Long:    "List all versions for a project, optionally filtered by status.",

--- a/internal/cmd/wiki/list.go
+++ b/internal/cmd/wiki/list.go
@@ -22,6 +22,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "List wiki pages",
 		Long:    "List wiki pages in a Redmine project.",


### PR DESCRIPTION
## Summary

Fixes #155. Custom-field values with spaces were never broken at the parsing layer — the actual failure mode was that `issues create` (and 30 other flag-only commands) had no cobra `Args` validator, so cobra defaulted to `ArbitraryArgs` and **silently swallowed stray positional arguments**:

```
redmine issues create --project 17 --subject test --custom-field 2="Value for field 2" 61="Value for 61"
```

created the issue with only field 2 set — `61="Value for 61"` was a positional argument, not attached to the flag, and vanished without any error. To the user this looked like "values with spaces don't work".

## Changes

- Set `Args: cobra.NoArgs` on all 31 runnable commands that take no positional arguments (`issues create`, `projects create`, `time log`, all `list` commands, `config`, …). Stray positionals now fail loudly with `unknown command "61=..."` before any API call is made.
- New contract test `TestRunnableCommandsDeclarePositionalArgsPolicy` walks the command tree and fails when a runnable command lacks an explicit `Args` validator, so new commands cannot regress.
- Unit tests pin both halves of #155: values with spaces round-trip through repeated `--custom-field` flags, and a stray positional pair aborts instead of silently creating a partial issue.
- E2E: seeds a string-format issue custom field `E2E Notes` (the existing list-format fixture can only carry its fixed values, so it cannot exercise spaces) and adds round-trip + stray-positional tests against real Redmine.
- Docs + `--help` examples now show the correct pattern: quote the whole pair and repeat the flag per field.
- Fixed `TestCmdIssueList_PassesNewFilters`, which relied on the old silent-swallow behavior: it passed `--is-private true` (bool flag + stray positional `true`) and only worked by accident; now uses `--is-private=true`.

## Verification

- `go test ./...` — all green
- `golangci-lint run` — 0 issues
- Full e2e suite against Redmine 7.0 via docker compose — 149 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)